### PR TITLE
[#28] Page 응답 구현

### DIFF
--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
@@ -4,8 +4,8 @@ import com.trybe.moduleapi.auth.CustomUserDetails;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
+import com.trybe.moduleapi.common.dto.PageResponse;
 import jakarta.validation.Valid;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,7 +33,7 @@ public class ChallengeController {
     }
 
     @PostMapping("/search")
-    public Page<ChallengeResponse.Summary> findAll(
+    public PageResponse<ChallengeResponse.Summary> findAll(
             @Valid @RequestBody ChallengeRequest.Read request,
             Pageable pageable
     ) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeParticipationController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeParticipationController.java
@@ -3,8 +3,8 @@ package com.trybe.moduleapi.challenge.controller;
 import com.trybe.moduleapi.auth.CustomUserDetails;
 import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
 import com.trybe.moduleapi.challenge.service.ChallengeParticipationService;
+import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +27,7 @@ public class ChallengeParticipationController {
     }
 
     @GetMapping("/my")
-    public Page<ChallengeParticipationResponse.Detail> getMyParticipations(
+    public PageResponse<ChallengeParticipationResponse.Detail> getMyParticipations(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("status") ParticipationStatus status,
             Pageable pageable
@@ -36,7 +36,7 @@ public class ChallengeParticipationController {
     }
 
     @GetMapping("/{challengeId}")
-    public Page<ChallengeParticipationResponse.Summary> getParticipants(
+    public PageResponse<ChallengeParticipationResponse.Summary> getParticipants(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("challengeId") Long challengeId,
             @RequestParam("status") ParticipationStatus status,

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -3,6 +3,7 @@ package com.trybe.moduleapi.challenge.service;
 import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
 import com.trybe.moduleapi.challenge.exception.*;
 import com.trybe.moduleapi.challenge.exception.participation.*;
+import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.enums.ChallengeRole;
@@ -42,21 +43,19 @@ public class ChallengeParticipationService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChallengeParticipationResponse.Detail> getMyParticipations(User user, ParticipationStatus status, Pageable pageable) {
+    public PageResponse<ChallengeParticipationResponse.Detail> getMyParticipations(User user, ParticipationStatus status, Pageable pageable) {
         Page<ChallengeParticipation> participations = challengeParticipationRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(user.getId(), status, pageable);
 
-        return participations.map(ChallengeParticipationResponse.Detail::from);
+        return new PageResponse<>(participations.map(ChallengeParticipationResponse.Detail::from));
     }
 
     @Transactional(readOnly = true)
-    public Page<ChallengeParticipationResponse.Summary> getParticipants(User user, Long challengeId, ParticipationStatus status, Pageable pageable) {
-        Challenge challenge = getChallenge(challengeId);
-
+    public PageResponse<ChallengeParticipationResponse.Summary> getParticipants(User user, Long challengeId, ParticipationStatus status, Pageable pageable) {
         ChallengeParticipation participation = getParticipation(user.getId(), challengeId);
         checkRole(participation, ChallengeRole.LEADER, "리더만 참여자 목록을 조회할 수 있습니다.");
 
         Page<ChallengeParticipation> participations = challengeParticipationRepository.findAllByChallengeIdAndStatusOrderByCreatedAtAsc(challengeId, status, pageable);
-        return participations.map(ChallengeParticipationResponse.Summary::from);
+        return new PageResponse<>(participations.map(ChallengeParticipationResponse.Summary::from));
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -5,6 +5,7 @@ import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
+import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.enums.ChallengeRole;
@@ -48,11 +49,11 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChallengeResponse.Summary> findAll(ChallengeRequest.Read request, Pageable pageable) {
+    public PageResponse<ChallengeResponse.Summary> findAll(ChallengeRequest.Read request, Pageable pageable) {
         // TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
         Page<Challenge> challenges = challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), pageable);
 
-        return challenges.map(ChallengeResponse.Summary::from);
+        return new PageResponse<>(challenges.map(ChallengeResponse.Summary::from));
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/common/dto/PageResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/common/dto/PageResponse.java
@@ -1,0 +1,23 @@
+package com.trybe.moduleapi.common.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int totalPages,
+        long totalElements,
+        int size,
+        int number,
+        boolean last
+) {
+    public PageResponse(Page<T> page) {
+        this(page.getContent(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.getSize(),
+                page.getNumber(),
+                page.isLast());
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -236,7 +236,7 @@ class ChallengeControllerTest extends ControllerTest {
 
         result.andExpectAll(
                 status().isOk(),
-                jsonPath("$.content.length()").value(ChallengeFixtures.챌린지_페이지_응답.getContent().size())
+                jsonPath("$.totalElements").value(ChallengeFixtures.챌린지_페이지_응답.totalElements())
         );
 
         result.andDo(document(docsPath + "search",
@@ -251,35 +251,18 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("categories").description("챌린지 카테고리")
                 ),
                 responseFields(
-                        fieldWithPath("pageable").description("페이지 정보"),
-                        fieldWithPath("pageable.pageNumber").description("페이지 번호"),
-                        fieldWithPath("pageable.pageSize").description("페이지 크기"),
-                        fieldWithPath("pageable.sort").description("정렬 정보"),
-                        fieldWithPath("pageable.sort.empty").description("정렬이 비어있는지 여부"),
-                        fieldWithPath("pageable.sort.sorted").description("정렬된 상태인지 여부"),
-                        fieldWithPath("pageable.sort.unsorted").description("정렬되지 않은 상태인지 여부"),
-                        fieldWithPath("pageable.offset").description("페이지 오프셋"),
-                        fieldWithPath("pageable.unpaged").description("페이지가 비어 있는지 여부"),
-                        fieldWithPath("pageable.paged").description("페이징 여부"),
-                        fieldWithPath("last").description("마지막 페이지 여부"),
-                        fieldWithPath("totalPages").description("전체 페이지 수"),
-                        fieldWithPath("totalElements").description("전체 요소 수"),
-                        fieldWithPath("first").description("첫번째 페이지 여부"),
-                        fieldWithPath("size").description("페이지 크기"),
-                        fieldWithPath("number").description("현재 페이지 번호"),
-                        fieldWithPath("numberOfElements").description("현재 페이지 요소 수"),
-                        fieldWithPath("empty").description("비어있는지 여부"),
-                        fieldWithPath("sort").description("전체 정렬 정보"),
-                        fieldWithPath("sort.empty").description("정렬이 비어있는지 여부"),
-                        fieldWithPath("sort.sorted").description("정렬된 상태인지 여부"),
-                        fieldWithPath("sort.unsorted").description("정렬되지 않은 상태인지 여부"),
                         fieldWithPath("content").description("챌린지 목록"),
                         fieldWithPath("content[].id").description("챌린지 ID"),
                         fieldWithPath("content[].title").description("챌린지 제목"),
                         fieldWithPath("content[].description").description("챌린지 설명"),
                         fieldWithPath("content[].status").description("챌린지 상태"),
                         fieldWithPath("content[].capacity").description("챌린지 인원"),
-                        fieldWithPath("content[].category").description("챌린지 카테고리")
+                        fieldWithPath("content[].category").description("챌린지 카테고리"),
+                        fieldWithPath("totalPages").description("총 페이지 수"),
+                        fieldWithPath("totalElements").description("총 요소 수"),
+                        fieldWithPath("size").description("페이지 크기"),
+                        fieldWithPath("number").description("현재 페이지 번호"),
+                        fieldWithPath("last").description("마지막 페이지 여부")
                 )));
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -2,6 +2,7 @@ package com.trybe.moduleapi.challenge.fixtures;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
@@ -175,5 +176,5 @@ public class ChallengeFixtures {
     public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = ChallengeResponse.Detail.from(내용_수정된_챌린지);
     public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = ChallengeResponse.Detail.from(인증_내용_수정된_챌린지);
 
-    public static final Page<ChallengeResponse.Summary> 챌린지_페이지_응답 = 챌린지_페이지.map(ChallengeResponse.Summary::from);
+    public static final PageResponse<ChallengeResponse.Summary> 챌린지_페이지_응답 = new PageResponse<>(챌린지_페이지.map(ChallengeResponse.Summary::from));
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -7,6 +7,7 @@ import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeParticipationFixtures;
+import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 
 import java.util.Optional;
 
@@ -97,10 +97,10 @@ class ChallengeServiceTest {
                 .thenReturn(ChallengeFixtures.챌린지_페이지);
 
         /* when */
-        Page<ChallengeResponse.Summary> response = challengeService.findAll(request, ChallengeFixtures.페이지_요청);
+        PageResponse<ChallengeResponse.Summary> response = challengeService.findAll(request, ChallengeFixtures.페이지_요청);
 
         /* then */
-        assertEquals(ChallengeFixtures.챌린지_페이지.getTotalElements(), response.getTotalElements());
+        assertEquals(ChallengeFixtures.챌린지_페이지_응답.totalElements(), response.totalElements());
     }
 
     @Test


### PR DESCRIPTION
- `PageResponse` 구현
- `Page<ChallengeResponse>` 형태의 응답을 `PageResponse<ChallengeResponse>`로 변경
- `Page<ChallengeParticipationResponse>` 형태의 응답을 `PageResponse<ChallengeParticipationResponse>`로 변경
- Challenge, ChallengeParticipation 테스트 코드에 변경 사항 적용