### PR TITLE
[#37] 게시글 좋아요 테스트 코드 

### DIFF
--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -768,3 +768,52 @@ include::{snippets}/post-controller-test/update/invalid/forbidden/http-request.a
 - 응답
 include::{snippets}/post-controller-test/update/invalid/forbidden/http-response.adoc[]
 include::{snippets}/post-controller-test/update/invalid/forbidden/response-fields.adoc[]
+
+---
+
+== 좋아요
+
+=== 게시글 좋아요 추가 API
+게시글에 좋아요 추가
+
+==== 정상 요청
+include::{snippets}/post-like-controller-test/addLike/http-request.adoc[]
+- 응답
+include::{snippets}/post-like-controller-test/addLike/http-response.adoc[]
+include::{snippets}/post-like-controller-test/addLike/response-fields.adoc[]
+
+==== 비정상 요청 (잘못된 요청)
+존재하지 않는 게시글에 좋아요 추가 시 404을 반환합니다.
+
+include::{snippets}/post-like-controller-test/addLike/invalid/not-found/http-request.adoc[]
+
+- 응답
+include::{snippets}/post-like-controller-test/addLike/invalid/not-found/http-response.adoc[]
+include::{snippets}/post-like-controller-test/addLike/invalid/not-found/response-fields.adoc[]
+
+=== 게시글 좋아요 삭제 API
+게시글에 좋아요 삭제
+
+==== 정상 요청
+include::{snippets}/post-like-controller-test/removeLike/http-request.adoc[]
+- 응답
+include::{snippets}/post-like-controller-test/removeLike/http-response.adoc[]
+include::{snippets}/post-like-controller-test/removeLike/response-fields.adoc[]
+
+==== 비정상 요청 (잘못된 요청)
+존재하지 않는 게시글에 좋아요 삭제 시 404을 반환합니다.
+
+include::{snippets}/post-like-controller-test/removeLike/invalid/not-found/http-request.adoc[]
+
+- 응답
+include::{snippets}/post-like-controller-test/removeLike/invalid/not-found/http-response.adoc[]
+include::{snippets}/post-like-controller-test/removeLike/invalid/not-found/response-fields.adoc[]
+
+=== 좋아요 누른 게시글 목록 조회 API
+좋아요 누른 게시글 목록 조회
+
+==== 정상 요청
+include::{snippets}/post-like-controller-test/getLikedPost/http-request.adoc[]
+- 응답
+include::{snippets}/post-like-controller-test/getLikedPost/http-response.adoc[]
+include::{snippets}/post-like-controller-test/getLikedPost/response-fields.adoc[]

--- a/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
@@ -91,9 +91,10 @@ public class PostLikeService {
         List<Post> posts = postRepository.findAllByIdIn(postIds);
         List<Post> sortedPosts = postIds.stream()
                                         .map(postId -> posts.stream()
-                                                                  .filter(post -> post.getId().equals(postId))
+                                                                  .filter(post -> postId.equals(post.getId()))
                                                                   .findFirst()
-                                                                  .orElseThrow(() -> new NotFoundPostException()))
+                                                                  .orElse(null))
+                                        .filter(Objects::nonNull)
                                         .collect(Collectors.toList());
 
 

--- a/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
@@ -36,14 +36,15 @@ public class PostLikeService {
 
         String userKey = createRedisKey(USER_REDIS_PREFIX, user.getId());
         String postKey = createRedisKey(POST_REDIS_PREFIX, postId);
+        int likeCount = count(postId);
 
         if (!alreadyLike(userKey, postId)) {
             double score = getCurrentTimeInSeconds();
             redisTemplate.opsForZSet().add(userKey, postId, score);
             redisTemplate.opsForSet().add(postKey, user.getId());
+            likeCount++;
         }
-
-        return PostResponse.Like.from(count(postId), true);
+        return PostResponse.Like.from(likeCount, true);
     }
 
     @Transactional
@@ -52,13 +53,14 @@ public class PostLikeService {
 
         String userKey = createRedisKey(USER_REDIS_PREFIX, user.getId());
         String postKey = createRedisKey(POST_REDIS_PREFIX, postId);
+        int likeCount = count(postId);
 
         if (alreadyLike(userKey, postId)) {
             redisTemplate.opsForZSet().remove(userKey, postId);
             redisTemplate.opsForSet().remove(postKey, user.getId());
+            likeCount--;
         }
-
-        return PostResponse.Like.from(count(postId),false);
+        return PostResponse.Like.from(likeCount,false);
     }
 
     public void removeLikesByPost(Long postId){

--- a/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostControllerTest.java
@@ -81,6 +81,7 @@ class PostControllerTest extends ControllerTest {
                        jsonPath("$.content").value(게시글_상세_응답.content()),
                        jsonPath("$.category").value(게시글_상세_응답.category().toString()),
                        jsonPath("$.createdAt").value(게시글_상세_응답.createdAt().toString()),
+                       jsonPath("$.likeCount").value(게시글_상세_응답.likeCount()),
                        jsonPath("$.challenges").isArray(),
                        jsonPath("$.challenges[0].id").value(게시글_상세_응답.challenges().get(0).id()),
                        jsonPath("$.challenges[0].title").value(게시글_상세_응답.challenges().get(0).title()),
@@ -105,6 +106,7 @@ class PostControllerTest extends ControllerTest {
                                        fieldWithPath("writer.id").description("작성자 ID"),
                                        fieldWithPath("writer.userId").type(JsonFieldType.STRING).description("작성자 아이디"),
                                        fieldWithPath("writer.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                                       fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
                                        fieldWithPath("createdAt").description("게시글 생성일"), // 날짜 널로 들어감
                                        fieldWithPath("challenges[]").type(JsonFieldType.ARRAY).description("챌린지 요약 내용"),
                                        fieldWithPath("challenges[].id").description("챌린지 ID"), // ID는 널로 들어감
@@ -204,7 +206,8 @@ class PostControllerTest extends ControllerTest {
                        jsonPath("$.title").value(게시글_상세_응답.title()),
                        jsonPath("$.content").value(게시글_상세_응답.content()),
                        jsonPath("$.category").value(게시글_상세_응답.category().toString()),
-                       jsonPath("$.createdAt").exists(), // 이게 왜 존재하지 않지?
+                       jsonPath("$.createdAt").exists(),
+                       jsonPath("$.likeCount").value(게시글_상세_응답.likeCount()),
                        jsonPath("$.challenges").isArray(),
                        jsonPath("$.challenges[0].id").value(게시글_상세_응답.challenges().get(0).id()),
                        jsonPath("$.challenges[0].title").value(게시글_상세_응답.challenges().get(0).title()),
@@ -224,6 +227,7 @@ class PostControllerTest extends ControllerTest {
                                        fieldWithPath("writer.id").description("작성자 ID"),
                                        fieldWithPath("writer.userId").type(JsonFieldType.STRING).description("작성자 아이디"),
                                        fieldWithPath("writer.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                                       fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
                                        fieldWithPath("createdAt").description("게시글 생성일"), // 날짜 널로 들어감
                                        fieldWithPath("challenges[]").type(JsonFieldType.ARRAY).description("챌린지 요약 내용"),
                                        fieldWithPath("challenges[].id").description("챌린지 ID"), // ID는 널로 들어감
@@ -346,6 +350,7 @@ class PostControllerTest extends ControllerTest {
                        jsonPath("$.content").value(게시글_상세_응답.content()),
                        jsonPath("$.category").value(게시글_상세_응답.category().toString()),
                        jsonPath("$.createdAt").value(게시글_상세_응답.createdAt().toString()),
+                       jsonPath("$.likeCount").value(게시글_상세_응답.likeCount()),
                        jsonPath("$.challenges").isArray(),
                        jsonPath("$.challenges[0].id").value(게시글_상세_응답.challenges().get(0).id()),
                        jsonPath("$.challenges[0].title").value(게시글_상세_응답.challenges().get(0).title()),
@@ -371,6 +376,7 @@ class PostControllerTest extends ControllerTest {
                                        fieldWithPath("writer.id").description("작성자 ID"),
                                        fieldWithPath("writer.userId").type(JsonFieldType.STRING).description("작성자 아이디"),
                                        fieldWithPath("writer.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                                       fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
                                        fieldWithPath("createdAt").description("게시글 생성일"),
                                        fieldWithPath("challenges[]").type(JsonFieldType.ARRAY).description("챌린지 요약 내용"),
                                        fieldWithPath("challenges[].id").description("챌린지 ID"),

--- a/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostControllerTest.java
@@ -63,9 +63,9 @@ class PostControllerTest extends ControllerTest {
     private PostService postService;
 
     @Test
-    @DisplayName("정상적인 포스트 생성 요청 시 200을 반환한다.")
+    @DisplayName("정상적인 게시글 생성 요청 시 200을 반환한다.")
     @WithCustomMockUser
-    void 정상적인_포스트_생성_요청_시_200을_반환한다() throws Exception {
+    void 정상적인_게시글_생성_요청_시_200을_반환한다() throws Exception {
         PostRequest.Create 게시글_생성 = PostFixtures.게시글_생성;
         PostResponse.Detail 게시글_상세_응답 = PostFixtures.컨트롤러_테스트_게시글_상세_응답;
         when(postService.save(any(User.class), any(PostRequest.Create.class))).thenReturn(게시글_상세_응답);
@@ -121,9 +121,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("유효성 검증에 실패하는 포스트 생성 요청 시 400을 반환한다.")
+    @DisplayName("유효성 검증에 실패하는 게시글 생성 요청 시 400을 반환한다.")
     @WithCustomMockUser
-    void 유효성_검증에_실패하는_포스트_생성_요청_시_400을_반환한다() throws Exception {
+    void 유효성_검증에_실패하는_게시글_생성_요청_시_400을_반환한다() throws Exception {
         PostRequest.Create 게시글_생성 = PostFixtures.잘못된_게시글_생성;
 
         mockMvc.perform(post("/api/v1/posts")
@@ -149,7 +149,7 @@ class PostControllerTest extends ControllerTest {
                                responseFields(
                                        fieldWithPath("status").description("HTTP 상태 코드"),
                                        fieldWithPath("message").description("유효성 검증 오류 메시지"),
-                                       fieldWithPath("data.category").description("포스트 카테고리 필드에 대한 유효성 오류 메시지"),
+                                       fieldWithPath("data.category").description("게시글 카테고리 필드에 대한 유효성 오류 메시지"),
                                        fieldWithPath("data.title").description("제목 필드에 대한 유효성 오류 메시지"),
                                        fieldWithPath("data.content").description("내용 필드에 대한 유효성 오류 메시지")
                                )
@@ -157,9 +157,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("포스트 생성 시 참여하지 않은 챌린지_ID를 보내면 404을 반환한다.")
+    @DisplayName("게시글 생성 시 참여하지 않은 챌린지_ID를 보내면 404을 반환한다.")
     @WithCustomMockUser
-    void 포스트_생성_시_참여하지_않은_챌린지_ID를_보내면_404을_반환한다() throws Exception {
+    void 게시글_생성_시_참여하지_않은_챌린지_ID를_보내면_404을_반환한다() throws Exception {
         PostRequest.Create 게시글_생성 = PostFixtures.게시글_생성;
         doThrow(new NotFoundChallengeParticipationException("참여하지 않는 챌린지는 언급할 수 없습니다.")).when(postService).save(any(User.class), any(PostRequest.Create.class));
 
@@ -191,9 +191,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("존재하는 포스트 조회 시 200을 반환한다.")
+    @DisplayName("존재하는 게시글 조회 시 200을 반환한다.")
     @WithCustomMockUser
-    void 존재하는_포스트_조회_시_200을_반환한다() throws Exception {
+    void 존재하는_게시글_조회_시_200을_반환한다() throws Exception {
         PostResponse.Detail 게시글_상세_응답 = PostFixtures.컨트롤러_테스트_게시글_상세_응답;
         when(postService.find(any(Long.class))).thenReturn(게시글_상세_응답);
 
@@ -218,7 +218,7 @@ class PostControllerTest extends ControllerTest {
                .andDo(document(docsPath + "findById",
                                preprocessRequest(prettyPrint()),
                                preprocessResponse(prettyPrint()),
-                               pathParameters(parameterWithName("id").description("포스트 ID")),
+                               pathParameters(parameterWithName("id").description("게시글 ID")),
                                responseFields(
                                        fieldWithPath("id").description("게시글 ID"),
                                        fieldWithPath("title").type(JsonFieldType.STRING).description("게시글 내용"),
@@ -242,9 +242,9 @@ class PostControllerTest extends ControllerTest {
 
     }
     @Test
-    @DisplayName("존재하지 않는 포스트 조회 시 404을 반환한다.")
+    @DisplayName("존재하지 않는 게시글 조회 시 404을 반환한다.")
     @WithCustomMockUser
-    void 존재하지_않는_포스트_조회_시_404을_반환한다() throws Exception {
+    void 존재하지_않는_게시글_조회_시_404을_반환한다() throws Exception {
         doThrow(new NotFoundPostException()).when(postService).find(eq(1L));
         mockMvc.perform(get("/api/v1/posts/{id}", 1L)
                                 .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
@@ -257,7 +257,7 @@ class PostControllerTest extends ControllerTest {
                ).andDo(document(docsPath + "findById" + invalidNotFoundPath,
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                pathParameters(parameterWithName("id").description("수정할 포스트 ID")),
+                                pathParameters(parameterWithName("id").description("수정할 게시글 ID")),
                                 responseFields(
                                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 코드"),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -267,15 +267,15 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("포스트 페이징 조회 시 200을 반환한다")
+    @DisplayName("게시글 페이징 조회 시 200을 반환한다")
     @WithCustomMockUser
-    void 포스트_페이징_조회_시_200을_반환한다() throws Exception {
+    void 게시글_페이징_조회_시_200을_반환한다() throws Exception {
         /* given */
         PostRequest.Read request = PostFixtures.게시글_필터링_조회;
-        PageResponse<PostResponse.Summary> 포스트_페이지_응답 = PostFixtures.컨트롤러_포스트_페이지_응답;
+        PageResponse<PostResponse.Summary> 게시글_페이지_응답 = PostFixtures.컨트롤러_게시글_페이지_응답;
 
         when(postService.findAll(request, PageRequest.of(0, 10)))
-                .thenReturn(포스트_페이지_응답);
+                .thenReturn(게시글_페이지_응답);
 
         /* when */
        mockMvc.perform(post("/api/v1/posts/search")
@@ -287,18 +287,18 @@ class PostControllerTest extends ControllerTest {
                                .content(objectMapper.writeValueAsString(request)))
               .andExpectAll(status().isOk(),
                             jsonPath("$.content").isArray(),
-                            jsonPath("$.content[0].id").value(포스트_페이지_응답.content().get(0).id()),
-                            jsonPath("$.content[0].title").value(포스트_페이지_응답.content().get(0).title()),
-                            jsonPath("$.content[0].category").value(포스트_페이지_응답.content().get(0).category().toString()),
-                            jsonPath("$.content[0].createdAt").value(포스트_페이지_응답.content().get(0).createdAt().toString()),
-                            jsonPath("content[0].writer.id").value(포스트_페이지_응답.content().get(0).writer().id()),
-                            jsonPath("content[0].writer.userId").value(포스트_페이지_응답.content().get(0).writer().userId()),
-                            jsonPath("content[0].writer.nickname").value(포스트_페이지_응답.content().get(0).writer().nickname()),
-                            jsonPath("$.totalElements").value(포스트_페이지_응답.totalElements()),
-                            jsonPath("$.totalPages").value(PostFixtures.포스트_페이지_응답.totalPages()),
+                            jsonPath("$.content[0].id").value(게시글_페이지_응답.content().get(0).id()),
+                            jsonPath("$.content[0].title").value(게시글_페이지_응답.content().get(0).title()),
+                            jsonPath("$.content[0].category").value(게시글_페이지_응답.content().get(0).category().toString()),
+                            jsonPath("$.content[0].createdAt").value(게시글_페이지_응답.content().get(0).createdAt().toString()),
+                            jsonPath("content[0].writer.id").value(게시글_페이지_응답.content().get(0).writer().id()),
+                            jsonPath("content[0].writer.userId").value(게시글_페이지_응답.content().get(0).writer().userId()),
+                            jsonPath("content[0].writer.nickname").value(게시글_페이지_응답.content().get(0).writer().nickname()),
+                            jsonPath("$.totalElements").value(게시글_페이지_응답.totalElements()),
+                            jsonPath("$.totalPages").value(PostFixtures.게시글_페이지_응답.totalPages()),
                             jsonPath("$.size").value(10),
                             jsonPath("$.number").value(0),
-                            jsonPath("$.last").value(PostFixtures.포스트_페이지_응답.last()))
+                            jsonPath("$.last").value(PostFixtures.게시글_페이지_응답.last()))
               .andDo(document(docsPath + "search",
                               preprocessRequest(prettyPrint()),
                               preprocessResponse(prettyPrint()),
@@ -308,19 +308,19 @@ class PostControllerTest extends ControllerTest {
                                       parameterWithName("order").description("정렬 기준")
                               ),
                               requestFields(
-                                      fieldWithPath("keyword").description("포스트 검색 키워트"),
-                                      fieldWithPath("categories").description("포스트 카테고리"),
-                                      fieldWithPath("order").description("포스트 정렬 기준")
+                                      fieldWithPath("keyword").description("게시글 검색 키워트"),
+                                      fieldWithPath("categories").description("게시글 카테고리"),
+                                      fieldWithPath("order").description("게시글 정렬 기준")
                               ),
                               responseFields(
-                                      fieldWithPath("content").description("포스트 목록"),
-                                      fieldWithPath("content[].id").description("포스트 ID"),
-                                      fieldWithPath("content[].title").description("포스트 제목"),
-                                      fieldWithPath("content[].category").description("포스트 카테고리"),
-                                      fieldWithPath("content[].createdAt").description("포스트 생성일"),
-                                      fieldWithPath("content[].writer.id").description("포스트 작성자 ID"),
-                                      fieldWithPath("content[].writer.userId").description("포스트 작성자 유저 ID"),
-                                      fieldWithPath("content[].writer.nickname").description("포스트 작성자 닉네임"),
+                                      fieldWithPath("content").description("게시글 목록"),
+                                      fieldWithPath("content[].id").description("게시글 ID"),
+                                      fieldWithPath("content[].title").description("게시글 제목"),
+                                      fieldWithPath("content[].category").description("게시글 카테고리"),
+                                      fieldWithPath("content[].createdAt").description("게시글 생성일"),
+                                      fieldWithPath("content[].writer.id").description("게시글 작성자 ID"),
+                                      fieldWithPath("content[].writer.userId").description("게시글 작성자 유저 ID"),
+                                      fieldWithPath("content[].writer.nickname").description("게시글 작성자 닉네임"),
                                       fieldWithPath("totalPages").description("총 페이지 수"),
                                       fieldWithPath("totalElements").description("총 요소 수"),
                                       fieldWithPath("size").description("페이지 크기"),
@@ -332,9 +332,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("정상적인 포스트 수정 요청 시 200을 반환한다")
+    @DisplayName("정상적인 게시글 수정 요청 시 200을 반환한다")
     @WithCustomMockUser
-    void 정상적인_포스트_수정_요청_시_200을_반환한다() throws Exception {
+    void 정상적인_게시글_수정_요청_시_200을_반환한다() throws Exception {
         PostRequest.Update 게시글_수정 = PostFixtures.게시글_수정;
         PostResponse.Detail 게시글_상세_응답 = PostFixtures.컨트롤러_테스트_게시글_상세_응답;
         when(postService.updatePost(any(User.class), any(Long.class), any(PostRequest.Update.class))).thenReturn(게시글_상세_응답);
@@ -361,7 +361,7 @@ class PostControllerTest extends ControllerTest {
                .andDo(document(docsPath + "update",
                                preprocessRequest(prettyPrint()),
                                preprocessResponse(prettyPrint()),
-                               pathParameters(parameterWithName("id").description("포스트 ID")),
+                               pathParameters(parameterWithName("id").description("게시글 ID")),
                                requestFields(
                                        fieldWithPath("title").type(JsonFieldType.STRING).description("게시글 제목"),
                                        fieldWithPath("content").type(JsonFieldType.STRING).description("게시글 내용"),
@@ -391,9 +391,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("유효성 검증에 실패하는 포스트 수정 요청 시 400을 반환한다")
+    @DisplayName("유효성 검증에 실패하는 게시글 수정 요청 시 400을 반환한다")
     @WithCustomMockUser
-    void 유효성_검증에_실패하는_포스트_수정_요청_시_400을_반환한다() throws Exception {
+    void 유효성_검증에_실패하는_게시글_수정_요청_시_400을_반환한다() throws Exception {
         PostRequest.Update 게시글_수정 = PostFixtures.잘못된_게시글_수정;
         PostResponse.Detail 게시글_상세_응답 = PostFixtures.컨트롤러_테스트_게시글_상세_응답;
         when(postService.updatePost(any(User.class), any(Long.class), any(PostRequest.Update.class))).thenReturn(게시글_상세_응답);
@@ -412,7 +412,7 @@ class PostControllerTest extends ControllerTest {
                ).andDo(document(docsPath + "update" + invalidBadRequestPath,
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                pathParameters(parameterWithName("id").description("포스트 ID")),
+                                pathParameters(parameterWithName("id").description("게시글 ID")),
                                 requestFields(
                                         fieldWithPath("title").description("게시글 제목"),
                                         fieldWithPath("content").description("게시글 내용"),
@@ -422,7 +422,7 @@ class PostControllerTest extends ControllerTest {
                                 responseFields(
                                         fieldWithPath("status").description("HTTP 상태 코드"),
                                         fieldWithPath("message").description("유효성 검증 오류 메시지"),
-                                        fieldWithPath("data.category").description("포스트 카테고리 필드에 대한 유효성 오류 메시지"),
+                                        fieldWithPath("data.category").description("게시글 카테고리 필드에 대한 유효성 오류 메시지"),
                                         fieldWithPath("data.title").description("제목 필드에 대한 유효성 오류 메시지"),
                                         fieldWithPath("data.content").description("내용 필드에 대한 유효성 오류 메시지")
                                 )
@@ -431,9 +431,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("접근권한이 없는 포스트 수정 요청 시 403을 반환한다")
+    @DisplayName("접근권한이 없는 게시글 수정 요청 시 403을 반환한다")
     @WithCustomMockUser
-    void 접근권한이_없는_포스트_수정_요청_시_403을_반환한다() throws Exception {
+    void 접근권한이_없는_게시글_수정_요청_시_403을_반환한다() throws Exception {
         PostRequest.Update 게시글_수정 = PostFixtures.게시글_수정;
 
         doThrow(new ForbiddenPostException()).when(postService).updatePost(any(User.class), eq(1L), any(PostRequest.Update.class));
@@ -449,7 +449,7 @@ class PostControllerTest extends ControllerTest {
                ).andDo(document(docsPath + "update" + invalidForbiddenPath,
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                pathParameters(parameterWithName("id").description("조회할 포스트 ID")),
+                                pathParameters(parameterWithName("id").description("조회할 게시글 ID")),
                                 responseFields(
                                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 코드"),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -460,9 +460,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 포스트 수정 요청 시 404을 반환한다")
+    @DisplayName("존재하지 않는 게시글 수정 요청 시 404을 반환한다")
     @WithCustomMockUser
-    void 존재하지_않는_포스트_수정_요청_시_404을_반환한다() throws Exception {
+    void 존재하지_않는_게시글_수정_요청_시_404을_반환한다() throws Exception {
         PostRequest.Update 게시글_수정 = PostFixtures.게시글_수정;
 
         doThrow(new NotFoundPostException()).when(postService).updatePost(any(User.class), eq(1L), any(PostRequest.Update.class));
@@ -478,7 +478,7 @@ class PostControllerTest extends ControllerTest {
                ).andDo(document(docsPath + "update" + invalidNotFoundPath,
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                pathParameters(parameterWithName("id").description("수정할 포스트 ID")),
+                                pathParameters(parameterWithName("id").description("수정할 게시글 ID")),
                                 responseFields(
                                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 코드"),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -489,9 +489,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("포스트 성공적으로 삭제 시 200을 반환한다")
+    @DisplayName("게시글 성공적으로 삭제 시 200을 반환한다")
     @WithCustomMockUser
-    void 포스트_성공적으로_삭제_시_200을_반환한다() throws Exception {
+    void 게시글_성공적으로_삭제_시_200을_반환한다() throws Exception {
         doNothing().when(postService).delete(any(User.class), eq(1L));
         mockMvc.perform(delete("/api/v1/posts/{id}", 1L)
                                 .header("Authorization", "Bearer "+ AuthenticationFixtures.accessToken))
@@ -499,14 +499,14 @@ class PostControllerTest extends ControllerTest {
                .andDo(document(docsPath + "delete",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                pathParameters(parameterWithName("id").description("조회할 포스트 ID"))
+                                pathParameters(parameterWithName("id").description("조회할 게시글 ID"))
                ));
     }
 
     @Test
-    @DisplayName("접근권한이 없는 포스트 삭제 시 403을 반환한다.")
+    @DisplayName("접근권한이 없는 게시글 삭제 시 403을 반환한다.")
     @WithCustomMockUser
-    void 접근권한이_없는_포스트_삭제_시_403을_반환한다() throws Exception {
+    void 접근권한이_없는_게시글_삭제_시_403을_반환한다() throws Exception {
         doThrow(new ForbiddenPostException()).when(postService).delete(any(User.class), eq(1L));
         mockMvc.perform(delete("/api/v1/posts/{id}", 1L)
                                 .header("Authorization", "Bearer "+ AuthenticationFixtures.accessToken))
@@ -518,7 +518,7 @@ class PostControllerTest extends ControllerTest {
                ).andDo(document(docsPath + "delete" + invalidForbiddenPath,
                                preprocessRequest(prettyPrint()),
                                preprocessResponse(prettyPrint()),
-                               pathParameters(parameterWithName("id").description("조회할 포스트 ID")),
+                               pathParameters(parameterWithName("id").description("조회할 게시글 ID")),
                                responseFields(
                                        fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 코드"),
                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -528,9 +528,9 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 포스트 삭제 시 404을 반환한다")
+    @DisplayName("존재하지 않는 게시글 삭제 시 404을 반환한다")
     @WithCustomMockUser
-    void 존재하지_않는_포스트_삭제_시_404을_반환한다() throws Exception {
+    void 존재하지_않는_게시글_삭제_시_404을_반환한다() throws Exception {
         doThrow(new NotFoundPostException()).when(postService).delete(any(User.class), eq(1L));
         mockMvc.perform(delete("/api/v1/posts/{id}", 1L)
                                 .header("Authorization", "Bearer "+ AuthenticationFixtures.accessToken))
@@ -542,7 +542,7 @@ class PostControllerTest extends ControllerTest {
                ).andDo(document(docsPath + "delete" + invalidNotFoundPath,
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                pathParameters(parameterWithName("id").description("조회할 포스트 ID")),
+                                pathParameters(parameterWithName("id").description("조회할 게시글 ID")),
                                 responseFields(
                                         fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 코드"),
                                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),

--- a/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostLikeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostLikeControllerTest.java
@@ -154,8 +154,8 @@ class PostLikeControllerTest extends ControllerTest {
     @WithCustomMockUser
     void 자신이_좋아요_누른_게시글을_조회하면_200을_반환한다() throws Exception {
         // given
-        PageResponse<PostResponse.Summary> 포스트_페이지_응답 = PostFixtures.컨트롤러_포스트_페이지_응답;
-        when(postLikeService.getLikePostByUser(any(User.class), any(Pageable.class))).thenReturn(PostFixtures.컨트롤러_포스트_페이지_응답);
+        PageResponse<PostResponse.Summary> 게시글_페이지_응답 = PostFixtures.컨트롤러_게시글_페이지_응답;
+        when(postLikeService.getLikePostByUser(any(User.class), any(Pageable.class))).thenReturn(PostFixtures.컨트롤러_게시글_페이지_응답);
 
         // when
         mockMvc.perform(get("/api/v1/posts/likes/my")
@@ -165,18 +165,18 @@ class PostLikeControllerTest extends ControllerTest {
                .andExpect(status().isOk())
                .andExpectAll(status().isOk(),
                               jsonPath("$.content").isArray(),
-                              jsonPath("$.content[0].id").value(포스트_페이지_응답.content().get(0).id()),
-                              jsonPath("$.content[0].title").value(포스트_페이지_응답.content().get(0).title()),
-                              jsonPath("$.content[0].category").value(포스트_페이지_응답.content().get(0).category().toString()),
-                              jsonPath("$.content[0].createdAt").value(포스트_페이지_응답.content().get(0).createdAt().toString()),
-                              jsonPath("content[0].writer.id").value(포스트_페이지_응답.content().get(0).writer().id()),
-                              jsonPath("content[0].writer.userId").value(포스트_페이지_응답.content().get(0).writer().userId()),
-                              jsonPath("content[0].writer.nickname").value(포스트_페이지_응답.content().get(0).writer().nickname()),
-                              jsonPath("$.totalElements").value(포스트_페이지_응답.totalElements()),
-                              jsonPath("$.totalPages").value(PostFixtures.포스트_페이지_응답.totalPages()),
+                              jsonPath("$.content[0].id").value(게시글_페이지_응답.content().get(0).id()),
+                              jsonPath("$.content[0].title").value(게시글_페이지_응답.content().get(0).title()),
+                              jsonPath("$.content[0].category").value(게시글_페이지_응답.content().get(0).category().toString()),
+                              jsonPath("$.content[0].createdAt").value(게시글_페이지_응답.content().get(0).createdAt().toString()),
+                              jsonPath("content[0].writer.id").value(게시글_페이지_응답.content().get(0).writer().id()),
+                              jsonPath("content[0].writer.userId").value(게시글_페이지_응답.content().get(0).writer().userId()),
+                              jsonPath("content[0].writer.nickname").value(게시글_페이지_응답.content().get(0).writer().nickname()),
+                              jsonPath("$.totalElements").value(게시글_페이지_응답.totalElements()),
+                              jsonPath("$.totalPages").value(PostFixtures.게시글_페이지_응답.totalPages()),
                               jsonPath("$.size").value(10),
                               jsonPath("$.number").value(0),
-                              jsonPath("$.last").value(PostFixtures.포스트_페이지_응답.last()))
+                              jsonPath("$.last").value(PostFixtures.게시글_페이지_응답.last()))
                .andDo(document(docsPath + "getLikedPost",
                                preprocessRequest(prettyPrint()),
                                preprocessResponse(prettyPrint()),
@@ -185,14 +185,14 @@ class PostLikeControllerTest extends ControllerTest {
                                        parameterWithName("size").description("페이지 크기")
                                ),
                                responseFields(
-                                       fieldWithPath("content").description("포스트 목록"),
-                                       fieldWithPath("content[].id").description("포스트 ID"),
-                                       fieldWithPath("content[].title").description("포스트 제목"),
-                                       fieldWithPath("content[].category").description("포스트 카테고리"),
-                                       fieldWithPath("content[].createdAt").description("포스트 생성일"),
-                                       fieldWithPath("content[].writer.id").description("포스트 작성자 ID"),
-                                       fieldWithPath("content[].writer.userId").description("포스트 작성자 유저 ID"),
-                                       fieldWithPath("content[].writer.nickname").description("포스트 작성자 닉네임"),
+                                       fieldWithPath("content").description("게시글 목록"),
+                                       fieldWithPath("content[].id").description("게시글 ID"),
+                                       fieldWithPath("content[].title").description("게시글 제목"),
+                                       fieldWithPath("content[].category").description("게시글 카테고리"),
+                                       fieldWithPath("content[].createdAt").description("게시글 생성일"),
+                                       fieldWithPath("content[].writer.id").description("게시글 작성자 ID"),
+                                       fieldWithPath("content[].writer.userId").description("게시글 작성자 유저 ID"),
+                                       fieldWithPath("content[].writer.nickname").description("게시글 작성자 닉네임"),
                                        fieldWithPath("totalPages").description("총 페이지 수"),
                                        fieldWithPath("totalElements").description("총 요소 수"),
                                        fieldWithPath("size").description("페이지 크기"),

--- a/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostLikeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/controller/PostLikeControllerTest.java
@@ -1,0 +1,205 @@
+package com.trybe.moduleapi.post.controller;
+
+import com.trybe.moduleapi.annotation.WithCustomMockUser;
+import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.moduleapi.common.ControllerTest;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.post.dto.PostResponse;
+import com.trybe.moduleapi.post.exception.NotFoundPostException;
+import com.trybe.moduleapi.post.fixtures.PostFixtures;
+import com.trybe.moduleapi.post.fixtures.PostLikeFixtures;
+import com.trybe.moduleapi.post.service.PostLikeService;
+import com.trybe.moduleapi.user.fixtures.AuthenticationFixtures;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(PostLikeController.class)
+class PostLikeControllerTest extends ControllerTest {
+    private final String docsPath = "post-like-controller-test/";
+    private final String invalidNotFoundPath = "/invalid/not-found/";
+
+    @MockitoBean
+    private PostLikeService postLikeService;
+
+    @Test
+    @DisplayName("존재하는 게시글에 좋아요를 누르면 200을 반환한다.")
+    @WithCustomMockUser
+    void 존재하는_게시글에_좋아요를_누르면_200을_반환한다() throws Exception {
+        // given
+        PostResponse.Like 좋아요_추가_응답 = PostLikeFixtures.좋아요_추가_응답;
+
+        when(postLikeService.addLike(any(User.class), any(Long.class)))
+                .thenReturn(좋아요_추가_응답);
+
+        // when
+        mockMvc.perform(post("/api/v1/posts/likes/{postId}", PostFixtures.id)
+                                .header("Authorization", "Bearer " + AuthenticationFixtures.accessToken))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.likeCount").value(좋아요_추가_응답.likeCount()))
+               .andExpect(jsonPath("$.isLiked").value(좋아요_추가_응답.isLiked()))
+               .andDo(document(docsPath + "addLike",
+                               preprocessRequest(prettyPrint()),
+                               preprocessResponse(prettyPrint()),
+                               pathParameters(parameterWithName("postId").description("게시글 ID")),
+                               responseFields(
+                                       fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                                       fieldWithPath("isLiked").type(JsonFieldType.BOOLEAN).description("좋아요 여부")
+                               )
+               ));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글에 좋아요를 누르면 404을 반환한다")
+    @WithCustomMockUser
+    void 존재하지_않는_게시글에_좋아요를_누르면_404을_반환한다() throws Exception {
+        // given
+        doThrow(new NotFoundPostException()).when(postLikeService).addLike(any(User.class), any(Long.class));
+
+        // when
+        mockMvc.perform(post("/api/v1/posts/likes/{postId}", PostFixtures.id)
+                                .header("Authorization", "Bearer " + AuthenticationFixtures.accessToken))
+               .andExpect(status().isNotFound())
+               .andExpectAll(
+                       jsonPath("$.status").value(404),
+                       jsonPath("$.message").exists(),
+                       jsonPath("$.data").doesNotExist()
+               )
+               .andDo(document(docsPath + "addLike" + invalidNotFoundPath,
+                               preprocessRequest(prettyPrint()),
+                               preprocessResponse(prettyPrint()),
+                               pathParameters(parameterWithName("postId").description("게시글 ID")),
+                               responseFields(
+                                       fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                       fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                                       fieldWithPath("data").type(JsonFieldType.OBJECT).description("추가 메시지").optional()
+                               )
+               ));
+    }
+
+    @Test
+    @DisplayName("존재하는 게시글에 좋아요를 삭제하면 200을 반환한다")
+    @WithCustomMockUser
+    void 존재하는_게시글에_좋아요를_삭제하면_200을_반환한다() throws Exception {
+        // given
+        PostResponse.Like 좋아요_삭제_응답 = PostLikeFixtures.좋아요_삭제_응답;
+
+        when(postLikeService.removeLike(any(User.class), any(Long.class))).thenReturn(좋아요_삭제_응답);
+
+        // when
+        mockMvc.perform(delete("/api/v1/posts/likes/{postId}", PostFixtures.id)
+                                .header("Authorization", "Bearer " + AuthenticationFixtures.accessToken))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.likeCount").value(좋아요_삭제_응답.likeCount()))
+               .andExpect(jsonPath("$.isLiked").value(좋아요_삭제_응답.isLiked()))
+               .andDo(document(docsPath + "removeLike",
+                               preprocessRequest(prettyPrint()),
+                               preprocessResponse(prettyPrint()),
+                               pathParameters(parameterWithName("postId").description("게시글 ID")),
+                               responseFields(
+                                       fieldWithPath("likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                                       fieldWithPath("isLiked").type(JsonFieldType.BOOLEAN).description("좋아요 여부")
+                               )
+               ));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글에 좋아요를 삭제하면 404을 반환한다")
+    @WithCustomMockUser
+    void 존재하지_않는_게시글에_좋아요를_삭제하면_404을_반환한다() throws Exception {
+        // given
+        doThrow(new NotFoundPostException()).when(postLikeService).removeLike(any(User.class), any(Long.class));
+
+        // when
+        mockMvc.perform(delete("/api/v1/posts/likes/{postId}", PostFixtures.id)
+                                .header("Authorization", "Bearer " + AuthenticationFixtures.accessToken))
+               .andExpect(status().isNotFound())
+               .andExpectAll(
+                       jsonPath("$.status").value(404),
+                       jsonPath("$.message").exists(),
+                       jsonPath("$.data").doesNotExist()
+               )
+               .andDo(document(docsPath + "removeLike" + invalidNotFoundPath,
+                               preprocessRequest(prettyPrint()),
+                               preprocessResponse(prettyPrint()),
+                               pathParameters(parameterWithName("postId").description("게시글 ID")),
+                               responseFields(
+                                       fieldWithPath("status").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                       fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                                       fieldWithPath("data").type(JsonFieldType.OBJECT).description("추가 메시지").optional()
+                               )
+               ));
+    }
+
+    @Test
+    @DisplayName("자신이 좋아요 누른 게시글을 조회하면 200을 반환한다.")
+    @WithCustomMockUser
+    void 자신이_좋아요_누른_게시글을_조회하면_200을_반환한다() throws Exception {
+        // given
+        PageResponse<PostResponse.Summary> 포스트_페이지_응답 = PostFixtures.컨트롤러_포스트_페이지_응답;
+        when(postLikeService.getLikePostByUser(any(User.class), any(Pageable.class))).thenReturn(PostFixtures.컨트롤러_포스트_페이지_응답);
+
+        // when
+        mockMvc.perform(get("/api/v1/posts/likes/my")
+                                .header("Authorization", "Bearer " + AuthenticationFixtures.accessToken)
+                                .param("page", "0")
+                                .param("size", "10"))
+               .andExpect(status().isOk())
+               .andExpectAll(status().isOk(),
+                              jsonPath("$.content").isArray(),
+                              jsonPath("$.content[0].id").value(포스트_페이지_응답.content().get(0).id()),
+                              jsonPath("$.content[0].title").value(포스트_페이지_응답.content().get(0).title()),
+                              jsonPath("$.content[0].category").value(포스트_페이지_응답.content().get(0).category().toString()),
+                              jsonPath("$.content[0].createdAt").value(포스트_페이지_응답.content().get(0).createdAt().toString()),
+                              jsonPath("content[0].writer.id").value(포스트_페이지_응답.content().get(0).writer().id()),
+                              jsonPath("content[0].writer.userId").value(포스트_페이지_응답.content().get(0).writer().userId()),
+                              jsonPath("content[0].writer.nickname").value(포스트_페이지_응답.content().get(0).writer().nickname()),
+                              jsonPath("$.totalElements").value(포스트_페이지_응답.totalElements()),
+                              jsonPath("$.totalPages").value(PostFixtures.포스트_페이지_응답.totalPages()),
+                              jsonPath("$.size").value(10),
+                              jsonPath("$.number").value(0),
+                              jsonPath("$.last").value(PostFixtures.포스트_페이지_응답.last()))
+               .andDo(document(docsPath + "getLikedPost",
+                               preprocessRequest(prettyPrint()),
+                               preprocessResponse(prettyPrint()),
+                               queryParameters(
+                                       parameterWithName("page").description("페이지 번호"),
+                                       parameterWithName("size").description("페이지 크기")
+                               ),
+                               responseFields(
+                                       fieldWithPath("content").description("포스트 목록"),
+                                       fieldWithPath("content[].id").description("포스트 ID"),
+                                       fieldWithPath("content[].title").description("포스트 제목"),
+                                       fieldWithPath("content[].category").description("포스트 카테고리"),
+                                       fieldWithPath("content[].createdAt").description("포스트 생성일"),
+                                       fieldWithPath("content[].writer.id").description("포스트 작성자 ID"),
+                                       fieldWithPath("content[].writer.userId").description("포스트 작성자 유저 ID"),
+                                       fieldWithPath("content[].writer.nickname").description("포스트 작성자 닉네임"),
+                                       fieldWithPath("totalPages").description("총 페이지 수"),
+                                       fieldWithPath("totalElements").description("총 요소 수"),
+                                       fieldWithPath("size").description("페이지 크기"),
+                                       fieldWithPath("number").description("현재 페이지 번호"),
+                                       fieldWithPath("last").description("마지막 페이지 여부")
+                               )
+               ));
+    }
+}
+

--- a/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostChallengeFixtures.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class PostChallengeFixtures {
 
-    public static PostChallenge 포스트_챌린지 = new PostChallenge(PostFixtures.게시글, ChallengeFixtures.챌린지());
-    public static List<PostChallenge> 포스트_챌린지_목록 = List.of(포스트_챌린지);
+    public static PostChallenge 게시글_챌린지 = new PostChallenge(PostFixtures.게시글, ChallengeFixtures.챌린지());
+    public static List<PostChallenge> 게시글_챌린지_목록 = List.of(게시글_챌린지);
 
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostFixtures.java
@@ -18,10 +18,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.parameters.P;
 
+import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PostFixtures {
     public static final Long id = 1L;
@@ -29,6 +31,7 @@ public class PostFixtures {
     public static final String 내용 = "테스트 게시글 내용입니다.";
     public static final PostCategory 카테고리 = PostCategory.PROMOTION;
     public static final Set<Long> 챌린지_Ids = Set.of(1L, 2L, 3L);
+    public static final Set<Long> 게시글_아이디_목록 = Set.of(1L, 2L, 3L, 4L, 5L);
     public static final LocalDateTime 작성일 = LocalDateTime.of(2025,01,01,20,10,58);
 
     public static final String 수정_제목 = "테스트 게시글 수정 제목입니다.";
@@ -62,17 +65,17 @@ public class PostFixtures {
     public static final PostRequest.Update 게시글_수정 = new PostRequest.Update(수정_제목, 수정_내용, 수정_카테고리, 수정_챌린지_Ids);
     public static final PostRequest.Update 잘못된_게시글_수정 = new PostRequest.Update("", "", null, null);
     public static final PostRequest.Read 게시글_필터링_조회 = new PostRequest.Read(검색_키워드, 게시글_카테고리,정렬);
-    public static final PostResponse.Detail 게시글_상세_응답 = PostResponse.Detail.from(게시글, ChallengeFixtures.챌린지_목록);
-    public static final PostResponse.Detail 컨트롤러_테스트_게시글_상세_응답 = new PostResponse.Detail(id, 제목, 내용, 카테고리, UserFixtures.요약_회원_응답, 작성일, ChallengeFixtures.챌린지_목록_응답);
+    public static final PostResponse.Detail 게시글_상세_응답 = PostResponse.Detail.from(게시글, ChallengeFixtures.챌린지_목록, 1);
+    public static final PostResponse.Detail 컨트롤러_테스트_게시글_상세_응답 = new PostResponse.Detail(id, 제목, 내용, 카테고리, UserFixtures.요약_회원_응답, 작성일,1, ChallengeFixtures.챌린지_목록_응답);
     public static final PostResponse.Summary 게시글_요약_응답 = new PostResponse.Summary(id, 제목, 카테고리, UserFixtures.요약_회원_응답, 작성일);
 
     public static Pageable 페이지_요청 = PageRequest.of(0, 10);
-    public static List<Post> 포스트_목록 = List.of(게시글,게시글,게시글,게시글,게시글,게시글,게시글);
-    public static Page<Post> 페이지_응답 = new PageImpl<>(포스트_목록, 페이지_요청, 포스트_목록.size());
+    public static List<Post> 게시글_목록 = List.of(게시글,게시글,게시글,게시글,게시글,게시글,게시글);
+    public static Page<Post> 페이지_응답 = new PageImpl<>(게시글_목록, 페이지_요청, 게시글_목록.size());
     public static final PageResponse<PostResponse.Summary> 포스트_페이지_응답 = new PageResponse<>(페이지_응답.map(PostResponse.Summary::from));
 
     public static List<Post> 컨트롤러_포스트_목록 = List.of(게시글);
-    public static Page<Post> 컨트롤러_페이지_응답 = new PageImpl<>(컨트롤러_포스트_목록, 페이지_요청, 포스트_목록.size());
+    public static Page<Post> 컨트롤러_페이지_응답 = new PageImpl<>(컨트롤러_포스트_목록, 페이지_요청, 게시글_목록.size());
     public static final PageResponse<PostResponse.Summary> 컨트롤러_포스트_페이지_응답 = new PageResponse<>(
             컨트롤러_페이지_응답.map(post -> new PostResponse.Summary(
                     post.getId(),
@@ -83,5 +86,26 @@ public class PostFixtures {
             ))
     );
 
+    public static final List<Post> ID_존재하는_게시글_목록 = List.of(1L, 2L, 3L, 4L, 5L).stream()
+                                       .map(id -> {
+                                           Post post = Post.builder()
+                                                           .user(UserFixtures.회원)
+                                                           .title(제목)
+                                                           .content(내용)
+                                                           .category(카테고리)
+                                                           .build();  // 기본 생성자 사용
+                                           setIdUsingReflection(post, id);  // 리플렉션을 이용하여 id 값을 설정
+                                           return post;
+                                       })
+                                       .collect(Collectors.toList());
 
+    private static void setIdUsingReflection(Post post, Long id) {
+        try {
+            Field idField = Post.class.getDeclaredField("id");  // id 필드를 리플렉션으로 가져오기
+            idField.setAccessible(true);  // private 필드에 접근 가능하게 설정
+            idField.set(post, id);  // 해당 post 객체에 id 값을 설정
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostFixtures.java
@@ -72,11 +72,11 @@ public class PostFixtures {
     public static Pageable 페이지_요청 = PageRequest.of(0, 10);
     public static List<Post> 게시글_목록 = List.of(게시글,게시글,게시글,게시글,게시글,게시글,게시글);
     public static Page<Post> 페이지_응답 = new PageImpl<>(게시글_목록, 페이지_요청, 게시글_목록.size());
-    public static final PageResponse<PostResponse.Summary> 포스트_페이지_응답 = new PageResponse<>(페이지_응답.map(PostResponse.Summary::from));
+    public static final PageResponse<PostResponse.Summary> 게시글_페이지_응답 = new PageResponse<>(페이지_응답.map(PostResponse.Summary::from));
 
-    public static List<Post> 컨트롤러_포스트_목록 = List.of(게시글);
-    public static Page<Post> 컨트롤러_페이지_응답 = new PageImpl<>(컨트롤러_포스트_목록, 페이지_요청, 게시글_목록.size());
-    public static final PageResponse<PostResponse.Summary> 컨트롤러_포스트_페이지_응답 = new PageResponse<>(
+    public static List<Post> 컨트롤러_게시글_목록 = List.of(게시글);
+    public static Page<Post> 컨트롤러_페이지_응답 = new PageImpl<>(컨트롤러_게시글_목록, 페이지_요청, 게시글_목록.size());
+    public static final PageResponse<PostResponse.Summary> 컨트롤러_게시글_페이지_응답 = new PageResponse<>(
             컨트롤러_페이지_응답.map(post -> new PostResponse.Summary(
                     post.getId(),
                     post.getTitle(),

--- a/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
@@ -7,7 +7,8 @@ import java.util.Set;
 public class PostLikeFixtures {
     public static final Set<Long> 게시글_좋아요_누른_유저목록 = Set.of(1L, 2L, 3L);
 
-    public static PostResponse.Like 좋아요_추가_응답 = PostResponse.Like.from(5, true);
-    public static PostResponse.Like 좋아요_삭제_응답 = PostResponse.Like.from(4, false);
-    public static int 좋아요_개수 = 10;
+    public static final PostResponse.Like 좋아요_추가_응답 = PostResponse.Like.from(5, true);
+    public static final PostResponse.Like 좋아요_삭제_응답 = PostResponse.Like.from(4, false);
+    public static final int 좋아요_개수 = 10;
+    public static final Long 좋아요_개수L = 20L;
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
@@ -9,4 +9,5 @@ public class PostLikeFixtures {
 
     public static PostResponse.Like 좋아요_추가_응답 = PostResponse.Like.from(5, true);
     public static PostResponse.Like 좋아요_삭제_응답 = PostResponse.Like.from(4, false);
+    public static int 좋아요_개수 = 10;
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
@@ -1,0 +1,12 @@
+package com.trybe.moduleapi.post.fixtures;
+
+import com.trybe.moduleapi.post.dto.PostResponse;
+
+import java.util.Set;
+
+public class PostLikeFixtures {
+    public static final Set<Long> 게시글_좋아요_누른_유저목록 = Set.of(1L, 2L, 3L);
+
+    public static PostResponse.Like 좋아요_추가_응답 = PostResponse.Like.from(5, true);
+    public static PostResponse.Like 좋아요_삭제_응답 = PostResponse.Like.from(4, false);
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
@@ -61,7 +61,7 @@ class PostLikeServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 게시글에 좋아요를 누르면 예외를 환한다")
+    @DisplayName("존재하지 않는 게시글에 좋아요를 누르면 예외를 반환한다.")
     void 존재하지_않는_게시글에_좋아요를_누르면_예외를_반환한다() {
         // given
         User 회원 = UserFixtures.회원;
@@ -95,7 +95,7 @@ class PostLikeServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 게시글에 좋아요를 삭제하면 예외를 환한다")
+    @DisplayName("존재하지 않는 게시글에 좋아요를 삭제하면 예외를 반환한다")
     void 존재하지_않는_게시글에_좋아요를_삭제하면_예외를_반환한다() {
         // given
         User 회원 = UserFixtures.회원;

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.*;
 class PostLikeServiceTest {
     @Mock
     private RedisTemplate<String, Long> redisTemplate;
-
     @Mock
     private PostRepository postRepository;
 
@@ -50,13 +49,18 @@ class PostLikeServiceTest {
         User 회원 = UserFixtures.회원;
         String userKey = "user:" + 회원.getId();
 
-        when(postRepository.existsById(PostFixtures.id)).thenReturn(true);
-        when(redisTemplate.opsForZSet().score(userKey, PostFixtures.id)).thenReturn(null);
+        Long 포스트_ID = PostFixtures.id;
+        String postKey = "post:" + 포스트_ID;
+
+        when(postRepository.existsById(포스트_ID)).thenReturn(true);
+        when(redisTemplate.opsForZSet().score(userKey, 포스트_ID)).thenReturn(null);
+        when(redisTemplate.opsForSet().size(postKey)).thenReturn(5L);
 
         // when
         PostResponse.Like 응답 = postLikeService.addLike(회원, PostFixtures.id);
 
         // then
+        assertEquals(응답.likeCount(), 6);
         assertEquals(응답.isLiked(), true);
     }
 
@@ -80,10 +84,14 @@ class PostLikeServiceTest {
 
         User 회원 = UserFixtures.회원;
         String userKey = "user:" + 회원.getId();
-        String postKey = "post:" + PostFixtures.id;
 
-        when(postRepository.existsById(PostFixtures.id)).thenReturn(true);
-        when(redisTemplate.opsForZSet().score(userKey, PostFixtures.id)).thenReturn(1.000);
+        Long 포스트_ID = PostFixtures.id;
+        String postKey = "post:" + 포스트_ID;
+
+        when(postRepository.existsById(포스트_ID)).thenReturn(true);
+        when(redisTemplate.opsForZSet().score(userKey, 포스트_ID)).thenReturn(1.000);
+        when(redisTemplate.opsForSet().size(postKey)).thenReturn(5L);
+
 
         // when
         PostResponse.Like 응답 = postLikeService.removeLike(회원, PostFixtures.id);
@@ -91,6 +99,7 @@ class PostLikeServiceTest {
         // then
         verify(redisTemplate.opsForZSet()).remove(eq(userKey), eq(PostFixtures.id));
         verify(redisTemplate.opsForSet()).remove(eq(postKey), eq(회원.getId()));
+        assertEquals(응답.likeCount(), 4);
         assertEquals(응답.isLiked(), false);
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
@@ -51,16 +51,17 @@ class PostLikeServiceTest {
 
         Long 포스트_ID = PostFixtures.id;
         String postKey = "post:" + 포스트_ID;
+        Long 좋아요_개수 = PostLikeFixtures.좋아요_개수L;
 
         when(postRepository.existsById(포스트_ID)).thenReturn(true);
         when(redisTemplate.opsForZSet().score(userKey, 포스트_ID)).thenReturn(null);
-        when(redisTemplate.opsForSet().size(postKey)).thenReturn(5L);
+        when(redisTemplate.opsForSet().size(postKey)).thenReturn(좋아요_개수);
 
         // when
         PostResponse.Like 응답 = postLikeService.addLike(회원, PostFixtures.id);
 
         // then
-        assertEquals(응답.likeCount(), 6);
+        assertEquals(응답.likeCount(), 좋아요_개수+1);
         assertEquals(응답.isLiked(), true);
     }
 
@@ -88,9 +89,11 @@ class PostLikeServiceTest {
         Long 포스트_ID = PostFixtures.id;
         String postKey = "post:" + 포스트_ID;
 
+        Long 좋아요_개수 = PostLikeFixtures.좋아요_개수L;
+
         when(postRepository.existsById(포스트_ID)).thenReturn(true);
         when(redisTemplate.opsForZSet().score(userKey, 포스트_ID)).thenReturn(1.000);
-        when(redisTemplate.opsForSet().size(postKey)).thenReturn(5L);
+        when(redisTemplate.opsForSet().size(postKey)).thenReturn(좋아요_개수);
 
 
         // when
@@ -99,7 +102,7 @@ class PostLikeServiceTest {
         // then
         verify(redisTemplate.opsForZSet()).remove(eq(userKey), eq(PostFixtures.id));
         verify(redisTemplate.opsForSet()).remove(eq(postKey), eq(회원.getId()));
-        assertEquals(응답.likeCount(), 4);
+        assertEquals(응답.likeCount(), 좋아요_개수-1);
         assertEquals(응답.isLiked(), false);
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
@@ -1,0 +1,180 @@
+package com.trybe.moduleapi.post.service;
+
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.post.dto.PostResponse;
+import com.trybe.moduleapi.post.exception.NotFoundPostException;
+import com.trybe.moduleapi.post.fixtures.PostFixtures;
+import com.trybe.moduleapi.post.fixtures.PostLikeFixtures;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.post.entity.Post;
+import com.trybe.modulecore.post.repository.PostRepository;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikeServiceTest {
+    @Mock
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostLikeService postLikeService;
+
+    @Test
+    @DisplayName("게시글에 좋아요를 누르면 Redis에 저장된다")
+    void 게시글에_좋아요를_누르면_Redis에_저장된다() {
+        // given
+        mockingRedisTemplate();
+
+        User 회원 = UserFixtures.회원;
+        String userKey = "user:" + 회원.getId();
+
+        when(postRepository.existsById(PostFixtures.id)).thenReturn(true);
+        when(redisTemplate.opsForZSet().score(userKey, PostFixtures.id)).thenReturn(null);
+
+        // when
+        PostResponse.Like 응답 = postLikeService.addLike(회원, PostFixtures.id);
+
+        // then
+        assertEquals(응답.isLiked(), true);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글에 좋아요를 누르면 예외를 환한다")
+    void 존재하지_않는_게시글에_좋아요를_누르면_예외를_반환한다() {
+        // given
+        User 회원 = UserFixtures.회원;
+        when(postRepository.existsById(PostFixtures.id)).thenReturn(false);
+
+        // when
+        // then
+        assertThrows(NotFoundPostException.class, () -> postLikeService.addLike(회원,PostFixtures.id));
+    }
+
+    @Test
+    @DisplayName("게시글에 대한 좋아요를 삭제하면 Redis에서 삭제된다.")
+    void 게시글에_대한_좋아요를_삭제하면_Redis에서_삭제된다() {
+        // given
+        mockingRedisTemplate();
+
+        User 회원 = UserFixtures.회원;
+        String userKey = "user:" + 회원.getId();
+        String postKey = "post:" + PostFixtures.id;
+
+        when(postRepository.existsById(PostFixtures.id)).thenReturn(true);
+        when(redisTemplate.opsForZSet().score(userKey, PostFixtures.id)).thenReturn(1.000);
+
+        // when
+        PostResponse.Like 응답 = postLikeService.removeLike(회원, PostFixtures.id);
+
+        // then
+        verify(redisTemplate.opsForZSet()).remove(eq(userKey), eq(PostFixtures.id));
+        verify(redisTemplate.opsForSet()).remove(eq(postKey), eq(회원.getId()));
+        assertEquals(응답.isLiked(), false);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글에 좋아요를 삭제하면 예외를 환한다")
+    void 존재하지_않는_게시글에_좋아요를_삭제하면_예외를_반환한다() {
+        // given
+        User 회원 = UserFixtures.회원;
+        when(postRepository.existsById(PostFixtures.id)).thenReturn(false);
+
+        // when
+        // then
+        assertThrows(NotFoundPostException.class, () -> postLikeService.removeLike(회원,PostFixtures.id));
+    }
+
+
+    @Test
+    @DisplayName("게시글이 삭제되면 해당 게시글에 대한 모든 좋아요는 삭제된다.")
+    void 게시글이_삭제되면_해당_게시글에_대한_모든_좋아요는_삭제된다() {
+        // given
+        mockingRedisTemplate();
+
+        String postKey = "post:" + PostFixtures.id;
+        Set<Long> userIds = PostLikeFixtures.게시글_좋아요_누른_유저목록;
+        when(redisTemplate.opsForSet().members(postKey)).thenReturn(userIds);
+
+        // When
+        postLikeService.removeLikesByPost(PostFixtures.id);
+
+        // Then
+        for (Long userId : userIds) {
+            verify(redisTemplate.opsForZSet(), times(1)).remove(eq("user:" + userId), eq(PostFixtures.id));
+        }
+        verify(redisTemplate, times(1)).delete(postKey);
+    }
+
+    @Test
+    @DisplayName("특정 게시글의 좋아요 수를 조회하면 좋아요 개수가 반환된다.")
+    void 특정_게시글의_좋아요_수를_조회하면_좋아요_개수가_반환된다() {
+        // given
+        SetOperations<String, Long> setOps = mock(SetOperations.class);
+        when(redisTemplate.opsForSet()).thenReturn(setOps);
+
+        String postKey = "post:" + PostFixtures.id;
+        when(redisTemplate.opsForSet().size(postKey)).thenReturn(5L);
+
+        // when
+        int likeCount = postLikeService.count(PostFixtures.id);
+
+        // then
+        assertEquals(likeCount, 5);
+    }
+
+    @Test
+    @DisplayName("회원이 자신이 좋아요 누른 게시글을 조회하면 좋아요 누른 순으로 반환된다.")
+    void 회원이_자신이_좋아요_누른_게시글을_조회하면_좋아요_누른_순으로_반환된다() {
+        // given
+        ZSetOperations<String, Long> zSetOps = mock(ZSetOperations.class);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        User 회원 = UserFixtures.회원;
+        String userKey = "user:" + 회원.getId();
+        Set<Long> postIds = PostFixtures.게시글_아이디_목록;
+        List<Post> 게시글_목록 = PostFixtures.ID_존재하는_게시글_목록;
+
+        when(redisTemplate.opsForZSet().reverseRange(userKey, 0, -1)).thenReturn(postIds);
+        when(postRepository.findAllByIdIn(postIds)).thenReturn(게시글_목록);
+
+        // When
+        PageResponse<PostResponse.Summary> 응답 = postLikeService.getLikePostByUser(회원, pageable);
+
+        // Then
+        assertEquals(응답.content().size(), 게시글_목록.size());
+    }
+
+    private void mockingRedisTemplate(){
+        ZSetOperations<String, Long> zSetOps = mock(ZSetOperations.class);
+        SetOperations<String, Long> setOps = mock(SetOperations.class);
+
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+        when(redisTemplate.opsForSet()).thenReturn(setOps);
+    }
+
+
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
@@ -44,6 +44,8 @@ class PostServiceTest {
     private PostChallengeRepository postChallengeRepository;
     @Mock
     private ChallengeParticipationRepository participationRepository;
+    @Mock
+    private PostLikeService postLikeService;
 
     @InjectMocks
     private PostService postService;
@@ -97,6 +99,7 @@ class PostServiceTest {
         Post 게시글 = PostFixtures.게시글;
         when(postRepository.findById(any())).thenReturn(Optional.of(PostFixtures.게시글));
         when(postChallengeRepository.findAllByPostId(any())).thenReturn(PostChallengeFixtures.포스트_챌린지_목록);
+        when(postLikeService.count(any())).thenReturn(1);
 
         /* when */
         PostResponse.Detail postDetail = postService.find(1L);
@@ -106,6 +109,7 @@ class PostServiceTest {
         assertEquals(postDetail.content(), 게시글.getContent());
         assertEquals(postDetail.writer().userId(), 게시글.getUser().getUserId());
         assertEquals(postDetail.writer().nickname(), 게시글.getUser().getNickname());
+        assertEquals(postDetail.likeCount(), 1);
         assertEquals(postDetail.challenges().size(), 1);
     }
 
@@ -214,6 +218,7 @@ class PostServiceTest {
         /* then */
         verify(postRepository, times(1)).deleteById(any());
         verify(postChallengeRepository, times(1)).deleteAllByPostId(any());
+        verify(postLikeService, times(1)).removeLikesByPost(any());
 
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
@@ -9,6 +9,7 @@ import com.trybe.moduleapi.post.exception.ForbiddenPostException;
 import com.trybe.moduleapi.post.exception.NotFoundPostException;
 import com.trybe.moduleapi.post.fixtures.PostChallengeFixtures;
 import com.trybe.moduleapi.post.fixtures.PostFixtures;
+import com.trybe.moduleapi.post.fixtures.PostLikeFixtures;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
@@ -71,6 +72,7 @@ class PostServiceTest {
         assertEquals(postDetail.content(), PostFixtures.내용);
         assertEquals(postDetail.writer().userId(), UserFixtures.회원_아이디);
         assertEquals(postDetail.writer().nickname(), UserFixtures.회원_닉네임);
+        assertEquals(postDetail.likeCount(), 0);
         assertEquals(postDetail.challenges().size(), 3);
     }
 
@@ -97,9 +99,11 @@ class PostServiceTest {
     void 게시글_단건_조회_시_게시글를_응답해준다() {
         /* given */
         Post 게시글 = PostFixtures.게시글;
-        when(postRepository.findById(any())).thenReturn(Optional.of(PostFixtures.게시글));
+        int 좋아요_개수 = PostLikeFixtures.좋아요_개수;
+
+        when(postRepository.findById(any())).thenReturn(Optional.of(게시글));
         when(postChallengeRepository.findAllByPostId(any())).thenReturn(PostChallengeFixtures.게시글_챌린지_목록);
-        when(postLikeService.count(any())).thenReturn(1);
+        when(postLikeService.count(any())).thenReturn(좋아요_개수);
 
         /* when */
         PostResponse.Detail postDetail = postService.find(1L);
@@ -109,7 +113,7 @@ class PostServiceTest {
         assertEquals(postDetail.content(), 게시글.getContent());
         assertEquals(postDetail.writer().userId(), 게시글.getUser().getUserId());
         assertEquals(postDetail.writer().nickname(), 게시글.getUser().getNickname());
-        assertEquals(postDetail.likeCount(), 1);
+        assertEquals(postDetail.likeCount(), 좋아요_개수);
         assertEquals(postDetail.challenges().size(), 1);
     }
 
@@ -150,9 +154,11 @@ class PostServiceTest {
     void 게시글_수정_시_수정된_게시글를_응답해준다() {
         /* given */
         PostRequest.Update 게시글_수정_요청 = PostFixtures.게시글_수정;
+        int 좋아요_개수 = PostLikeFixtures.좋아요_개수;
 
         when(postRepository.findById(any())).thenReturn(Optional.of(PostFixtures.게시글));
         when(challengeRepository.findAllByIdIn(PostFixtures.수정_챌린지_Ids)).thenReturn(List.of(ChallengeFixtures.챌린지(),ChallengeFixtures.챌린지()));
+        when(postLikeService.count(any())).thenReturn(좋아요_개수);
 
 
         /* when */
@@ -163,6 +169,7 @@ class PostServiceTest {
         assertEquals(postDetail.content(), PostFixtures.수정_내용);
         assertEquals(postDetail.writer().userId(), UserFixtures.회원_아이디);
         assertEquals(postDetail.writer().nickname(), UserFixtures.회원_닉네임);
+        assertEquals(postDetail.likeCount(), 좋아요_개수);
         assertEquals(postDetail.challenges().size(), 2);
     }
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
@@ -51,8 +51,8 @@ class PostServiceTest {
     private PostService postService;
     
     @Test
-    @DisplayName("포스트 생성 시 생성된 포스트를 응답해준다.")
-    void 포스트_생성_시_생성된_포스트를_응답해준다() {
+    @DisplayName("게시글 생성 시 생성된 게시글를 응답해준다.")
+    void 게시글_생성_시_생성된_게시글를_응답해준다() {
         /* given */
         PostRequest.Create 게시글_생성_요청 = PostFixtures.게시글_생성;
         User 회원 = UserFixtures.회원;
@@ -75,8 +75,8 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("포스트 생성 시 참여하지 않은 챌린지 ID를 보내면 예외를 터뜨린다.")
-    void 포스트_생성_시_참여하지_않은_챌린지_ID를_보내면_예외를_터뜨린다() {
+    @DisplayName("게시글 생성 시 참여하지 않은 챌린지 ID를 보내면 예외를 터뜨린다.")
+    void 게시글_생성_시_참여하지_않은_챌린지_ID를_보내면_예외를_터뜨린다() {
         /* given */
         PostRequest.Create 게시글_생성_요청 = PostFixtures.게시글_생성;
         User 회원 = UserFixtures.회원;
@@ -93,12 +93,12 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("포스트 단건 조회 시 포스트를 응답해준다.")
-    void 포스트_단건_조회_시_포스트를_응답해준다() {
+    @DisplayName("게시글 단건 조회 시 게시글를 응답해준다.")
+    void 게시글_단건_조회_시_게시글를_응답해준다() {
         /* given */
         Post 게시글 = PostFixtures.게시글;
         when(postRepository.findById(any())).thenReturn(Optional.of(PostFixtures.게시글));
-        when(postChallengeRepository.findAllByPostId(any())).thenReturn(PostChallengeFixtures.포스트_챌린지_목록);
+        when(postChallengeRepository.findAllByPostId(any())).thenReturn(PostChallengeFixtures.게시글_챌린지_목록);
         when(postLikeService.count(any())).thenReturn(1);
 
         /* when */
@@ -114,20 +114,20 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 포스트 단건 조회 시 예외를 터뜨린다.")
-    void 존재하지_않는_포스트_단건_조회_시_예외를_터뜨린다() {
+    @DisplayName("존재하지 않는 게시글 단건 조회 시 예외를 터뜨린다.")
+    void 존재하지_않는_게시글_단건_조회_시_예외를_터뜨린다() {
         /* given */
         when(postRepository.findById(any())).thenReturn(Optional.empty());
 
         /* when, then */
         assertThrows(NotFoundPostException.class, () -> {
             postService.find(1L);
-        }, "존재하지 않는 포스트입니다.");
+        }, "존재하지 않는 게시글입니다.");
     }
 
     @Test
-    @DisplayName("포스트 필터링 조회 시 페이징으로 응답해준다")
-    void 포스트_필터링_조회_시_페이징으로_응답해준다 () {
+    @DisplayName("게시글 필터링 조회 시 페이징으로 응답해준다")
+    void 게시글_필터링_조회_시_페이징으로_응답해준다 () {
         /* given */
         PostRequest.Read 게시글_필터링_조회 = PostFixtures.게시글_필터링_조회;
         Pageable 페이지_요청 = PostFixtures.페이지_요청;
@@ -142,12 +142,12 @@ class PostServiceTest {
 
         /* then */
         assertEquals(response.size(), 페이지_요청.getPageSize());
-        assertEquals(response.totalElements(), PostFixtures.포스트_페이지_응답.totalElements());
+        assertEquals(response.totalElements(), PostFixtures.게시글_페이지_응답.totalElements());
     }
 
     @Test
-    @DisplayName("포스트 수정 시 수정된 포스트를 응답해준다")
-    void 포스트_수정_시_수정된_포스트를_응답해준다() {
+    @DisplayName("게시글 수정 시 수정된 게시글를 응답해준다")
+    void 게시글_수정_시_수정된_게시글를_응답해준다() {
         /* given */
         PostRequest.Update 게시글_수정_요청 = PostFixtures.게시글_수정;
 
@@ -166,8 +166,8 @@ class PostServiceTest {
         assertEquals(postDetail.challenges().size(), 2);
     }
     @Test
-    @DisplayName("존재하지 않는 포스트 수정 시 예외를 터뜨린다.")
-    void 존재하지_않는_포스트_수정_시_예외를_터뜨린다() {
+    @DisplayName("존재하지 않는 게시글 수정 시 예외를 터뜨린다.")
+    void 존재하지_않는_게시글_수정_시_예외를_터뜨린다() {
         /* given */
         PostRequest.Update 게시글_수정_요청 = PostFixtures.게시글_수정;
 
@@ -176,12 +176,12 @@ class PostServiceTest {
         /* when, then */
         assertThrows(NotFoundPostException.class, () -> {
             postService.updatePost(UserFixtures.회원,1L, 게시글_수정_요청);
-        }, "존재하지 않는 포스트입니다.");
+        }, "존재하지 않는 게시글입니다.");
     }
 
     @Test
-    @DisplayName("접근권한 없는 포스트 수정 시 예외를 터뜨린다.")
-    void 접근권한_없는_포스트_수정_시_예외를_터뜨린다() {
+    @DisplayName("접근권한 없는 게시글 수정 시 예외를 터뜨린다.")
+    void 접근권한_없는_게시글_수정_시_예외를_터뜨린다() {
         /* given */
         PostRequest.Update 게시글_수정_요청 = PostFixtures.게시글_수정;
 
@@ -202,8 +202,8 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("포스트 삭제 시 포스트를 삭제한다.")
-    void 포스트_삭제_시_포스트를_삭제한다() {
+    @DisplayName("게시글 삭제 시 게시글를 삭제한다.")
+    void 게시글_삭제_시_게시글를_삭제한다() {
         /* given */
         User user = UserFixtures.회원;
         Post post = PostFixtures.게시글;
@@ -223,8 +223,8 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 포스트 삭제 시 예외를 터뜨린다.")
-    void 존재하지_않는_포스트_삭제_시_예외를_터뜨린다() {
+    @DisplayName("존재하지 않는 게시글 삭제 시 예외를 터뜨린다.")
+    void 존재하지_않는_게시글_삭제_시_예외를_터뜨린다() {
         /* given */
         User newUser = UserFixtures.회원_생성("gunny", "gunny@gunny.com");
 
@@ -233,12 +233,12 @@ class PostServiceTest {
         /* when, then */
         assertThrows(NotFoundPostException.class, () -> {
             postService.delete(newUser,1L);
-        }, "존재하지 않는 포스트입니다.");
+        }, "존재하지 않는 게시글입니다.");
     }
 
     @Test
-    @DisplayName("접근권한 없는 포스트 삭제 시 예외를 터뜨린다.")
-    void 접근권한_없는_포스트_삭제_시_예외를_터뜨린다() {
+    @DisplayName("접근권한 없는 게시글 삭제 시 예외를 터뜨린다.")
+    void 접근권한_없는_게시글_삭제_시_예외를_터뜨린다() {
         /* given */
         User user = spy(UserFixtures.회원_생성("chacha", "chacha@chacha.com"));
         when(user.getId()).thenReturn(100L);

--- a/module-core/src/main/java/com/trybe/modulecore/post/entity/PostLike.java
+++ b/module-core/src/main/java/com/trybe/modulecore/post/entity/PostLike.java
@@ -12,8 +12,8 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "postLikes")
-@SQLDelete(sql = "UPDATE postLikes SET deleted_at = NOW() WHERE id = ?")
+@Table(name = "post_likes")
+@SQLDelete(sql = "UPDATE post_likes SET deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 public class PostLike extends BaseEntity {
 


### PR DESCRIPTION
게시글 좋아요에 대한 테스트 코드 작성
- PostLikeFixtures 작성
- PostLikeServiceTest 작성
- PostLikeControllerTest 작성

게시글 반환값에 좋아요 필드 추가
- PostFixtures에 좋아요 추가
- PostServiceTest 코드에 게시글 조회 시 좋아요 개수 검증 추가
- PostServcieTest 코드에 게시글 삭제 시 redis에서 삭제된 게시글에 대한 좋아요 삭제 메소드 검증 추가
- PostControllerTest 코드에 좋아요 필드 추가

Spring Rest Docs의 index.adoc 파일 수정
- 게시글 좋아요 API에 대한 섹션 추가