### PR TITLE
[#7] 인증 히스토리 도메인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 ### ETC ###
 data
 **/application.yml
+
+redis/

--- a/module-api/http/proof-history-vote.http
+++ b/module-api/http/proof-history-vote.http
@@ -1,0 +1,11 @@
+### 1. 인증 기록 투표 생성
+POST http://localhost:8080/api/v1/proofs/histories/votes/1?approved=true
+Authorization: {{accessToken}}
+
+### 2. 나의 인증 기록 투표 조회
+GET http://localhost:8080/api/v1/proofs/histories/votes/1
+Authorization: {{accessToken}}
+
+### 3. 인증 기록 투표 결과 조회
+GET http://localhost:8080/api/v1/proofs/histories/votes/1/result
+Authorization: {{accessToken}}

--- a/module-api/http/proof-history.http
+++ b/module-api/http/proof-history.http
@@ -1,0 +1,43 @@
+### 1. 인증 기록 생성
+POST http://localhost:8080/api/v1/proofs/histories/1
+Authorization: {{accessToken}}
+Content-Type: application/json
+
+{
+  "content": "인증 기록 생성 테스트"
+}
+
+### 1-1. 인증 기록 생성 (유효성 검증 실패)
+POST http://localhost:8080/api/v1/proofs/histories/1
+Authorization: {{accessToken}}
+Content-Type: application/json
+
+{
+  "content": ""
+}
+
+### 2. 인증 기록 목록 조회
+GET http://localhost:8080/api/v1/proofs/histories/1?size=10&page=0
+Authorization: {{accessToken}}
+
+### 3. 인증 기록 수정
+PUT http://localhost:8080/api/v1/proofs/histories/1
+Authorization: {{accessToken}}
+Content-Type: application/json
+
+{
+  "content": "인증 기록 수정 테스트"
+}
+
+### 3-1. 인증 기록 수정 (유효성 검증 실패)
+PUT http://localhost:8080/api/v1/proofs/histories/1
+Authorization: {{accessToken}}
+Content-Type: application/json
+
+{
+  "content": ""
+}
+
+### 4. 인증 기록 삭제
+DELETE http://localhost:8080/api/v1/proofs/histories/1
+Authorization: {{accessToken}}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
@@ -29,7 +29,7 @@ public class ChallengeScheduler {
 
     @Scheduled(cron = "59 59 23 * * *")
     @Transactional
-    public void updateChalengeStatusDone() {
+    public void updateChallengeStatusDone() {
         List<Challenge> challenges = challengeRepository.findAllByStatusAndEndDate(ChallengeStatus.ONGOING, LocalDate.now());
         challenges.forEach(challenge -> {
             challenge.updateStatus(ChallengeStatus.DONE);

--- a/module-api/src/main/java/com/trybe/moduleapi/config/RedisConfig.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.util.Set;
 
@@ -31,9 +32,14 @@ public class RedisConfig {
     public RedisTemplate<String, Long> redisTemplate() {
         RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setEnableTransactionSupport(true);
 
         redisTemplate.setKeySerializer(new GenericToStringSerializer<>(String.class));
         redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
         return redisTemplate;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
@@ -1,0 +1,56 @@
+package com.trybe.moduleapi.proof.controller;
+
+import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
+import com.trybe.moduleapi.proof.service.ProofHistoryService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/proofs/histories")
+public class ProofHistoryController {
+    private final ProofHistoryService proofHistoryService;
+
+    public ProofHistoryController(ProofHistoryService proofHistoryService) {
+        this.proofHistoryService = proofHistoryService;
+    }
+
+    @PostMapping("/{proofId}")
+    public ProofHistoryResponse.Summary save(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("proofId") Long proofId,
+            @Valid @RequestBody ProofHistoryRequest.Create request
+    ) {
+        return proofHistoryService.save(userDetails.getUser(),proofId, request);
+    }
+
+    @GetMapping("/{proofId}")
+    public PageResponse<ProofHistoryResponse.Summary> findAll(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("proofId") Long proofId,
+            Pageable pageable
+    ) {
+        return proofHistoryService.findAll(userDetails.getUser(), proofId, pageable);
+    }
+
+    @PutMapping("/{proofHistoryId}")
+    public ProofHistoryResponse.Summary update(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("proofHistoryId") Long proofHistoryId,
+            @Valid @RequestBody ProofHistoryRequest.Update request
+    ) {
+        return proofHistoryService.update(userDetails.getUser(), proofHistoryId, request);
+    }
+
+    @DeleteMapping("/{proofHistoryId}")
+    public void delete(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("proofHistoryId") Long proofHistoryId
+    ) {
+        proofHistoryService.delete(userDetails.getUser(), proofHistoryId);
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
@@ -28,7 +28,7 @@ public class ProofHistoryController {
         return proofHistoryService.save(userDetails.getUser(),proofId, request);
     }
 
-    @GetMapping("/{proofId}")
+    @GetMapping("/all/{proofId}")
     public PageResponse<ProofHistoryResponse.Summary> findAll(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("proofId") Long proofId,

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteController.java
@@ -1,0 +1,42 @@
+package com.trybe.moduleapi.proof.controller;
+
+import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryVoteResponse;
+import com.trybe.moduleapi.proof.service.ProofHistoryVoteService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/proofs/histories/votes")
+public class ProofHistoryVoteController {
+    private final ProofHistoryVoteService proofHistoryVoteService;
+
+    public ProofHistoryVoteController(ProofHistoryVoteService proofHistoryVoteService) {
+        this.proofHistoryVoteService = proofHistoryVoteService;
+    }
+
+    @PostMapping("/{proofHistoryId}")
+    public ProofHistoryVoteResponse.My save(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("proofHistoryId") Long proofHistoryId,
+            @RequestParam("approved") Boolean approved
+    ) {
+        return proofHistoryVoteService.save(userDetails.getUser(), proofHistoryId, approved);
+    }
+
+    @GetMapping("/{proofHistoryId}")
+    public ProofHistoryVoteResponse.My findMyVote(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("proofHistoryId") Long proofHistoryId
+    ) {
+        return proofHistoryVoteService.findMyVote(userDetails.getUser(), proofHistoryId);
+    }
+
+    @GetMapping("/{proofHistoryId}/result")
+    public ProofHistoryVoteResponse.Result findResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("proofHistoryId") Long proofHistoryId
+    ) {
+        return proofHistoryVoteService.getResult(userDetails.getUser(), proofHistoryId);
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteController.java
@@ -33,7 +33,7 @@ public class ProofHistoryVoteController {
     }
 
     @GetMapping("/{proofHistoryId}/result")
-    public ProofHistoryVoteResponse.Result findResult(
+    public ProofHistoryVoteResponse.Result getResult(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("proofHistoryId") Long proofHistoryId
     ) {

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
@@ -1,0 +1,28 @@
+package com.trybe.moduleapi.proof.dto.request;
+
+import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class ProofHistoryRequest {
+    private static final String CONTENT_NOT_BLANK_MESSAGE = "인증 내용을 입력해주세요.";
+    private static final String CONTENT_MAX_LENGTH_MESSAGE = "인증 내용은 최대 1,000자까지 입력 가능합니다.";
+
+    public record Create(
+            @NotBlank(message = CONTENT_NOT_BLANK_MESSAGE)
+            @Size(max = 1000, message = CONTENT_MAX_LENGTH_MESSAGE)
+            String content
+    ) {
+        public ProofHistory toEntity(Proof proof, User user, String content) {
+            return new ProofHistory(proof, user, content);
+        }
+    }
+
+    public record Update(
+            @NotBlank(message = CONTENT_NOT_BLANK_MESSAGE)
+            @Size(max = 1000, message = CONTENT_MAX_LENGTH_MESSAGE)
+            String content
+    ) {}
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryResponse.java
@@ -1,0 +1,42 @@
+package com.trybe.moduleapi.proof.dto.response;
+
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+
+import java.time.LocalDateTime;
+
+public class ProofHistoryResponse {
+    public record Summary(
+            Long id,
+            String content,
+            ProofHistoryStatus status,
+            LocalDateTime createdAt
+    ) {
+        public static Summary from(ProofHistory proofHistory) {
+            return new Summary(
+                    proofHistory.getId(),
+                    proofHistory.getContent(),
+                    proofHistory.getStatus(),
+                    proofHistory.getCreatedAt()
+            );
+        }
+    }
+
+    public record Detail(
+            ProofResponse.Summary proof,
+            Long id,
+            String content,
+            ProofHistoryStatus status,
+            LocalDateTime createdAt
+    ) {
+        public static Detail from(ProofHistory proofHistory) {
+            return new Detail(
+                    ProofResponse.Summary.from(proofHistory.getProof()),
+                    proofHistory.getId(),
+                    proofHistory.getContent(),
+                    proofHistory.getStatus(),
+                    proofHistory.getCreatedAt()
+            );
+        }
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryVoteResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryVoteResponse.java
@@ -1,0 +1,13 @@
+package com.trybe.moduleapi.proof.dto.response;
+
+public class ProofHistoryVoteResponse {
+    public record My(
+            Boolean approved
+    ) { }
+
+    public record Result(
+            long approvedCount,
+            long disapprovedCount,
+            long nonParticipatedCount
+    ) { }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryVoteResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryVoteResponse.java
@@ -6,8 +6,8 @@ public class ProofHistoryVoteResponse {
     ) { }
 
     public record Result(
-            long approvedCount,
-            long disapprovedCount,
-            long nonParticipatedCount
+            int approvedCount,
+            int disapprovedCount,
+            int nonParticipatedCount
     ) { }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/exception/InvalidProofDateException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/exception/InvalidProofDateException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.proof.exception;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidProofDateException extends BusinessException {
+    public InvalidProofDateException() {
+        super("인증 기록은 인증 날짜에만 등록할 수 있습니다.", HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/DuplicatedProofHistoryVoteException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/DuplicatedProofHistoryVoteException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.proof.exception.history;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicatedProofHistoryVoteException extends BusinessException {
+    public DuplicatedProofHistoryVoteException() {
+        super("이미 투표에 참여했습니다.", HttpStatus.CONFLICT.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/ForbiddenProofHistoryException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/ForbiddenProofHistoryException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.proof.exception.history;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenProofHistoryException extends BusinessException {
+    public ForbiddenProofHistoryException(String message) {
+        super(message, HttpStatus.FORBIDDEN.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/InvalidProofHistoryStatusException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/InvalidProofHistoryStatusException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.proof.exception.history;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidProofHistoryStatusException extends BusinessException {
+    public InvalidProofHistoryStatusException(String message) {
+        super(message, HttpStatus.CONFLICT.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/NotFoundProofHistoryException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/NotFoundProofHistoryException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.proof.exception.history;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundProofHistoryException extends BusinessException {
+    public NotFoundProofHistoryException() {
+        super("존재하지 않는 인증 기록입니다.", HttpStatus.NOT_FOUND.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
@@ -1,0 +1,46 @@
+package com.trybe.moduleapi.proof.service;
+
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProofHistoryScheduler {
+    private final ProofHistoryRepository proofHistoryRepository;
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    public ProofHistoryScheduler(ProofHistoryRepository proofHistoryRepository, RedisTemplate<String, Long> redisTemplate) {
+        this.proofHistoryRepository = proofHistoryRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void updateProofHistoryStatusByVote() {
+        LocalDate targetDate = LocalDate.now().minusDays(2);
+        List<ProofHistory> proofHistories = proofHistoryRepository.findAllByProof_Date(targetDate);
+
+        proofHistories.forEach(proofHistory -> {
+            boolean result = isApproved(proofHistory);
+            proofHistory.updateStatus(result ? ProofHistoryStatus.PASSED : ProofHistoryStatus.FAILED);
+        });
+    }
+
+    private boolean isApproved(ProofHistory proofHistory) {
+        String approvedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:approvedCount";
+        String disapprovedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:disapprovedCount";
+
+        long approvedCount = Optional.ofNullable(redisTemplate.opsForValue().get(approvedCountKey)).orElse(0L);
+        long disapprovedCount = Optional.ofNullable(redisTemplate.opsForValue().get(disapprovedCountKey)).orElse(0L);
+
+        return approvedCount >= disapprovedCount;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -1,0 +1,113 @@
+package com.trybe.moduleapi.proof.service;
+
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
+import com.trybe.moduleapi.proof.exception.*;
+import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
+import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
+import com.trybe.modulecore.proof.repository.ProofRepository;
+import com.trybe.modulecore.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+public class ProofHistoryService {
+    private final ProofHistoryRepository proofHistoryRepository;
+    private final ProofRepository proofRepository;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
+
+    public ProofHistoryService(ProofHistoryRepository proofHistoryRepository, ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository) {
+        this.proofHistoryRepository = proofHistoryRepository;
+        this.proofRepository = proofRepository;
+        this.challengeParticipationRepository = challengeParticipationRepository;
+    }
+
+    @Transactional
+    public ProofHistoryResponse.Summary save(User user, Long proofId, ProofHistoryRequest.Create request) {
+        Proof proof = getProof(proofId);
+
+        validateMemberParticipation(user.getId(), proof.getChallenge().getId(), "멤버만 인증 기록을 등록할 수 있습니다.");
+        validateDate(proof);
+
+        ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
+        return ProofHistoryResponse.Summary.from(savedProofHistory);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ProofHistoryResponse.Summary> findAll(User user, Long proofId, Pageable pageable) {
+        Proof proof = getProof(proofId);
+
+        validateMemberParticipation(user.getId(), proof.getChallenge().getId(), "멤버만 인증 기록을 조회할 수 있습니다.");
+
+        Page<ProofHistory> proofHistories = proofHistoryRepository.findAllByProofId(proofId, pageable);
+        return new PageResponse<>(proofHistories.map(ProofHistoryResponse.Summary::from));
+    }
+
+    @Transactional
+    public ProofHistoryResponse.Summary update(User user, Long proofHistoryId, ProofHistoryRequest.Update request) {
+        ProofHistory proofHistory = getProofHistory(proofHistoryId);
+
+        validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 수정할 수 있습니다.");
+        validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록은 수정할 수 없습니다.");
+
+        proofHistory.updateContent(request.content());
+
+        return ProofHistoryResponse.Summary.from(proofHistory);
+    }
+
+    @Transactional
+    public void delete(User user, Long proofHistoryId) {
+        ProofHistory proofHistory = getProofHistory(proofHistoryId);
+
+        validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 삭제할 수 있습니다.");
+
+        proofHistoryRepository.delete(proofHistory);
+    }
+
+    private Proof getProof(Long proofId) {
+        return proofRepository.findById(proofId)
+                .orElseThrow(NotFoundProofException::new);
+    }
+
+    private ProofHistory getProofHistory(Long proofHistoryId) {
+        return proofHistoryRepository.findById(proofHistoryId)
+                .orElseThrow(NotFoundProofHistoryException::new);
+    }
+
+    private void validateMemberParticipation(Long userId, Long challengeId, String message) {
+        if (!challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(userId, challengeId, ParticipationStatus.ACCEPTED)) {
+            throw new InvalidParticipationStatusActionException(message);
+        }
+    }
+
+    private void validateProofHistoryOwner(User user, boolean shouldBe, ProofHistory proofHistory, String message) {
+        if ((user.getId() != proofHistory.getUser().getId()) == shouldBe) {
+            throw new ForbiddenProofHistoryException(message);
+        }
+    }
+
+    private void validateDate(Proof proof) {
+        if (!proof.getDate().equals(LocalDate.now())) {
+            throw new InvalidProofDateException();
+        }
+    }
+
+    private void validateProofHistoryStatus(ProofHistory proofHistory, ProofHistoryStatus status, String message) {
+        if (proofHistory.getStatus().isNot(status)) {
+            throw new InvalidProofHistoryStatusException(message);
+        }
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -80,6 +80,7 @@ public class ProofHistoryVoteService {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
 
         validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 투표 결과를 조회할 수 있습니다.");
+        validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 결과를 조회할 수 없습니다.");
 
         String approvedCountKey = getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistory.getId());
         String disapprovedCountKey = getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistory.getId());

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -28,6 +28,13 @@ public class ProofHistoryVoteService {
         this.redisTemplate = redisTemplate;
     }
 
+    private final String USER_KEY = "user:%d";
+    private final String PROOF_HISTORY_VOTES_KEY = "proofHistory:%d:votes";
+    private final String PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY = "proofHistory:%d:votes:approvedCount";
+    private final String PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY = "proofHistory:%d:votes:disapprovedCount";
+    private final String APPROVED = "approved";
+    private final String DISAPPROVED = "disapproved";
+
     @Transactional
     public ProofHistoryVoteResponse.My save(User user, Long proofHistoryId, boolean approved) {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
@@ -36,22 +43,22 @@ public class ProofHistoryVoteService {
         validateProofHistoryOwner(user, false, proofHistory, "자기 자신의 인증 기록에 투표할 수 없습니다.");
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대해 투표할 수 없습니다.");
 
-        String key = "proofHistory:" + proofHistory.getId() + ":votes";
-        String userKey = "user:" + user.getId();
+        String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());
+        String userKey = getRedisKey(USER_KEY, user.getId());
 
         if (redisTemplate.opsForHash().get(key, userKey) != null) {
             throw new DuplicatedProofHistoryVoteException();
         }
 
-        String approvedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:approvedCount";
-        String disapprovedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:disapprovedCount";
+        String approvedCountKey = getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistory.getId());
+        String disapprovedCountKey = getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistory.getId());
 
         if (approved) {
             redisTemplate.opsForValue().increment(approvedCountKey, 1);
         } else {
             redisTemplate.opsForValue().increment(disapprovedCountKey, 1);
         }
-        redisTemplate.opsForHash().put(key, userKey, (approved ? "1" : "0"));
+        redisTemplate.opsForHash().put(key, userKey, (approved ? APPROVED : DISAPPROVED));
 
         return new ProofHistoryVoteResponse.My(approved);
     }
@@ -63,11 +70,11 @@ public class ProofHistoryVoteService {
         validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 내역을 조회할 수 있슶니다.");
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 내역을 조회할 수 없습니다.");
 
-        String key = "proofHistory:" + proofHistory.getId() + ":votes";
-        String userKey = "user:" + user.getId();
+        String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());
+        String userKey = getRedisKey(USER_KEY, user.getId());
         String vote = (String) redisTemplate.opsForHash().get(key, userKey);
 
-        return new ProofHistoryVoteResponse.My(vote == null ? null : vote.equals("1"));
+        return new ProofHistoryVoteResponse.My(vote == null ? null : vote.equals(APPROVED));
     }
 
     @Transactional(readOnly = true)
@@ -76,8 +83,8 @@ public class ProofHistoryVoteService {
 
         validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 투표 결과를 조회할 수 있습니다.");
 
-        String approvedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:approvedCount";
-        String disapprovedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:disapprovedCount";
+        String approvedCountKey = getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistory.getId());
+        String disapprovedCountKey = getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistory.getId());
 
         Long approvedCount = redisTemplate.opsForValue().get(approvedCountKey);
         Long disapprovedCount = redisTemplate.opsForValue().get(disapprovedCountKey);
@@ -111,5 +118,9 @@ public class ProofHistoryVoteService {
         if (proofHistory.getStatus().isNot(status)) {
             throw new InvalidProofHistoryStatusException(message);
         }
+    }
+
+    private String getRedisKey(String key, Long id) {
+        return String.format(key, id);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -1,0 +1,115 @@
+package com.trybe.moduleapi.proof.service;
+
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryVoteResponse;
+import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryVoteException;
+import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
+import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
+import com.trybe.modulecore.user.entity.User;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProofHistoryVoteService {
+    private final ProofHistoryRepository proofHistoryRepository;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    public ProofHistoryVoteService(ProofHistoryRepository proofHistoryRepository, ChallengeParticipationRepository challengeParticipationRepository, RedisTemplate<String, Long> redisTemplate) {
+        this.proofHistoryRepository = proofHistoryRepository;
+        this.challengeParticipationRepository = challengeParticipationRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Transactional
+    public ProofHistoryVoteResponse.My save(User user, Long proofHistoryId, boolean approved) {
+        ProofHistory proofHistory = getProofHistory(proofHistoryId);
+
+        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 인증 기록에 대해 투표할 수 있습니다.");
+        validateProofHistoryOwner(user, false, proofHistory, "자기 자신의 인증 기록에 투표할 수 없습니다.");
+        validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대해 투표할 수 없습니다.");
+
+        String key = "proofHistory:" + proofHistory.getId() + ":votes";
+        String userKey = "user:" + user.getId();
+
+        if (redisTemplate.opsForHash().get(key, userKey) != null) {
+            throw new DuplicatedProofHistoryVoteException();
+        }
+
+        String approvedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:approvedCount";
+        String disapprovedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:disapprovedCount";
+
+        if (approved) {
+            redisTemplate.opsForValue().increment(approvedCountKey, 1);
+        } else {
+            redisTemplate.opsForValue().increment(disapprovedCountKey, 1);
+        }
+        redisTemplate.opsForHash().put(key, userKey, (approved ? "1" : "0"));
+
+        return new ProofHistoryVoteResponse.My(approved);
+    }
+
+    @Transactional(readOnly = true)
+    public ProofHistoryVoteResponse.My findMyVote(User user, Long proofHistoryId) {
+        ProofHistory proofHistory = getProofHistory(proofHistoryId);
+
+        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 내역을 조회할 수 있슶니다.");
+        validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 내역을 조회할 수 없습니다.");
+
+        String key = "proofHistory:" + proofHistory.getId() + ":votes";
+        String userKey = "user:" + user.getId();
+        String vote = (String) redisTemplate.opsForHash().get(key, userKey);
+
+        return new ProofHistoryVoteResponse.My(vote == null ? null : vote.equals("1"));
+    }
+
+    @Transactional(readOnly = true)
+    public ProofHistoryVoteResponse.Result getResult(User user, Long proofHistoryId) {
+        ProofHistory proofHistory = getProofHistory(proofHistoryId);
+
+        validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 투표 결과를 조회할 수 있습니다.");
+
+        String approvedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:approvedCount";
+        String disapprovedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:disapprovedCount";
+
+        Long approvedCount = redisTemplate.opsForValue().get(approvedCountKey);
+        Long disapprovedCount = redisTemplate.opsForValue().get(disapprovedCountKey);
+
+        approvedCount = approvedCount == null ? 0 : approvedCount;
+        disapprovedCount = disapprovedCount == null ? 0 : disapprovedCount;
+
+        int participantCount = challengeParticipationRepository.countByChallengeIdAndStatus(proofHistory.getProof().getChallenge().getId(), ParticipationStatus.ACCEPTED) - 1;
+
+        return new ProofHistoryVoteResponse.Result(approvedCount, disapprovedCount, participantCount - (approvedCount + disapprovedCount));
+    }
+
+    private ProofHistory getProofHistory(Long proofHistoryId) {
+        return proofHistoryRepository.findById(proofHistoryId)
+                .orElseThrow(() -> new NotFoundProofHistoryException());
+    }
+
+    private void validateMemberParticipation(Long userId, Long challengeId, String message) {
+        if (!challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(userId, challengeId, ParticipationStatus.ACCEPTED)) {
+            throw new InvalidParticipationStatusActionException(message);
+        }
+    }
+
+    private void validateProofHistoryOwner(User user, boolean shouldBe, ProofHistory proofHistory, String message) {
+        if ((user.getId() != proofHistory.getUser().getId()) == shouldBe) {
+            throw new ForbiddenProofHistoryException(message);
+        }
+    }
+
+    private void validateProofHistoryStatus(ProofHistory proofHistory, ProofHistoryStatus status, String message) {
+        if (proofHistory.getStatus().isNot(status)) {
+            throw new InvalidProofHistoryStatusException(message);
+        }
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -16,6 +16,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 public class ProofHistoryVoteService {
     private final ProofHistoryRepository proofHistoryRepository;
@@ -85,11 +87,8 @@ public class ProofHistoryVoteService {
         String approvedCountKey = getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistory.getId());
         String disapprovedCountKey = getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistory.getId());
 
-        Long approvedCount = redisTemplate.opsForValue().get(approvedCountKey);
-        Long disapprovedCount = redisTemplate.opsForValue().get(disapprovedCountKey);
-
-        approvedCount = approvedCount == null ? 0 : approvedCount;
-        disapprovedCount = disapprovedCount == null ? 0 : disapprovedCount;
+        int approvedCount = Optional.ofNullable(redisTemplate.opsForValue().get(approvedCountKey)).map(Long::intValue).orElse(0);
+        int disapprovedCount = Optional.ofNullable(redisTemplate.opsForValue().get(disapprovedCountKey)).map(Long::intValue).orElse(0);
 
         int participantCount = challengeParticipationRepository.countByChallengeIdAndStatus(proofHistory.getProof().getChallenge().getId(), ParticipationStatus.ACCEPTED) - 1;
 

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -46,9 +46,7 @@ public class ProofHistoryVoteService {
         String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());
         String userKey = getRedisKey(USER_KEY, user.getId());
 
-        if (redisTemplate.opsForHash().get(key, userKey) != null) {
-            throw new DuplicatedProofHistoryVoteException();
-        }
+        validateDuplicatedVote(key, userKey);
 
         String approvedCountKey = getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistory.getId());
         String disapprovedCountKey = getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistory.getId());
@@ -117,6 +115,12 @@ public class ProofHistoryVoteService {
     private void validateProofHistoryStatus(ProofHistory proofHistory, ProofHistoryStatus status, String message) {
         if (proofHistory.getStatus().isNot(status)) {
             throw new InvalidProofHistoryStatusException(message);
+        }
+    }
+
+    private void validateDuplicatedVote(String key, String userKey) {
+        if (redisTemplate.opsForHash().get(key, userKey) != null) {
+            throw new DuplicatedProofHistoryVoteException();
         }
     }
 

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
@@ -41,6 +41,7 @@ public class ProofHistory extends BaseEntity {
     private String content;
 
     @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private ProofHistoryStatus status = ProofHistoryStatus.PENDING;
 
     @Column(name = "deleted_at")

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
@@ -1,0 +1,56 @@
+package com.trybe.modulecore.proof.entity;
+
+import com.trybe.modulecore.common.entity.BaseEntity;
+import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+import com.trybe.modulecore.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "proof_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE proof_histories SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class ProofHistory extends BaseEntity {
+    public ProofHistory(Proof proof, User user, String content) {
+        this.proof = proof;
+        this.user = user;
+        this.content = content;
+    }
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "proof_id", nullable = false, updatable = false)
+    private Proof proof;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, updatable = false)
+    private User user;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "status", nullable = false)
+    private ProofHistoryStatus status = ProofHistoryStatus.PENDING;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateStatus(ProofHistoryStatus status) {
+        this.status = status;
+    }
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/enums/ProofHistoryStatus.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/enums/ProofHistoryStatus.java
@@ -1,0 +1,24 @@
+package com.trybe.modulecore.proof.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ProofHistoryStatus {
+    PENDING("대기"),
+    PASSED("성공"),
+    FAILED("실패");
+
+    private final String description;
+
+    ProofHistoryStatus(String description) {
+        this.description = description;
+    }
+
+    public boolean is(ProofHistoryStatus status) {
+        return this == status;
+    }
+
+    public boolean isNot(ProofHistoryStatus status) {
+        return this != status;
+    }
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.trybe.modulecore.proof.repository;
+
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProofHistoryRepository extends JpaRepository<ProofHistory, Long> {
+    Page<ProofHistory> findAllByProofId(Long proofId, Pageable pageable);
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface ProofHistoryRepository extends JpaRepository<ProofHistory, Long> {
     Page<ProofHistory> findAllByProofId(Long proofId, Pageable pageable);
+    List<ProofHistory> findAllByProof_Date(LocalDate date);
 }


### PR DESCRIPTION
- `ProofHistory` 엔티티 구현
- `ProofHistoryRepository`, `ProofHistoryService`, `ProofHistoryController` 구현
  - 인증 기록 생성, 인증 기록 조회, 인증 기록 수정, 인증 기록 삭제
- `ProofHistoryVote`에 대한 서비스, 컨트롤러 작성
  - 인증 기록에 대한 투표 생성, 투표 기록 조회, 투표 결과 조회
- `ProofHistoryController`, `ProofHistoryVoteController`에 대한 HTTP 요청 파일 작성
- 투표 결과에 따라 ProofHistory의 Status를 변경하는 스케줄러 작성