### PR TITLE
[#24] 챌린지 도메인 코드 수정

### DIFF
--- a/module-api/http/challenge.http
+++ b/module-api/http/challenge.http
@@ -7,7 +7,7 @@ Content-Type: application/json
   "title": "클린코드 도서 읽기",
   "description": "클린코드 책을 일주일에 한 챕터씩 읽은 후 리뷰하기",
   "startDate": "2025-04-07",
-  "endDate": "2025-08-03",
+  "endDate": "2025-06-01",
   "capacity": 5,
   "category": "STUDY",
   "proofWay": "읽은 내용을 정리해서 공유",
@@ -32,7 +32,7 @@ Content-Type: application/json
 GET http://localhost:8080/api/v1/challenges/1
 
 ### 3. 챌린지 검색 조회
-POST http://localhost:8080/api/v1/challenges/search
+POST http://localhost:8080/api/v1/challenges/search?page=0&size=10
 Content-Type: application/json
 
 {
@@ -49,7 +49,7 @@ Content-Type: application/json
   "title": "클린코드 도서 읽기",
   "description": "클린코드 책을 일주일에 한 챕터씩 읽은 후 리뷰하기",
   "startDate": "2025-04-07",
-  "endDate": "2025-07-27",
+  "endDate": "2025-05-31",
   "capacity": 10,
   "category": "STUDY"
 }

--- a/module-api/http/challenge.http
+++ b/module-api/http/challenge.http
@@ -1,5 +1,6 @@
 ### 1. 챌린지 생성
 POST http://localhost:8080/api/v1/challenges
+Authorization: {{accessToken}}
 Content-Type: application/json
 
 {
@@ -15,6 +16,7 @@ Content-Type: application/json
 
 ### 1-1. 챌린지 생성 (유효성 검증 실패)
 POST http://localhost:8080/api/v1/challenges
+Authorization: {{accessToken}}
 Content-Type: application/json
 
 {
@@ -40,6 +42,7 @@ Content-Type: application/json
 
 ### 4. 챌린지 내용 수정
 PUT http://localhost:8080/api/v1/challenges/1/content
+Authorization: {{accessToken}}
 Content-Type: application/json
 
 {
@@ -54,6 +57,7 @@ Content-Type: application/json
 
 ### 4-1. 챌린지 내용 수정 (유효성 검증 실패)
 PUT http://localhost:8080/api/v1/challenges/1/content
+Authorization: {{accessToken}}
 Content-Type: application/json
 
 {
@@ -67,6 +71,7 @@ Content-Type: application/json
 
 ### 5. 챌린지 인증 내용 수정
 PUT http://localhost:8080/api/v1/challenges/1/proof
+Authorization: {{accessToken}}
 Content-Type: application/json
 
 {
@@ -76,6 +81,7 @@ Content-Type: application/json
 
 ### 5-1. 챌린지 인증 내용 수정 (유효성 검증 실패)
 PUT http://localhost:8080/api/v1/challenges/1/proof
+Authorization: {{accessToken}}
 Content-Type: application/json
 
 {
@@ -85,3 +91,4 @@ Content-Type: application/json
 
 ### 6. 챌린지 삭제
 DELETE http://localhost:8080/api/v1/challenges/1
+Authorization: {{accessToken}}

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -270,6 +270,16 @@ include::{snippets}/challenge-controller-test/update-content/invalid/bad-request
 include::{snippets}/challenge-controller-test/update-content/invalid/bad-request/http-response.adoc[]
 include::{snippets}/challenge-controller-test/update-content/invalid/bad-request/response-fields.adoc[]
 
+==== 비정상 요청 (리더가 아닌 사용자)
+리더가 아닌 사용자가 챌린지 내용을 수정했을 때, 다음과 같은 응답이 반환됩니다.
+include::{snippets}/challenge-controller-test/update-content/invalid/forbidden/http-response.adoc[]
+include::{snippets}/challenge-controller-test/update-content/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (진행 예정이 아닌 챌린지)
+진행 예정 외의 상태인 챌린지를 수정했을 때, 다음과 같은 응답이 반환됩니다.
+include::{snippets}/challenge-controller-test/update-content/invalid/conflict/http-response.adoc[]
+include::{snippets}/challenge-controller-test/update-content/invalid/conflict/response-fields.adoc[]
+
 ==== 비정상 요청 (존재하지 않는 챌린지)
 존재하지 않는 챌린지 ID로 수정했을 때, 다음과 같은 응답이 반환됩니다.
 include::{snippets}/challenge-controller-test/update-content/invalid/not-found/http-response.adoc[]
@@ -296,6 +306,16 @@ include::{snippets}/challenge-controller-test/update-proof/invalid/bad-request/h
 include::{snippets}/challenge-controller-test/update-proof/invalid/bad-request/http-response.adoc[]
 include::{snippets}/challenge-controller-test/update-proof/invalid/bad-request/response-fields.adoc[]
 
+==== 비정상 요청 (리더가 아닌 사용자)
+리더가 아닌 사용자가 챌린지 인증 내용을 수정했을 때, 다음과 같은 응답이 반환됩니다.
+include::{snippets}/challenge-controller-test/update-proof/invalid/forbidden/http-response.adoc[]
+include::{snippets}/challenge-controller-test/update-proof/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (진행 예정이 아닌 챌린지)
+진행 예정 외의 상태인 챌린지를 수정했을 때, 다음과 같은 응답이 반환됩니다.
+include::{snippets}/challenge-controller-test/update-proof/invalid/conflict/http-response.adoc[]
+include::{snippets}/challenge-controller-test/update-proof/invalid/conflict/response-fields.adoc[]
+
 ==== 비정상 요청 (존재하지 않는 챌린지)
 존재하지 않는 챌린지 ID로 수정했을 때, 다음과 같은 응답이 반환됩니다.
 include::{snippets}/challenge-controller-test/update-proof/invalid/not-found/http-response.adoc[]
@@ -312,6 +332,16 @@ include::{snippets}/challenge-controller-test/delete/path-parameters.adoc[]
 
 - 응답
 include::{snippets}/challenge-controller-test/delete/http-response.adoc[]
+
+==== 비정상 요청 (리더가 아닌 사용자)
+리더가 아닌 사용자가 챌린지 삭제를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+include::{snippets}/challenge-controller-test/delete/invalid/forbidden/http-response.adoc[]
+include::{snippets}/challenge-controller-test/delete/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (진행 중인 챌린지)
+진행 중인 챌린지 삭제를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+include::{snippets}/challenge-controller-test/delete/invalid/conflict/http-response.adoc[]
+include::{snippets}/challenge-controller-test/delete/invalid/conflict/response-fields.adoc[]
 
 ==== 비정상 요청 (존재하지 않는 챌린지)
 존재하지 않는 챌린지 ID로 삭제했을 때, 다음과 같은 응답이 반환됩니다.

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -216,6 +216,7 @@ include::{snippets}/challenge-controller-test/create/invalid/bad-request/respons
 
 ==== 정상 요청
 include::{snippets}/challenge-controller-test/find/http-request.adoc[]
+include::{snippets}/challenge-controller-test/find/path-parameters.adoc[]
 
 - 응답
 include::{snippets}/challenge-controller-test/find/http-response.adoc[]
@@ -233,6 +234,7 @@ include::{snippets}/challenge-controller-test/find/invalid/not-found/response-fi
 
 ==== 정상 요청
 include::{snippets}/challenge-controller-test/search/http-request.adoc[]
+include::{snippets}/challenge-controller-test/search/query-parameters.adoc[]
 include::{snippets}/challenge-controller-test/search/request-fields.adoc[]
 
 - 응답
@@ -254,6 +256,7 @@ include::{snippets}/challenge-controller-test/search/invalid/bad-request/respons
 
 ==== 정상 요청
 include::{snippets}/challenge-controller-test/update-content/http-request.adoc[]
+include::{snippets}/challenge-controller-test/update-content/path-parameters.adoc[]
 include::{snippets}/challenge-controller-test/update-content/request-fields.adoc[]
 
 - 응답
@@ -279,6 +282,7 @@ include::{snippets}/challenge-controller-test/update-content/invalid/not-found/r
 
 ==== 정상 요청
 include::{snippets}/challenge-controller-test/update-proof/http-request.adoc[]
+include::{snippets}/challenge-controller-test/update-proof/path-parameters.adoc[]
 include::{snippets}/challenge-controller-test/update-proof/request-fields.adoc[]
 
 - 응답
@@ -304,6 +308,7 @@ include::{snippets}/challenge-controller-test/update-proof/invalid/not-found/res
 
 ==== 정상 요청
 include::{snippets}/challenge-controller-test/delete/http-request.adoc[]
+include::{snippets}/challenge-controller-test/delete/path-parameters.adoc[]
 
 - 응답
 include::{snippets}/challenge-controller-test/delete/http-response.adoc[]

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
@@ -5,10 +5,10 @@ import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/challenges")
@@ -33,8 +33,11 @@ public class ChallengeController {
     }
 
     @PostMapping("/search")
-    public List<ChallengeResponse.Summary> findAll(@Valid @RequestBody ChallengeRequest.Read request) {
-        return challengeService.findAll(request);
+    public Page<ChallengeResponse.Summary> findAll(
+            @Valid @RequestBody ChallengeRequest.Read request,
+            Pageable pageable
+    ) {
+        return challengeService.findAll(request, pageable);
     }
 
     @PutMapping("/{id}/content")

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
@@ -1,9 +1,11 @@
 package com.trybe.moduleapi.challenge.controller;
 
+import com.trybe.moduleapi.auth.CustomUserDetails;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,12 +19,12 @@ public class ChallengeController {
         this.challengeService = challengeService;
     }
 
-    private final Long TMP_USER_ID = 1L;
-    // TODO: Authentication 적용
-
     @PostMapping
-    public ChallengeResponse.Detail save(@Valid @RequestBody ChallengeRequest.Create request) {
-        return challengeService.save(request, TMP_USER_ID);
+    public ChallengeResponse.Detail save(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ChallengeRequest.Create request
+    ) {
+        return challengeService.save(userDetails.getUser(), request);
     }
 
     @GetMapping("/{id}")
@@ -37,22 +39,27 @@ public class ChallengeController {
 
     @PutMapping("/{id}/content")
     public ChallengeResponse.Detail updateContent(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("id") Long id,
             @Valid @RequestBody ChallengeRequest.UpdateContent request
     ) {
-        return challengeService.updateContent(id, request, TMP_USER_ID);
+        return challengeService.updateContent(userDetails.getUser(), id, request);
     }
 
     @PutMapping("/{id}/proof")
     public ChallengeResponse.Detail updateProof(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("id") Long id,
             @Valid @RequestBody ChallengeRequest.UpdateProof request
     ) {
-        return challengeService.updateProof(id, request, TMP_USER_ID);
+        return challengeService.updateProof(userDetails.getUser(), id, request);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable("id") Long id) {
-        challengeService.delete(id, TMP_USER_ID);
+    public void delete(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("id") Long id
+    ) {
+        challengeService.delete(userDetails.getUser(), id);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
@@ -152,7 +152,7 @@ public class ChallengeRequest {
 
         @AssertTrue(message = DURATION_LIMIT_MESSAGE)
         private boolean isDurationLimit() {
-            long durationInDays = ChronoUnit.DAYS.between(startDate, endDate);
+            long durationInDays = ChronoUnit.DAYS.between(startDate, endDate) + 1;
             return durationInDays >= 7 && durationInDays <= 56;
         }
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
@@ -90,7 +90,7 @@ public class ChallengeRequest {
 
         @AssertTrue(message = DURATION_LIMIT_MESSAGE)
         private boolean isDurationLimit() {
-            long durationInDays = ChronoUnit.DAYS.between(startDate, endDate);
+            long durationInDays = ChronoUnit.DAYS.between(startDate, endDate) + 1;
             return durationInDays >= 7 && durationInDays <= 56;
         }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
@@ -7,6 +7,7 @@ import com.trybe.modulecore.challenge.enums.ChallengeStatus;
 import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 public class ChallengeRequest {
@@ -22,6 +23,7 @@ public class ChallengeRequest {
     private static final String END_DATE_NOT_NULL_MESSAGE = "종료일을 입력해주세요.";
     private static final String START_DATE_BEFORE_END_DATE_MESSAGE = "시작일은 종료일보다 빠를 수 없습니다.";
     private static final String DATES_AFTER_TODAY_MESSAGE = "시작일과 종료일은 모두 현재 날짜 이후여야 합니다.";
+    private static final String DURATION_LIMIT_MESSAGE = "챌린지는 최소 1주, 최대 8주까지 진행 가능합니다.";
 
     private static final String CAPACITY_NOT_NULL_MESSAGE = "챌린지 인원을 입력해주세요.";
     private static final int CAPACITY_MIN = 1;
@@ -86,6 +88,12 @@ public class ChallengeRequest {
             return startDate.isAfter(LocalDate.now()) && endDate.isAfter(LocalDate.now());
         }
 
+        @AssertTrue(message = DURATION_LIMIT_MESSAGE)
+        private boolean isDurationLimit() {
+            long durationInDays = ChronoUnit.DAYS.between(startDate, endDate);
+            return durationInDays >= 7 && durationInDays <= 56;
+        }
+
         public Challenge toEntity() {
             return new Challenge(
                     title,
@@ -140,6 +148,12 @@ public class ChallengeRequest {
         @AssertTrue(message = DATES_AFTER_TODAY_MESSAGE)
         private boolean isDatesAfterToday() {
             return startDate.isAfter(LocalDate.now()) && endDate.isAfter(LocalDate.now());
+        }
+
+        @AssertTrue(message = DURATION_LIMIT_MESSAGE)
+        private boolean isDurationLimit() {
+            long durationInDays = ChronoUnit.DAYS.between(startDate, endDate);
+            return durationInDays >= 7 && durationInDays <= 56;
         }
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/exception/InvalidChallengeStatusException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/exception/InvalidChallengeStatusException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidChallengeStatusException extends BusinessException {
     public InvalidChallengeStatusException(String message) {
-        super(message, HttpStatus.BAD_REQUEST.value());
+        super(message, HttpStatus.CONFLICT.value());
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/exception/InvalidChallengeStatusException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/exception/InvalidChallengeStatusException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.challenge.exception;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidChallengeStatusException extends BusinessException {
+    public InvalidChallengeStatusException(String message) {
+        super(message, HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -96,7 +96,7 @@ public class ChallengeParticipationService {
     }
 
     private void checkRole(ChallengeParticipation participation, ChallengeRole requiredRole, String message) {
-        if (participation.getRole() != requiredRole) {
+        if (participation.getRole().isNot(requiredRole)) {
             throw new InvalidChallengeRoleActionException(message);
         }
     }
@@ -118,11 +118,11 @@ public class ChallengeParticipationService {
     }
 
     private void validateStatus(ChallengeParticipation participation, ParticipationStatus status) {
-        if (participation.getStatus() != ParticipationStatus.PENDING) {
+        if (participation.getStatus().isNot(ParticipationStatus.PENDING)) {
             throw new InvalidParticipationStatusException("참여 상태가 대기 중인 참여자만 처리할 수 있습니다.");
         }
 
-        if (status != ParticipationStatus.ACCEPTED && status != ParticipationStatus.REJECTED) {
+        if (status.isNot(ParticipationStatus.ACCEPTED) && status.isNot(ParticipationStatus.REJECTED)) {
             throw new InvalidParticipationStatusException("참여 수락 또는 거절만 가능합니다.");
         }
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -18,8 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.stream.Collectors;
-
 @Service
 public class ChallengeService {
     private final ChallengeRepository challengeRepository;
@@ -106,13 +104,13 @@ public class ChallengeService {
     }
 
     private void validateRole(ChallengeParticipation participation, ChallengeRole role, String message) {
-        if (participation.getRole() != role) {
+        if (participation.getRole().isNot(role)) {
             throw new InvalidChallengeRoleActionException(message);
         }
     }
 
     private void validateChallengeStatus(Challenge challenge, boolean shouldBe, ChallengeStatus status, String message) {
-        if ((shouldBe && challenge.getStatus() != status) || (!shouldBe && challenge.getStatus() == status)) {
+        if ((shouldBe && challenge.getStatus().isNot(status)) || (!shouldBe && challenge.getStatus().is(status))) {
             throw new InvalidChallengeStatusException(message);
         }
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -12,10 +12,11 @@ import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -46,11 +47,11 @@ public class ChallengeService {
         return ChallengeResponse.Detail.from(challenge);
     }
 
-    public List<ChallengeResponse.Summary> findAll(ChallengeRequest.Read request) {
+    public Page<ChallengeResponse.Summary> findAll(ChallengeRequest.Read request, Pageable pageable) {
         // TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
-        List<Challenge> challenges = challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories());
+        Page<Challenge> challenges = challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), pageable);
 
-        return challenges.stream().map(ChallengeResponse.Summary::from).collect(Collectors.toList());
+        return challenges.map(ChallengeResponse.Summary::from);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -90,6 +90,7 @@ public class ChallengeService {
         validateRole(participation, ChallengeRole.LEADER, "리더만 챌린지를 삭제할 수 있습니다.");
         validateChallengeStatus(challenge, false, ChallengeStatus.ONGOING, "진행 중인 챌린지는 삭제할 수 없습니다.");
 
+        challengeParticipationRepository.deleteAllByChallengeId(id);
         challengeRepository.delete(challenge);
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -4,6 +4,10 @@ import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.challenge.enums.ChallengeRole;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.stereotype.Service;
@@ -15,16 +19,21 @@ import java.util.stream.Collectors;
 @Service
 public class ChallengeService {
     private final ChallengeRepository challengeRepository;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
 
-    public ChallengeService(ChallengeRepository challengeRepository) {
+    public ChallengeService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository) {
         this.challengeRepository = challengeRepository;
+        this.challengeParticipationRepository = challengeParticipationRepository;
     }
 
     @Transactional
     public ChallengeResponse.Detail save(User user, ChallengeRequest.Create request) {
-        // TODO: Challenge participation 에 대한 로직 추가
+        Challenge challenge = request.toEntity();
+        ChallengeParticipation participation = new ChallengeParticipation(user, challenge, ChallengeRole.LEADER, ParticipationStatus.ACCEPTED);
 
-        Challenge savedChallenge = challengeRepository.save(request.toEntity());
+        challengeParticipationRepository.save(participation);
+        Challenge savedChallenge = challengeRepository.save(challenge);
+
         return ChallengeResponse.Detail.from(savedChallenge);
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -5,6 +5,7 @@ import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
+import com.trybe.modulecore.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,13 +20,8 @@ public class ChallengeService {
         this.challengeRepository = challengeRepository;
     }
 
-    /**
-     * TODO: JWT 설정 완료 후 Authentication 객체에 저장된 유저 정보를 가져오도록 수정
-     * save, updateContent, updateProof, delete 메소드의 파라미터
-      */
-
     @Transactional
-    public ChallengeResponse.Detail save(ChallengeRequest.Create request, Long userId) {
+    public ChallengeResponse.Detail save(User user, ChallengeRequest.Create request) {
         // TODO: Challenge participation 에 대한 로직 추가
 
         Challenge savedChallenge = challengeRepository.save(request.toEntity());
@@ -33,11 +29,7 @@ public class ChallengeService {
     }
 
     public ChallengeResponse.Detail find(Long id) {
-        /**
-         * TODO: Challenge participation 정보 추가 반환 (참여자 정보)
-         * TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
-          */
-
+        // TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
         Challenge challenge = getChallenge(id);
 
         return ChallengeResponse.Detail.from(challenge);
@@ -51,7 +43,7 @@ public class ChallengeService {
     }
 
     @Transactional
-    public ChallengeResponse.Detail updateContent(Long id, ChallengeRequest.UpdateContent request, Long userId) {
+    public ChallengeResponse.Detail updateContent(User user, Long id, ChallengeRequest.UpdateContent request) {
         // TODO: Challenge 의 수정 권한 확인
         Challenge challenge = getChallenge(id);
 
@@ -61,7 +53,7 @@ public class ChallengeService {
     }
 
     @Transactional
-    public ChallengeResponse.Detail updateProof(Long id, ChallengeRequest.UpdateProof request, Long userId) {
+    public ChallengeResponse.Detail updateProof(User user, Long id, ChallengeRequest.UpdateProof request) {
         // TODO: Challenge 의 수정 권한 확인
         Challenge challenge = getChallenge(id);
 
@@ -71,7 +63,7 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void delete(Long id, Long userId) {
+    public void delete(User user, Long id) {
         // TODO: Challenge 의 삭제 권한 확인
         Challenge challenge = getChallenge(id);
 
@@ -79,9 +71,7 @@ public class ChallengeService {
     }
 
     private Challenge getChallenge(Long id) {
-        Challenge challenge = challengeRepository.findById(id)
+        return challengeRepository.findById(id)
                 .orElseThrow(() -> new NotFoundChallengeException());
-
-        return challenge;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -63,7 +63,7 @@ public class ChallengeService {
         ChallengeParticipation participation = getParticipation(user.getId(), id);
 
         validateRole(participation, ChallengeRole.LEADER, "리더만 챌린지 정보를 수정할 수 있습니다.");
-        validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 인증 정보를 수정할 수 있습니다.");
+        validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 정보를 수정할 수 있습니다.");
 
         challenge.updateContent(request.title(), request.description(), request.startDate(), request.endDate(), request.capacity(), request.category());
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -2,6 +2,7 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
 import com.trybe.modulecore.challenge.entity.Challenge;
@@ -112,7 +113,7 @@ public class ChallengeService {
 
     private void validateChallengeStatus(Challenge challenge, boolean shouldBe, ChallengeStatus status, String message) {
         if ((shouldBe && challenge.getStatus() != status) || (!shouldBe && challenge.getStatus() == status)) {
-            throw new InvalidChallengeRoleActionException(message);
+            throw new InvalidChallengeStatusException(message);
         }
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -32,10 +32,10 @@ public class ChallengeService {
     @Transactional
     public ChallengeResponse.Detail save(User user, ChallengeRequest.Create request) {
         Challenge challenge = request.toEntity();
-        ChallengeParticipation participation = new ChallengeParticipation(user, challenge, ChallengeRole.LEADER, ParticipationStatus.ACCEPTED);
-
-        challengeParticipationRepository.save(participation);
         Challenge savedChallenge = challengeRepository.save(challenge);
+
+        ChallengeParticipation participation = new ChallengeParticipation(user, savedChallenge, ChallengeRole.LEADER, ParticipationStatus.ACCEPTED);
+        challengeParticipationRepository.save(participation);
 
         return ChallengeResponse.Detail.from(savedChallenge);
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -40,6 +40,7 @@ public class ChallengeService {
         return ChallengeResponse.Detail.from(savedChallenge);
     }
 
+    @Transactional(readOnly = true)
     public ChallengeResponse.Detail find(Long id) {
         // TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
         Challenge challenge = getChallenge(id);
@@ -47,6 +48,7 @@ public class ChallengeService {
         return ChallengeResponse.Detail.from(challenge);
     }
 
+    @Transactional(readOnly = true)
     public Page<ChallengeResponse.Summary> findAll(ChallengeRequest.Read request, Pageable pageable) {
         // TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
         Page<Challenge> challenges = challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), pageable);

--- a/module-api/src/main/java/com/trybe/moduleapi/config/SecurityConfig.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
                 .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/login")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/token/reissue")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/api/v1/users/check-user-id")).permitAll()
-                .requestMatchers(new AntPathRequestMatcher("/api/v1/users/check-email")).permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/challenges/{id}").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/challenges/search").permitAll()
                 .anyRequest()
                 .authenticated());
 

--- a/module-api/src/test/java/com/trybe/moduleapi/annotation/WithCustomMockUser.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/annotation/WithCustomMockUser.java
@@ -1,0 +1,14 @@
+package com.trybe.moduleapi.annotation;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+    String username() default "testuser";
+    String email() default "test@test.com";
+    String nickname() default "테스트유저";
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/annotation/WithCustomMockUserSecurityContextFactory.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/annotation/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,29 @@
+package com.trybe.moduleapi.annotation;
+
+import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.modulecore.user.entity.User;
+import com.trybe.modulecore.user.enums.Gender;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+        String username = annotation.username();
+        String email = annotation.email();
+        String nickname = annotation.nickname();
+
+        User user = new User(username, email, nickname, Gender.NULL, null);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(authentication);
+
+        return context;
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -1,70 +1,37 @@
 package com.trybe.moduleapi.challenge.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
-import com.trybe.moduleapi.common.api.exception.ApiExceptionHandler;
+import com.trybe.moduleapi.common.ControllerTest;
 import com.trybe.modulecore.user.entity.User;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
-@AutoConfigureRestDocs(outputDir = "build/generated-snippets")
-class ChallengeControllerTest {
-    @InjectMocks
-    private ChallengeController challengeController;
-
-    @Mock
+@WebMvcTest(ChallengeController.class)
+class ChallengeControllerTest extends ControllerTest {
+    @MockitoBean
     private ChallengeService challengeService;
-
-    @Mock
-    private MockMvc mockMvc;
-    private ObjectMapper objectMapper;
 
     private String endpoint = "/api/v1/challenges";
 
     private String docsPath = "challenge-controller-test/";
     private final String invalidBadRequestPath = "invalid/bad-request/";
     private final String invalidNotFoundPath = "invalid/not-found/";
-
-    @BeforeEach
-    public void init(RestDocumentationContextProvider restDocumentation) {
-        objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        mockMvc = MockMvcBuilders.standaloneSetup(challengeController)
-                .setControllerAdvice(new ApiExceptionHandler())
-                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
-                .apply(documentationConfiguration(restDocumentation))
-                .build();
-    }
 
     @Test
     @DisplayName("정상적인 챌린지 생성 요청 시 응답코드 200을 반환한다.")

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -36,6 +36,8 @@ class ChallengeControllerTest extends ControllerTest {
     private String docsPath = "challenge-controller-test/";
     private final String invalidBadRequestPath = "invalid/bad-request/";
     private final String invalidNotFoundPath = "invalid/not-found/";
+    private final String invalidForbiddenPath = "invalid/forbidden/";
+    private final String invalidConflictPath = "invalid/conflict/";
 
     @Test
     @WithCustomMockUser
@@ -423,7 +425,7 @@ class ChallengeControllerTest extends ControllerTest {
         Long challengeId = ChallengeFixtures.챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
 
-        doThrow(new InvalidChallengeRoleActionException("리더만 챌린지 정봅를 수정할 수 있습니다."))
+        doThrow(new InvalidChallengeRoleActionException("리더만 챌린지 정보를 수정할 수 있습니다."))
                 .when(challengeService).updateContent(any(User.class), eq(challengeId), eq(request));
 
         /* when */
@@ -439,7 +441,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.data").doesNotExist()
         );
 
-        result.andDo(document(docsPath + "update-content/" + invalidBadRequestPath + "role-exception",
+        result.andDo(document(docsPath + "update-content/" + invalidForbiddenPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
@@ -473,7 +475,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.data").doesNotExist()
         );
 
-        result.andDo(document(docsPath + "update-content/" + invalidBadRequestPath + "status-exception",
+        result.andDo(document(docsPath + "update-content/" + invalidConflictPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
@@ -628,7 +630,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.data").doesNotExist()
         );
 
-        result.andDo(document(docsPath + "update-proof/" + invalidBadRequestPath + "role-exception",
+        result.andDo(document(docsPath + "update-proof/" + invalidForbiddenPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
@@ -662,7 +664,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.data").doesNotExist()
         );
 
-        result.andDo(document(docsPath + "update-proof/" + invalidBadRequestPath + "status-exception",
+        result.andDo(document(docsPath + "update-proof/" + invalidConflictPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
@@ -745,7 +747,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.data").doesNotExist()
         );
 
-        result.andDo(document(docsPath + "delete/" + invalidBadRequestPath + "role-exception",
+        result.andDo(document(docsPath + "delete/" + invalidForbiddenPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
@@ -776,7 +778,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.data").doesNotExist()
         );
 
-        result.andDo(document(docsPath + "delete/" + invalidBadRequestPath + "status-exception",
+        result.andDo(document(docsPath + "delete/" + invalidConflictPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -2,7 +2,9 @@ package com.trybe.moduleapi.challenge.controller;
 
 import com.trybe.moduleapi.annotation.WithCustomMockUser;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
+import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
 import com.trybe.moduleapi.common.ControllerTest;
@@ -415,6 +417,74 @@ class ChallengeControllerTest extends ControllerTest {
 
     @Test
     @WithCustomMockUser
+    @DisplayName("리더가 아닌 사용자가 챌린지 내용 수정 요청 시 응답코드 403을 반환한다.")
+    void 리더가_아닌_사용자가_챌린지_내용_수정_요청_시_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+
+        doThrow(new InvalidChallengeRoleActionException("리더만 챌린지 정봅를 수정할 수 있습니다."))
+                .when(challengeService).updateContent(any(User.class), eq(challengeId), eq(request));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/content", challengeId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "update-content/" + invalidBadRequestPath + "role-exception",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("진행 예정이 아닌 챌린지 내용 수정 요청 시 응답코드 409을 반환한다.")
+    void 진행_예정이_아닌_챌린지_내용_수정_요청_시_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+
+        doThrow(new InvalidChallengeStatusException("진행 예정인 챌린지만 수정할 수 있습니다."))
+                .when(challengeService).updateContent(any(User.class), eq(challengeId), eq(request));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/content", challengeId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "update-content/" + invalidBadRequestPath + "status-exception",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )));
+    }
+
+    @Test
+    @WithCustomMockUser
     @DisplayName("존재하지 않는 챌린지 내용 수정 요청 시 응답코드 404을 반환한다.")
     void 존재하지_않는_챌린지_내용_수정_요청_시_응답코드_404을_반환한다 () throws Exception {
         /* given */
@@ -536,6 +606,74 @@ class ChallengeControllerTest extends ControllerTest {
 
     @Test
     @WithCustomMockUser
+    @DisplayName("리더가 아닌 사용자가 챌린지 인증 내용 수정 요청 시 응답코드 403을 반환한다.")
+    void 리더가_아닌_사용자가_챌린지_인증_내용_수정_요청_시_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+
+        doThrow(new InvalidChallengeRoleActionException("리더만 챌린지 인증 내용을 수정할 수 있습니다."))
+                .when(challengeService).updateProof(any(User.class), eq(challengeId), eq(request));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/proof", challengeId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "update-proof/" + invalidBadRequestPath + "role-exception",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("진행 예정이 아닌 챌린지 인증 내용 수정 요청 시 응답코드 409을 반환한다.")
+    void 진행_예정이_아닌_챌린지_인증_내용_수정_요청_시_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+
+        doThrow(new InvalidChallengeStatusException("진행 예정인 챌린지만 인증 내용을 수정할 수 있습니다."))
+                .when(challengeService).updateProof(any(User.class), eq(challengeId), eq(request));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/proof", challengeId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "update-proof/" + invalidBadRequestPath + "status-exception",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )));
+    }
+
+    @Test
+    @WithCustomMockUser
     @DisplayName("존재하지 않는 챌린지 인증 내용 수정 요청 시 응답코드 404을 반환한다.")
     void 존재하지_않는_챌린지_인증_내용_수정_요청_시_응답코드_404를_반환한다 () throws Exception {
         /* given */
@@ -584,6 +722,68 @@ class ChallengeControllerTest extends ControllerTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 pathParameters(parameterWithName("id").description("삭제할 챌린지 ID"))));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("리더가 아닌 사용자가 챌린지 삭제 요청 시 응답코드 403을 반환한다.")
+    void 리더가_아닌_사용자가_챌린지_삭제_요청_시_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        doThrow(new InvalidChallengeRoleActionException("리더만 챌린지를 삭제할 수 있습니다."))
+                .when(challengeService).delete(any(User.class), eq(challengeId));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{id}", challengeId));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "delete/" + invalidBadRequestPath + "role-exception",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("진행 중인 챌린지 삭제 요청 시 응답코드 409을 반환한다.")
+    void 진행_중인_챌린지_삭제_요청_시_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        doThrow(new InvalidChallengeStatusException("진행 중인 챌린지는 삭제할 수 없습니다."))
+                .when(challengeService).delete(any(User.class), eq(challengeId));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{id}", challengeId));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "delete/" + invalidBadRequestPath + "status-exception",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )));
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -5,16 +5,16 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
 import com.trybe.moduleapi.common.api.exception.ApiExceptionHandler;
-import com.trybe.moduleapi.fixtures.ChallengeFixtures;
+import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.http.MediaType;
@@ -54,8 +54,6 @@ class ChallengeControllerTest {
     private final String invalidBadRequestPath = "invalid/bad-request/";
     private final String invalidNotFoundPath = "invalid/not-found/";
 
-    private final Long TMP_USER_ID = 1L;
-
     @BeforeEach
     public void init(RestDocumentationContextProvider restDocumentation) {
         objectMapper = new ObjectMapper();
@@ -74,7 +72,7 @@ class ChallengeControllerTest {
         /* given */
         ChallengeRequest.Create request = ChallengeFixtures.챌린지_생성_요청;
 
-        when(challengeService.save(request, TMP_USER_ID))
+        when(challengeService.save(any(User.class), eq(request)))
                 .thenReturn(ChallengeFixtures.챌린지_상세_응답);
 
         /* when */
@@ -249,8 +247,8 @@ class ChallengeControllerTest {
         /* given */
         ChallengeRequest.Read request = ChallengeFixtures.챌린지_조회_요청;
 
-        when(challengeService.findAll(request))
-                .thenReturn(ChallengeFixtures.챌린지_목록_응답);
+        when(challengeService.findAll(request, ChallengeFixtures.페이지_요청))
+                .thenReturn(ChallengeFixtures.챌린지_페이지_응답);
 
         /* when */
         /* then */
@@ -260,7 +258,7 @@ class ChallengeControllerTest {
 
         result.andExpectAll(
                 status().isOk(),
-                jsonPath("$.size()").value(ChallengeFixtures.챌린지_목록_응답.size())
+                jsonPath("$.length()").value(ChallengeFixtures.챌린지_페이지_응답.getTotalElements())
         );
 
         result.andDo(document(docsPath + "search",
@@ -319,7 +317,7 @@ class ChallengeControllerTest {
         Long challengeId = ChallengeFixtures.챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
 
-        when(challengeService.updateContent(challengeId, request, TMP_USER_ID))
+        when(challengeService.updateContent(any(User.class), challengeId, request))
                 .thenReturn(ChallengeFixtures.내용_수정된_챌린지_상세_응답);
 
         /* when */
@@ -417,7 +415,7 @@ class ChallengeControllerTest {
         Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
 
-        doThrow(new NotFoundChallengeException()).when(challengeService).updateContent(challengeId, request, TMP_USER_ID);
+        doThrow(new NotFoundChallengeException()).when(challengeService).updateContent(any(User.class), challengeId, request);
 
         /* when */
         /* then */
@@ -448,7 +446,7 @@ class ChallengeControllerTest {
         Long challengeId = ChallengeFixtures.챌린지_ID;
         ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
 
-        when(challengeService.updateProof(challengeId, request, TMP_USER_ID))
+        when(challengeService.updateProof(any(User.class), challengeId, request))
                 .thenReturn(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답);
 
         /* when */
@@ -534,7 +532,7 @@ class ChallengeControllerTest {
         Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
         ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
 
-        doThrow(new NotFoundChallengeException()).when(challengeService).updateProof(challengeId, request, TMP_USER_ID);
+        doThrow(new NotFoundChallengeException()).when(challengeService).updateProof(any(User.class), challengeId, request);
 
         /* when */
         /* then */
@@ -569,7 +567,7 @@ class ChallengeControllerTest {
         ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/" + challengeId));
 
         result.andExpect(status().isOk());
-        verify(challengeService, atLeastOnce()).delete(challengeId, TMP_USER_ID);
+        verify(challengeService, atLeastOnce()).delete(any(User.class), challengeId);
 
         result.andDo(document(docsPath + "delete",
                 preprocessRequest(prettyPrint()),
@@ -582,7 +580,7 @@ class ChallengeControllerTest {
         /* given */
         Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
 
-        doThrow(new NotFoundChallengeException()).when(challengeService).delete(challengeId, TMP_USER_ID);
+        doThrow(new NotFoundChallengeException()).when(challengeService).delete(any(User.class), challengeId);
 
         /* when */
         /* then */

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -1,4 +1,4 @@
-package com.trybe.moduleapi.fixtures;
+package com.trybe.moduleapi.challenge.fixtures;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -5,6 +5,10 @@ import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -158,7 +162,9 @@ public class ChallengeFixtures {
     public static Challenge 진행중인_챌린지 = createChallenge(ChallengeStatus.ONGOING);
     public static Challenge 종료된_챌린지 = createChallenge(ChallengeStatus.DONE);
 
-    public static List<Challenge> 챌린지_목록 = List.of(진행중인_챌린지);
+    public static Pageable 페이지_요청 = PageRequest.of(0, 10);
+    private static List<Challenge> 챌린지_목록 = List.of(진행중인_챌린지);
+    public static Page<Challenge> 챌린지_페이지 = new PageImpl<>(챌린지_목록, 페이지_요청, 챌린지_목록.size());
 
     public static ChallengeStatus 대기중 = ChallengeStatus.PENDING;
 
@@ -169,5 +175,5 @@ public class ChallengeFixtures {
     public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = ChallengeResponse.Detail.from(내용_수정된_챌린지);
     public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = ChallengeResponse.Detail.from(인증_내용_수정된_챌린지);
 
-    public static final List<ChallengeResponse.Summary> 챌린지_목록_응답 = 챌린지_목록.stream().map(ChallengeResponse.Summary::from).toList();
+    public static final Page<ChallengeResponse.Summary> 챌린지_페이지_응답 = 챌린지_페이지.map(ChallengeResponse.Summary::from);
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeParticipationFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeParticipationFixtures.java
@@ -1,0 +1,52 @@
+package com.trybe.moduleapi.challenge.fixtures;
+
+import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.challenge.enums.ChallengeRole;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+
+import java.util.List;
+
+public class ChallengeParticipationFixtures {
+    public static final Long 챌린지_참여_ID = 1L;
+    public static final Long 잘못된_챌린지_참여_ID = 0L;
+
+    public static final ChallengeRole 챌린지_리더_역할 = ChallengeRole.LEADER;
+    public static final ChallengeRole 챌린지_멤버_역할 = ChallengeRole.MEMBER;
+
+    public static final ParticipationStatus 챌린지_참여_대기_상태 = ParticipationStatus.PENDING;
+    public static final ParticipationStatus 챌린지_참여_수락_상태 = ParticipationStatus.ACCEPTED;
+    public static final ParticipationStatus 챌린지_참여_거절_상태 = ParticipationStatus.REJECTED;
+    public static final ParticipationStatus 챌린지_참여_탈퇴_상태 = ParticipationStatus.DISABLED;
+
+    /* Entity */
+    public static ChallengeParticipation 챌린지_리더_참여() {
+        return new ChallengeParticipation(UserFixtures.회원, ChallengeFixtures.챌린지(), 챌린지_리더_역할, 챌린지_참여_수락_상태);
+    }
+
+    public static ChallengeParticipation 챌린지_멤버_참여() {
+        return new ChallengeParticipation(UserFixtures.회원, ChallengeFixtures.챌린지(), 챌린지_멤버_역할, 챌린지_참여_수락_상태);
+    }
+
+    public static ChallengeParticipation 챌린지_멤버_참여_대기() {
+        return new ChallengeParticipation(UserFixtures.회원, ChallengeFixtures.챌린지(), 챌린지_멤버_역할, 챌린지_참여_대기_상태);
+    }
+
+    /* Response DTO */
+    public static ChallengeParticipationResponse.Detail 챌린지_참여_상세_응답() {
+        return ChallengeParticipationResponse.Detail.from(챌린지_멤버_참여_대기());
+    }
+
+    public static ChallengeParticipationResponse.Summary 챌린지_참여_요약_리더() {
+        return ChallengeParticipationResponse.Summary.from(챌린지_리더_참여());
+    }
+
+    public static ChallengeParticipationResponse.Summary 챌린지_참여_요약_멤버() {
+        return ChallengeParticipationResponse.Summary.from(챌린지_멤버_참여());
+    }
+
+    public static List<ChallengeParticipationResponse.Summary> 챌린지_참여_요약_목록() {
+        return List.of(챌린지_참여_요약_리더(), 챌린지_참여_요약_멤버());
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -2,7 +2,9 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeParticipationFixtures;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
@@ -121,6 +123,40 @@ class ChallengeServiceTest {
     }
 
     @Test
+    @DisplayName("챌린지 정보 수정 시 리더가 아닌 경우 예외를 던진다.")
+    void 챌린지_정보_수정_시_리더가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
+        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
+                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_멤버_참여()));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeRoleActionException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, request));
+    }
+
+    @Test
+    @DisplayName("챌린지 정보 수정 시 진행 예정 챌린지가 아닌 경우 예외를 던진다.")
+    void 챌린지_정보_수정_시_진행_예정_챌린지가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
+                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeStatusException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, request));
+    }
+
+    @Test
     @DisplayName("챌린지 정보 수정 시 존재하지 않는 챌린지 ID가 주어지면 예외를 던진다.")
     void 챌린지_정보_수정_시_존재하지_않는_챌린지_ID가_주어지면_예외를_던진다 () {
         /* given */
@@ -152,6 +188,40 @@ class ChallengeServiceTest {
 
         /* then */
         verifyChallengeResponse(ChallengeFixtures.인증_내용_수정된_챌린지, response);
+    }
+
+    @Test
+    @DisplayName("챌린지 인증 정보 수정 시 리더가 아닌 경우 예외를 던진다.")
+    void 챌린지_인증_정보_수정_시_리더가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
+        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
+                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_멤버_참여()));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeRoleActionException.class, () -> challengeService.updateProof(UserFixtures.회원, challengeId, request));
+    }
+
+    @Test
+    @DisplayName("챌린지 인증 정보 수정 시 진행 예정 챌린지가 아닌 경우 예외를 던진다")
+    void 챌린지_인증_정보_수정_시_진행_예정_챌린지가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
+                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeStatusException.class, () -> challengeService.updateProof(UserFixtures.회원, challengeId, request));
     }
 
     @Test
@@ -189,6 +259,38 @@ class ChallengeServiceTest {
 
         verify(challengeRepository, atLeastOnce()).delete(any(Challenge.class));
         verify(challengeParticipationRepository, atLeastOnce()).deleteAllByChallengeId(challengeId);
+    }
+
+    @Test
+    @DisplayName("챌린지 삭제 시 리더가 아닌 경우 예외를 던진다.")
+    void 챌린지_삭제_시_리더가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
+        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
+                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_멤버_참여()));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeRoleActionException.class, () -> challengeService.delete(UserFixtures.회원, challengeId));
+    }
+
+    @Test
+    @DisplayName("챌린지 삭제 시 진행 중인 챌린지인 경우 예외를 던진다.")
+    void 챌린지_삭제_시_진행_중인_챌린지인_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
+                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeStatusException.class, () -> challengeService.delete(UserFixtures.회원, challengeId));
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ChallengeServiceTest {
@@ -176,6 +176,8 @@ class ChallengeServiceTest {
         /* when */
         /* then */
         challengeService.delete(challengeId, TMP_USER_ID);
+
+        verify(challengeRepository, atLeastOnce()).deleteById(challengeId);
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/common/ControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/common/ControllerTest.java
@@ -1,0 +1,37 @@
+package com.trybe.moduleapi.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trybe.moduleapi.auth.CustomUserDetailsService;
+import com.trybe.moduleapi.auth.jwt.JwtUtils;
+import com.trybe.moduleapi.auth.jwt.exception.CustomAccessDeniedHandler;
+import com.trybe.moduleapi.auth.jwt.exception.CustomAuthenticationEntryPoint;
+import com.trybe.moduleapi.config.SecurityConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(outputDir = "build/generated-snippets")
+@Import(SecurityConfig.class)
+public abstract class ControllerTest {
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockitoBean
+    protected CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    protected JwtUtils jwtUtils;
+
+    @MockitoBean
+    protected CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @MockitoBean
+    protected CustomAccessDeniedHandler customAccessDeniedHandler;
+}

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
@@ -2,6 +2,7 @@ package com.trybe.modulecore.challenge.entity;
 
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
+import com.trybe.modulecore.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE challenge SET deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
-public class Challenge {
+public class Challenge extends BaseEntity {
     public Challenge(String title, String description, LocalDate startDate, LocalDate endDate, int capacity, ChallengeCategory category, String proofWay, int proofCount) {
         this.title = title;
         this.description = description;

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ChallengeRole.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ChallengeRole.java
@@ -10,4 +10,12 @@ public enum ChallengeRole {
     ChallengeRole(String description) {
         this.description = description;
     }
+
+    public boolean is(ChallengeRole role) {
+        return this == role;
+    }
+
+    public boolean isNot(ChallengeRole role) {
+        return this != role;
+    }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ChallengeStatus.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ChallengeStatus.java
@@ -13,4 +13,12 @@ public enum ChallengeStatus {
     ChallengeStatus(String description) {
         this.description = description;
     }
+
+    public boolean is(ChallengeStatus status) {
+        return this == status;
+    }
+
+    public boolean isNot(ChallengeStatus status) {
+        return this != status;
+    }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ParticipationStatus.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ParticipationStatus.java
@@ -14,4 +14,12 @@ public enum ParticipationStatus {
     ParticipationStatus(String description) {
         this.description = description;
     }
+
+    public boolean is(ParticipationStatus status) {
+        return this == status;
+    }
+
+    public boolean isNot(ParticipationStatus status) {
+        return this != status;
+    }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeParticipationRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeParticipationRepository.java
@@ -17,4 +17,5 @@ public interface ChallengeParticipationRepository extends JpaRepository<Challeng
     Page<ChallengeParticipation> findAllByUserIdAndStatusOrderByCreatedAtDesc(Long userId, ParticipationStatus status, Pageable pageable);
     Page<ChallengeParticipation> findAllByChallengeIdAndStatusOrderByCreatedAtAsc(Long challengeId, ParticipationStatus status, Pageable pageable);
     Optional<ChallengeParticipation> findByUserIdAndChallengeId(Long userId, Long challengeId);
+    void deleteAllByChallengeId(Long challengeId);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeRepository.java
@@ -3,6 +3,8 @@ package com.trybe.modulecore.challenge.repository;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +13,7 @@ import java.util.List;
 
 @Repository
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
-    public List<Challenge> findAllByStatusInAndCategoryIn(List<ChallengeStatus> statuses, List<ChallengeCategory> categories);
-    public List<Challenge> findAllByStatusAndStartDate(ChallengeStatus status, LocalDate startDate);
-    public List<Challenge> findAllByStatusAndEndDate(ChallengeStatus status, LocalDate endDate);
+    Page<Challenge> findAllByStatusInAndCategoryIn(List<ChallengeStatus> statuses, List<ChallengeCategory> categories, Pageable pageable);
+    List<Challenge> findAllByStatusAndStartDate(ChallengeStatus status, LocalDate startDate);
+    List<Challenge> findAllByStatusAndEndDate(ChallengeStatus status, LocalDate endDate);
 }


### PR DESCRIPTION
- `Challenge` 엔티티의 BaseEntity 상속 누락 수정
- `ChallengeController` 코드 수정
  - AuthenticationPrincipal 어노테이션 추가
  - 챌린지 필터링 조회 시 페이징 처리
- `ChallengeService` 코드 수정
  - 챌린지 필터링 조회 시 페이징 처리
  - 로그인 유저가 필요한 메서드에 User 타입의 user을 파라미터로 받도록 수정
  - 챌린지 생성 시, 생성자의 리더 참여 정보를 저장하는 로직 추가
  - 챌린지 수정 및 삭제 시 리더인지 확인하는 검증 로직 추가
  - 챌린지 수정 시 진행 예정 상태인지 확인하는 검증 로직 추가
  - 챌린지 삭제 시 진행 중인 상태가 아닌지 확인하는 검증 로직 추가
  - 챌린지 삭제 시 챌린지 참여 정보도 삭제될 수 있도록 코드 수정
  - 챌린지 조회 메서드에 대해 Transactional(readOnly = true) 어노테이션 추가
- `ChallengeRequest` 코드 수정
  - 챌린지 생성 및 수정 시 챌린지 기간이 최소 1주에서 최대 8주를 충족하는지 검증
- 챌린지 API 내 로그인이 필요한 HTTP 요청에 Authorization 헤더 추가
- 변경 내용에 따른 챌린지 테스트 코드 수정
  - Controller 단위 테스트를 위한 공통 설정 클래스 추가
  - CustomUserDetail를 SecurityContext 내 Authentication에 저장하는 WithCustomMockUser 어노테이션 구현
  - 챌린지 수정 및 삭제 시 권한 예외, 챌린지 상태 예외 테스트 코드 추가
  - 추가된 테스트 코드 결과를 index.adoc 파일에 추가