### PR TITLE
[#35] 챌린지 인증 테스트 코드 작성

### DIFF
--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -350,97 +350,6 @@ include::{snippets}/challenge-controller-test/delete/invalid/not-found/response-
 
 ---
 
-== 게시글
-
-=== 게시글 생성 API
-
-게시글을 작성합니다.
-
-==== 정상 요청
-include::{snippets}/post-controller-test/save/http-request.adoc[]
-include::{snippets}/post-controller-test/save/request-fields.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/save/http-response.adoc[]
-include::{snippets}/post-controller-test/save/response-fields.adoc[]
-
-==== 비정상 요청 (잘못된 요청)
-유효성 검증에 실패하는 요청 시 다음과 같이 반환합니다.
-
-include::{snippets}/post-controller-test/save/invalid/bad-request/http-request.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/save/invalid/bad-request/http-response.adoc[]
-include::{snippets}/post-controller-test/save/invalid/bad-request/response-fields.adoc[]
-
-=== 게시글 단건 조회 API
-게시글을 조회합니다.
-
-==== 정상 요청
-include::{snippets}/post-controller-test/findById/http-request.adoc[]
-include::{snippets}/post-controller-test/findById/path-parameters.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/findById/http-response.adoc[]
-include::{snippets}/post-controller-test/findById/response-fields.adoc[]
-
-==== 비정상 요청 (존재하지 않는 게시글 조회 시)
-존재하지 않는 게시글 조회 시 다음과 같이 반환됩니다.
-
-include::{snippets}/post-controller-test/findById/invalid/not-found/http-request.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/findById/invalid/not-found/http-response.adoc[]
-include::{snippets}/post-controller-test/findById/invalid/not-found/response-fields.adoc[]
-
-=== 게시글 목록 조회 API
-
-게시글 목록 조회합니다.
-
-==== 정상 요청
-include::{snippets}/post-controller-test/search/http-request.adoc[]
-include::{snippets}/post-controller-test/search/query-parameters.adoc
-
-- 응답
-include::{snippets}/post-controller-test/search/http-response.adoc[]
-include::{snippets}/post-controller-test/search/response-fields.adoc[]
-
-=== 게시글 수정 API
-
-게시글을 수정합니다.
-
-==== 정상 요청
-include::{snippets}/post-controller-test/update/http-request.adoc[]
-include::{snippets}/post-controller-test/update/path-parameters.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/update/http-response.adoc[]
-include::{snippets}/post-controller-test/update/response-fields.adoc[]
-
-==== 비정상 요청 (잘못된 요청)
-유효성 검증에 실패하는 수정 시 다음과 같이 반환합니다.
-include::{snippets}/post-controller-test/update/invalid/forbidden/http-request.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/update/invalid/forbidden/http-response.adoc[]
-include::{snippets}/post-controller-test/update/invalid/forbidden/response-fields.adoc[]
-
-==== 비정상 요청 (존재하지 않는 게시글 수 시)
-존재하지 않는 글을 수정 시 다음과 같이 반환됩니다.
-include::{snippets}/post-controller-test/update/invalid/not-found/http-request.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/update/invalid/not-found/http-response.adoc[]
-include::{snippets}/post-controller-test/update/invalid/not-found/response-fields.adoc[]
-
-==== 비정상 요청 (작성자가 아닌 게시글 수정 시)
-작성자가 아닌 게시글 수정 시 다음과 같이 반환됩니다.
-include::{snippets}/post-controller-test/update/invalid/forbidden/http-request.adoc[]
-
-- 응답
-include::{snippets}/post-controller-test/update/invalid/forbidden/http-response.adoc[]
-include::{snippets}/post-controller-test/update/invalid/forbidden/response-fields.adoc[]
-
 == 챌린지 참여 API
 
 === 챌린지 참여 신청
@@ -632,3 +541,230 @@ include::{snippets}/challenge-participation-controller-test/cancel/invalid/forbi
 
 include::{snippets}/challenge-participation-controller-test/cancel/invalid/forbidden/participation-status/http-response.adoc[]
 include::{snippets}/challenge-participation-controller-test/cancel/invalid/forbidden/participation-status/response-fields.adoc[]
+
+---
+
+== 챌린지 인증 API
+
+=== 챌린지 인증 생성
+챌린지 인증 정보를 생성합니다.
+
+==== 정상 요청
+include::{snippets}/proof-controller-test/save/http-request.adoc[]
+include::{snippets}/proof-controller-test/save/request-fields.adoc[]
+
+- 응답
+include::{snippets}/proof-controller-test/save/http-response.adoc[]
+include::{snippets}/proof-controller-test/save/response-fields.adoc[]
+
+==== 비정상 요청 (잘못된 요청)
+유효성 검증에 실패하는 요청 시 다음과 같이 반환합니다.
+
+include::{snippets}/proof-controller-test/save/invalid/bad-request/http-request.adoc[]
+
+- 응답
+include::{snippets}/proof-controller-test/save/invalid/bad-request/http-response.adoc[]
+include::{snippets}/proof-controller-test/save/invalid/bad-request/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지)
+존재하지 않는 챌린지 ID로 인증 정보를 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/save/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-controller-test/save/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (리더가 아닌 사용자)
+리더가 아닌 사용자가 인증을 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/save/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-controller-test/save/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (진행 중이 아닌 챌린지)
+진행 중이 아닌 챌린지에 대한 인증 생성을 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/save/invalid/conflict/status/http-response.adoc[]
+include::{snippets}/proof-controller-test/save/invalid/conflict/status/response-fields.adoc[]
+
+==== 비정상 요청 (이미 인증이 존재하는 경우)
+인증 수행 날짜에 대한 인증이 이미 존재하는 경우, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/save/invalid/conflict/duplicated/http-response.adoc[]
+include::{snippets}/proof-controller-test/save/invalid/conflict/duplicated/response-fields.adoc[]
+
+==== 비정상 요청 (인증 라운드 초과)
+인증 라운드가 챌린지의 인증 횟수를 초과하는 경우, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/save/invalid/conflict/round/http-response.adoc[]
+include::{snippets}/proof-controller-test/save/invalid/conflict/round/response-fields.adoc[]
+
+---
+
+=== 챌린지 인증 단일 조회
+인증 ID에 대한 인증을 조회합니다.
+
+==== 정상 요청
+include::{snippets}/proof-controller-test/find/http-request.adoc[]
+include::{snippets}/proof-controller-test/find/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-controller-test/find/http-response.adoc[]
+include::{snippets}/proof-controller-test/find/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 인증)
+존재하지 않는 인증 ID로 인증 정보를 조회했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/find/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-controller-test/find/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (수락된 참여자가 아닌 사용자)
+챌린지에 대한 수락된 참여자가 아닌 사용자가 인증 단일 조회를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/find/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-controller-test/find/invalid/forbidden/response-fields.adoc[]
+
+---
+
+=== 챌린지 인증 목록 조회
+챌린지 ID에 대한 챌린지의 인증 목록을 조회합니다.
+
+==== 정상 요청
+include::{snippets}/proof-controller-test/findAll/http-request.adoc[]
+include::{snippets}/proof-controller-test/findAll/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-controller-test/findAll/http-response.adoc[]
+include::{snippets}/proof-controller-test/findAll/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지)
+존재하지 않는 챌린지 ID로 인증 목록을 조회했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/findAll/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-controller-test/findAll/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (수락된 참여자가 아닌 사용자)
+챌린지에 대한 수락된 참여자가 아닌 사용자가 인증 목록 조회를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/findAll/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-controller-test/findAll/invalid/forbidden/response-fields.adoc[]
+
+---
+
+=== 챌린지 인증 삭제
+챌린지 ID에 대한 인증 삭제를 수행합니다.
+
+==== 정상 요청
+include::{snippets}/proof-controller-test/delete/http-request.adoc[]
+include::{snippets}/proof-controller-test/delete/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-controller-test/delete/http-response.adoc[]
+
+==== 비정상 요청 (존재하지 않는 인증)
+존재하지 않는 인증 ID로 인증 삭제를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/delete/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-controller-test/delete/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (리더가 아닌 사용자)
+리더가 아닌 사용자가 인증을 삭제했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/delete/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-controller-test/delete/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (삭제 제한 시간 초과)
+인증 삭제 요청 시 삭제 제한 시간을 초과한 경우, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-controller-test/delete/invalid/bad-request/http-response.adoc[]
+include::{snippets}/proof-controller-test/delete/invalid/bad-request/response-fields.adoc[]
+
+---
+
+== 게시글
+
+=== 게시글 생성 API
+
+게시글을 작성합니다.
+
+==== 정상 요청
+include::{snippets}/post-controller-test/save/http-request.adoc[]
+include::{snippets}/post-controller-test/save/request-fields.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/save/http-response.adoc[]
+include::{snippets}/post-controller-test/save/response-fields.adoc[]
+
+==== 비정상 요청 (잘못된 요청)
+유효성 검증에 실패하는 요청 시 다음과 같이 반환합니다.
+
+include::{snippets}/post-controller-test/save/invalid/bad-request/http-request.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/save/invalid/bad-request/http-response.adoc[]
+include::{snippets}/post-controller-test/save/invalid/bad-request/response-fields.adoc[]
+
+=== 게시글 단건 조회 API
+게시글을 조회합니다.
+
+==== 정상 요청
+include::{snippets}/post-controller-test/findById/http-request.adoc[]
+include::{snippets}/post-controller-test/findById/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/findById/http-response.adoc[]
+include::{snippets}/post-controller-test/findById/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 게시글 조회 시)
+존재하지 않는 게시글 조회 시 다음과 같이 반환됩니다.
+
+include::{snippets}/post-controller-test/findById/invalid/not-found/http-request.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/findById/invalid/not-found/http-response.adoc[]
+include::{snippets}/post-controller-test/findById/invalid/not-found/response-fields.adoc[]
+
+=== 게시글 목록 조회 API
+
+게시글 목록 조회합니다.
+
+==== 정상 요청
+include::{snippets}/post-controller-test/search/http-request.adoc[]
+include::{snippets}/post-controller-test/search/query-parameters.adoc
+
+- 응답
+include::{snippets}/post-controller-test/search/http-response.adoc[]
+include::{snippets}/post-controller-test/search/response-fields.adoc[]
+
+=== 게시글 수정 API
+
+게시글을 수정합니다.
+
+==== 정상 요청
+include::{snippets}/post-controller-test/update/http-request.adoc[]
+include::{snippets}/post-controller-test/update/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/update/http-response.adoc[]
+include::{snippets}/post-controller-test/update/response-fields.adoc[]
+
+==== 비정상 요청 (잘못된 요청)
+유효성 검증에 실패하는 수정 시 다음과 같이 반환합니다.
+include::{snippets}/post-controller-test/update/invalid/forbidden/http-request.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/update/invalid/forbidden/http-response.adoc[]
+include::{snippets}/post-controller-test/update/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 게시글 수 시)
+존재하지 않는 글을 수정 시 다음과 같이 반환됩니다.
+include::{snippets}/post-controller-test/update/invalid/not-found/http-request.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/update/invalid/not-found/http-response.adoc[]
+include::{snippets}/post-controller-test/update/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (작성자가 아닌 게시글 수정 시)
+작성자가 아닌 게시글 수정 시 다음과 같이 반환됩니다.
+include::{snippets}/post-controller-test/update/invalid/forbidden/http-request.adoc[]
+
+- 응답
+include::{snippets}/post-controller-test/update/invalid/forbidden/http-response.adoc[]
+include::{snippets}/post-controller-test/update/invalid/forbidden/response-fields.adoc[]

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofControllerTest.java
@@ -31,8 +31,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -411,6 +410,10 @@ class ProofControllerTest extends ControllerTest {
                 preprocessResponse(prettyPrint()),
                 pathParameters(
                         parameterWithName("challengeId").description("챌린지 ID")
+                ),
+                queryParameters(
+                        parameterWithName("page").description("페이지 번호"),
+                        parameterWithName("size").description("페이지 크기")
                 ),
                 responseFields(
                         fieldWithPath("content").description("인증 목록"),

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofControllerTest.java
@@ -1,0 +1,606 @@
+package com.trybe.moduleapi.proof.controller;
+
+import com.trybe.moduleapi.annotation.WithCustomMockUser;
+import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
+import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
+import com.trybe.moduleapi.common.ControllerTest;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofResponse;
+import com.trybe.moduleapi.proof.exception.DuplicatedProofException;
+import com.trybe.moduleapi.proof.exception.InvalidProofDeletionException;
+import com.trybe.moduleapi.proof.exception.NotFoundProofException;
+import com.trybe.moduleapi.proof.exception.ProofCountExceededException;
+import com.trybe.moduleapi.proof.service.ProofService;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.trybe.moduleapi.proof.fixtures.ProofFixtures.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProofController.class)
+class ProofControllerTest extends ControllerTest {
+    @MockitoBean
+    private ProofService proofService;
+
+    private final String endpoint = "/api/v1/proofs";
+
+    private final String docsPath = "proof-controller-test/";
+    private final String invalidBadRequestPath = "/invalid/bad-request/";
+    private final String invalidNotFoundPath = "/invalid/not-found/";
+    private final String invalidConflictPath = "/invalid/conflict/";
+    private final String invalidForbiddenPath = "/invalid/forbidden/";
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 생성 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_생성_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+        ProofResponse.Summary response = 인증_요약_응답;
+
+        when(proofService.save(any(User.class), any(ProofRequest.Create.class)))
+                .thenReturn(response);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.id").value(response.id()),
+                jsonPath("$.date").value(response.date().toString()),
+                jsonPath("$.round").value(response.round())
+        );
+
+        result.andDo(document(docsPath + "save",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("challengeId").description("챌린지 ID"),
+                        fieldWithPath("date").description("인증 수행 날짜")
+                ),
+                responseFields(
+                        fieldWithPath("id").description("인증 ID"),
+                        fieldWithPath("date").description("인증 수행 날짜"),
+                        fieldWithPath("round").description("인증 라운드")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("비정상적인 인증 생성 요청 시 응답코드 400을 반환한다.")
+    void 비정상적인_인증_생성_요청_시_응답코드_400을_반환한다 () throws Exception {
+        /* given */
+        ProofRequest.Create request = 잘못된_날짜_인증_생성_요청;
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.status").value(400),
+                jsonPath("$.message").doesNotExist(),
+                jsonPath("$.data.date").exists()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidBadRequestPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        subsectionWithPath("data").description("에러 데이터"),
+                        fieldWithPath("data.date").description("인증 수행 날짜 에러")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 챌린지에 대한 인증 생성 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_챌린지에_대한_인증_생성_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(proofService.save(any(User.class), any(ProofRequest.Create.class)))
+                .thenThrow(new NotFoundProofException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 생성 요청 시 주어진 챌린지의 리더가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_생성_요청_시_주어진_챌린지의_리더가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(proofService.save(any(User.class), any(ProofRequest.Create.class)))
+                .thenThrow(new InvalidChallengeRoleActionException("리더만 인증을 등록할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 생성 요청 시 진행 중인 챌린지가 아닌 경우 응답코드 409을 반환한다.")
+    void 인증_생성_요청_시_진행_중인_챌린지가_아닌_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(proofService.save(any(User.class), any(ProofRequest.Create.class)))
+                .thenThrow(new InvalidChallengeStatusException("진행 중인 챌린지만 인증을 등록할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidConflictPath + "status",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 생성 요청 시 중복된 인증이 존재하는 경우 응답코드 409을 반환한다.")
+    void 인증_생성_요청_시_중복된_인증이_존재하는_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(proofService.save(any(User.class), any(ProofRequest.Create.class)))
+                .thenThrow(new DuplicatedProofException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidConflictPath + "duplicated",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 생성 요청 시 인증 라운드가 챌린지의 인증 횟수를 초과하는 경우 응답코드 400을 반환한다.")
+    void 인증_생성_요청_시_인증_라운드가_챌린지의_인증_횟수를_초과하는_경우_응답코드_400을_반환한다 () throws Exception {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(proofService.save(any(User.class), any(ProofRequest.Create.class)))
+                .thenThrow(new ProofCountExceededException(ChallengeFixtures.챌린지_인증_횟수));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.status").value(400),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidConflictPath + "round",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 단일 조회 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_단일_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofService.find(any(User.class), eq(proofId)))
+                .thenReturn(인증_요약_응답);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofId}", proofId));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.id").value(인증_요약_응답.id()),
+                jsonPath("$.date").value(인증_요약_응답.date().toString()),
+                jsonPath("$.round").value(인증_요약_응답.round())
+        );
+
+        result.andDo(document(docsPath + "find",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("proofId").description("인증 ID")
+                ),
+                responseFields(
+                        fieldWithPath("id").description("인증 ID"),
+                        fieldWithPath("date").description("인증 수행 날짜"),
+                        fieldWithPath("round").description("인증 라운드")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증에 대한 단일 조회 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증에_대한_단일_조회_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofService.find(any(User.class), eq(proofId)))
+                .thenThrow(new NotFoundProofException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofId}", proofId));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "find" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 단일 조회 요청 시 수락된 참여자가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_단일_조회_요청_시_수락된_참여자가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofService.find(any(User.class), eq(proofId)))
+                .thenThrow(new InvalidParticipationStatusActionException("참여자만 인증을 조회할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofId}", proofId));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "find" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 목록 조회 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_목록_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        PageResponse<ProofResponse.Summary> response = 인증_페이지_응답;
+
+        when(proofService.findAll(any(User.class), eq(challengeId), any()))
+                .thenReturn(response);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/challenge/{challengeId}", challengeId)
+                        .param("page", "0").param("size", "10"));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.content").isArray(),
+                jsonPath("$.content.size()").value(response.content().size()),
+                jsonPath("$.totalPages").value(response.totalPages()),
+                jsonPath("$.totalElements").value(response.totalElements()),
+                jsonPath("$.size").value(response.size()),
+                jsonPath("$.number").value(response.number()),
+                jsonPath("$.last").value(response.last())
+        );
+
+        result.andDo(document(docsPath + "findAll",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("challengeId").description("챌린지 ID")
+                ),
+                responseFields(
+                        fieldWithPath("content").description("인증 목록"),
+                        fieldWithPath("content[].id").description("인증 ID"),
+                        fieldWithPath("content[].date").description("인증 수행 날짜"),
+                        fieldWithPath("content[].round").description("인증 라운드"),
+                        fieldWithPath("totalPages").description("총 페이지 수"),
+                        fieldWithPath("totalElements").description("총 요소 수"),
+                        fieldWithPath("size").description("페이지 크기"),
+                        fieldWithPath("number").description("현재 페이지 번호"),
+                        fieldWithPath("last").description("마지막 페이지 여부")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 챌린지에 대한 인증 목록 조회 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_챌린지에_대한_인증_목록_조회_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(proofService.findAll(any(User.class), eq(challengeId), any()))
+                .thenThrow(new NotFoundChallengeException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/challenge/{challengeId}", challengeId)
+                        .param("page", "0").param("size", "10"));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "findAll" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 목록 조회 요청 시 수락된 참여자가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_목록_조회_요청_시_수락된_참여자가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(proofService.findAll(any(User.class), eq(challengeId), any()))
+                .thenThrow(new InvalidParticipationStatusActionException("참여자만 인증 목록을 조회할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/challenge/{challengeId}", challengeId)
+                        .param("page", "0").param("size", "10"));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "findAll" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 삭제 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_삭제_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = 인증_ID;
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{proofId}", proofId));
+
+        result.andExpect(status().isOk());
+        verify(proofService, atLeastOnce()).delete(any(User.class), eq(proofId));
+
+        result.andDo(document(docsPath + "delete",
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("proofId").description("인증 ID"))
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증에 대한 삭제 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증에_대한_삭제_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = 인증_ID;
+
+        doThrow(new NotFoundProofException())
+                .when(proofService).delete(any(User.class), eq(proofId));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{proofId}", proofId));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "delete" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 삭제 요청 시 리더가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_삭제_요청_시_리더가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = 인증_ID;
+
+        doThrow(new InvalidChallengeRoleActionException("리더만 인증을 삭제할 수 있습니다."))
+                .when(proofService).delete(any(User.class), eq(proofId));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{proofId}", proofId));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "delete" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 삭제 요청 시 삭제 시간 제한을 초과한 경우 응답코드 400을 반환한다.")
+    void 인증_삭제_요청_시_삭제_시간_제한을_초과한_경우_응답코드_400을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = 인증_ID;
+        Long hoursBefore = 1L;
+
+        doThrow(new InvalidProofDeletionException("인증 삭제는 시작하기 " + hoursBefore + "시간 이내에만 가능합니다."))
+                .when(proofService).delete(any(User.class), eq(proofId));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{proofId}", proofId));
+
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.status").value(400),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "delete" + invalidBadRequestPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("에러 데이터")
+                )
+        ));
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofFixtures.java
@@ -1,0 +1,45 @@
+package com.trybe.moduleapi.proof.fixtures;
+
+import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofResponse;
+import com.trybe.modulecore.proof.entity.Proof;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class ProofFixtures {
+    public static final Long 인증_ID = 1L;
+    public static final LocalDate 인증_날짜 = LocalDate.of(2025, 4, 14);
+    public static final LocalDate 잘못된_인증_날짜 = LocalDate.of(2001, 11, 14);
+
+    public static final int 인증_라운드 = 1;
+
+    /* Request DTO */
+    public static final ProofRequest.Create 인증_생성_요청 = new ProofRequest.Create(ChallengeFixtures.챌린지_ID, 인증_날짜);
+    public static final ProofRequest.Create 잘못된_날짜_인증_생성_요청 = new ProofRequest.Create(ChallengeFixtures.챌린지_ID, 잘못된_인증_날짜);
+
+    /* Entity */
+    private static final Proof 인증_생성(LocalDate date, int round) {
+        return new Proof(ChallengeFixtures.진행중인_챌린지, date, round);
+    }
+
+    public static final Proof 인증 = 인증_생성(인증_날짜, 인증_라운드);
+    public static Pageable 페이지_요청 = PageRequest.of(0, 10);
+    private static final List<Proof> 인증_목록 = List.of(
+            인증_생성(LocalDate.of(2025, 4, 14), 1),
+            인증_생성(LocalDate.of(2025, 4, 15), 2),
+            인증_생성(LocalDate.of(2025, 4, 16), 3)
+    );
+
+    public static final Page<Proof> 인증_페이지 = new PageImpl<>(인증_목록, 페이지_요청, 인증_목록.size());
+
+    /* Response DTO */
+    public static final ProofResponse.Summary 인증_요약_응답 = new ProofResponse.Summary(인증_ID, 인증_날짜, 인증_라운드);
+    public static final PageResponse<ProofResponse.Summary> 인증_페이지_응답 = new PageResponse<>(인증_페이지.map(ProofResponse.Summary::from));
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofServiceTest.java
@@ -1,0 +1,311 @@
+package com.trybe.moduleapi.proof.service;
+
+import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
+import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofResponse;
+import com.trybe.moduleapi.proof.exception.DuplicatedProofException;
+import com.trybe.moduleapi.proof.exception.NotFoundProofException;
+import com.trybe.moduleapi.proof.exception.ProofCountExceededException;
+import com.trybe.moduleapi.proof.fixtures.ProofFixtures;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.challenge.enums.ChallengeRole;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.challenge.repository.ChallengeRepository;
+import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.proof.repository.ProofRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.trybe.moduleapi.proof.fixtures.ProofFixtures.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProofServiceTest {
+    @InjectMocks
+    private ProofService proofService;
+
+    @Mock
+    private ProofRepository proofRepository;
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @Mock
+    private ChallengeParticipationRepository challengeParticipationRepository;
+
+    @Test
+    @DisplayName("인증 생성 시 저장된 인증 정보를 반환한다.")
+    void 인증_생성_시_저장된_인증_정보를_반환한다 () {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+        Proof proof = 인증;
+        int recentRound = 0;
+
+        when(challengeRepository.findById(request.challengeId()))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), any(), eq(ChallengeRole.LEADER)))
+                .thenReturn(true);
+        when(proofRepository.existsByChallengeIdAndDate(any(), eq(request.date())))
+                .thenReturn(false);
+        when(proofRepository.countByChallengeId(any()))
+                .thenReturn(recentRound);
+        when(proofRepository.save(any(Proof.class)))
+                .thenReturn(인증);
+
+        /* when */
+        ProofResponse.Summary result = proofService.save(UserFixtures.회원, request);
+
+        /* then */
+        assertEquals(proof.getId(), result.id());
+        assertEquals(request.date(), result.date());
+        assertEquals(recentRound + 1., result.round());
+    }
+
+    @Test
+    @DisplayName("인증 생성 시 존재하지 않는 챌린지 ID가 주어지면 예외를 던진다.")
+    void 인증_생성_시_존재하지_않는_챌린지_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(challengeRepository.findById(request.challengeId()))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundChallengeException.class, () -> proofService.save(UserFixtures.회원, request));
+    }
+    
+    @Test
+    @DisplayName("인증 생성 시 주어진 챌린지의 리더가 아닌 경우 예외를 던진다.")
+    void 인증_생성_시_주어진_챌린지의_리더가_아닌_경우_예외를_던진다 () {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(challengeRepository.findById(request.challengeId()))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), any(), eq(ChallengeRole.LEADER)))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeRoleActionException.class, () -> proofService.save(UserFixtures.회원, request));
+    }
+
+    @Test
+    @DisplayName("인증 생성 시 진행 중인 챌린지가 아닌 경우 예외를 던진다.")
+    void 인증_생성_시_진행_중인_챌린지가_아닌_경우_예외를_던진다 () {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(challengeRepository.findById(request.challengeId()))
+                .thenReturn(Optional.of(ChallengeFixtures.종료된_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), any(), eq(ChallengeRole.LEADER)))
+                .thenReturn(true);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeStatusException.class, () -> proofService.save(UserFixtures.회원, request));
+    }
+
+    @Test
+    @DisplayName("인증 생성 시 이미 요청한 날짜에 인증이 등록된 경우 예외를 던진다.")
+    void 인증_생성_시_이미_요청한_날짜에_인증이_등록된_경우_예외를_던진다 () {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(challengeRepository.findById(request.challengeId()))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), any(), eq(ChallengeRole.LEADER)))
+                .thenReturn(true);
+        when(proofRepository.existsByChallengeIdAndDate(any(), eq(request.date())))
+                .thenReturn(true);
+
+        /* when */
+        /* then */
+        assertThrows(DuplicatedProofException.class, () -> proofService.save(UserFixtures.회원, request));
+    }
+
+    @Test
+    @DisplayName("인증 생성 시 챌린지 인증 라운드를 초과하는 경우 예외를 던진다.")
+    void 인증_생성_시_챌린지_인증_라운드를_초과하는_경우_예외를_던진다 () {
+        /* given */
+        ProofRequest.Create request = 인증_생성_요청;
+
+        when(challengeRepository.findById(request.challengeId()))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), any(), eq(ChallengeRole.LEADER)))
+                .thenReturn(true);
+        when(proofRepository.existsByChallengeIdAndDate(any(), eq(request.date())))
+                .thenReturn(false);
+        when(proofRepository.countByChallengeId(any()))
+                .thenReturn(ChallengeFixtures.진행중인_챌린지.getProofCount());
+
+        /* when */
+        /* then */
+        assertThrows(ProofCountExceededException.class, () -> proofService.save(UserFixtures.회원, request));
+    }
+
+    @Test
+    @DisplayName("인증 단일 조회 시 인증 정보를 반환한다.")
+    void 인증_단일_조회_시_인증_정보를_반환한다 () {
+        /* given */
+        Long proofId = 인증_ID;
+        Proof proof = 인증;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(proof));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+
+        /* when */
+        ProofResponse.Summary result = proofService.find(UserFixtures.회원, proofId);
+
+        /* then */
+        assertEquals(proof.getId(), result.id());
+        assertEquals(proof.getDate(), result.date());
+        assertEquals(proof.getRound(), result.round());
+    }
+
+    @Test
+    @DisplayName("인증 단일 조회 시 존재하지 않는 인증 ID가 주어지면 예외를 던진다.")
+    void 인증_단일_조회_시_존재하지_않는_인증_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofException.class, () -> proofService.find(UserFixtures.회원, proofId));
+    }
+
+    @Test
+    @DisplayName("인증 단일 조회 시 수락된 참여자가 아닌 경우 예외를 던진다.")
+    void 인증_단일_조회_시_수락된_참여자가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidParticipationStatusActionException.class, () -> proofService.find(UserFixtures.회원, proofId));
+    }
+
+    @Test
+    @DisplayName("인증 목록 조회 시 주어진 챌린지에 대한 인증 목록을 반환한다.")
+    void 인증_목록_조회_시_주어진_챌린지에_대한_인증_목록을_반환한다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        when(proofRepository.findAllByChallengeId(challengeId, ProofFixtures.페이지_요청))
+                .thenReturn(인증_페이지);
+
+        /* when */
+        PageResponse<ProofResponse.Summary> result = proofService.findAll(UserFixtures.회원, challengeId, ProofFixtures.페이지_요청);
+
+        /* then */
+        assertEquals(인증_페이지_응답.totalElements(), result.totalElements());
+    }
+
+    @Test
+    @DisplayName("인증 목록 조회 시 존재하지 않는 챌린지 ID가 주어지면 예외를 던진다.")
+    void 인증_목록_조회_시_존재하지_않는_챌린지_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundChallengeException.class, () -> proofService.findAll(UserFixtures.회원, challengeId, ProofFixtures.페이지_요청));
+    }
+
+    @Test
+    @DisplayName("인증 목록 조회 시 수락된 참여자가 아닌 경우 예외를 던진다.")
+    void 인증_목록_조회_시_수락된_참여자가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidParticipationStatusActionException.class, () -> proofService.findAll(UserFixtures.회원, challengeId, ProofFixtures.페이지_요청));
+    }
+
+    @Test
+    @DisplayName("인증 삭제 시 인증을 삭제한다.")
+    void 인증_삭제_시_인증을_삭제한다 () {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), any(), eq(ChallengeRole.LEADER)))
+                .thenReturn(true);
+
+        /* when */
+        /* then */
+        proofService.delete(UserFixtures.회원, proofId);
+
+        verify(proofRepository, atLeastOnce()).delete(any(Proof.class));
+    }
+
+    @Test
+    @DisplayName("인증 삭제 시 존재하지 않는 인증 ID가 주어지면 예외를 던진다.")
+    void 인증_삭제_시_존재하지_않는_인증_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofException.class, () -> proofService.delete(UserFixtures.회원, proofId));
+    }
+
+    @Test
+    @DisplayName("인증 삭제 시 챌린지의 리더가 아닌 경우 예외를 던진다")
+    void 인증_삭제_시_챌린지의_리더가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofId = 인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), any(), eq(ChallengeRole.LEADER)))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidChallengeRoleActionException.class, () -> proofService.delete(UserFixtures.회원, proofId));
+    }
+}


### PR DESCRIPTION
- 챌린지 인증에 대한 테스트 코드 작성
  - `ProofFixtures` 작성
  - `ProofServiceTest` 작성
  - `ProofControllerTest` 작성
- Spring Rest Docs의 index.adoc 파일 수정
  - 챌린지 인증 API에 대한 섹션 추가
  - 게시글 API 섹션 순서 이동