### PR TITLE
[#4] 챌린지 북마크 기능 구현

### DIFF
--- a/module-api/http/authentication.http
+++ b/module-api/http/authentication.http
@@ -24,6 +24,10 @@ Content-Type: application/json
 POST http://localhost:8080/api/v1/auth/logout
 Authorization: {{accessToken}}
 
+> {%
+    client.global.clear("accessToken");
+    client.global.clear("refreshToken");
+%}
 
 ### 2-1 로그아웃 API (인증 객체 없음)
 POST http://localhost:8080/api/v1/auth/logout

--- a/module-api/http/challenge-bookmark.http
+++ b/module-api/http/challenge-bookmark.http
@@ -1,0 +1,11 @@
+### 1. 챌린지 북마크 추가
+POST http://localhost:8080/api/v1/challenges/bookmarks/1
+Authorization: {{accessToken}}
+
+### 2. 챌린지 북마크 삭제
+DELETE http://localhost:8080/api/v1/challenges/bookmarks/1
+Authorization: {{accessToken}}
+
+### 3. 나의 챌린지 북마크 목록 조회
+GET http://localhost:8080/api/v1/challenges/bookmarks/my?page=0&size=10
+Authorization: {{accessToken}}

--- a/module-api/http/challenge.http
+++ b/module-api/http/challenge.http
@@ -30,9 +30,11 @@ Content-Type: application/json
 
 ### 2. 챌린지 단일 조회
 GET http://localhost:8080/api/v1/challenges/1
+Authorization: {{accessToken}}
 
 ### 3. 챌린지 검색 조회
 POST http://localhost:8080/api/v1/challenges/search?page=0&size=10
+Authorization: {{accessToken}}
 Content-Type: application/json
 
 {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkController.java
@@ -1,0 +1,43 @@
+package com.trybe.moduleapi.challenge.controller;
+
+import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.service.ChallengeBookmarkService;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/challenges/bookmarks")
+public class ChallengeBookmarkController {
+    private final ChallengeBookmarkService challengeBookmarkService;
+
+    public ChallengeBookmarkController(ChallengeBookmarkService challengeBookmarkService) {
+        this.challengeBookmarkService = challengeBookmarkService;
+    }
+
+    @PostMapping("/{challengeId}")
+    public ChallengeResponse.Bookmark addBookmark(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("challengeId") Long challengeId
+    ) {
+        return challengeBookmarkService.addBookmark(userDetails.getUser(), challengeId);
+    }
+
+    @DeleteMapping("/{challengeId}")
+    public ChallengeResponse.Bookmark removeBookmark(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("challengeId") Long challengeId
+    ) {
+        return challengeBookmarkService.removeBookmark(userDetails.getUser(), challengeId);
+    }
+
+    @GetMapping("/my")
+    public PageResponse<ChallengeResponse.Summary> getMyBookmarkedChallenges(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            Pageable pageable
+    ) {
+        return challengeBookmarkService.getMyBookmarkedChallenges(userDetails.getUser(), pageable);
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkController.java
@@ -34,7 +34,7 @@ public class ChallengeBookmarkController {
     }
 
     @GetMapping("/my")
-    public PageResponse<ChallengeResponse.Summary> getMyBookmarkedChallenges(
+    public PageResponse<ChallengeResponse.Preview> getMyBookmarkedChallenges(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             Pageable pageable
     ) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
@@ -5,6 +5,7 @@ import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.modulecore.user.entity.User;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,16 +29,22 @@ public class ChallengeController {
     }
 
     @GetMapping("/{id}")
-    public ChallengeResponse.Detail find(@PathVariable("id") Long id) {
-        return challengeService.find(id);
+    public ChallengeResponse.Detail find(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("id") Long id
+    ) {
+        User user = userDetails == null ? null : userDetails.getUser();
+        return challengeService.find(user, id);
     }
 
     @PostMapping("/search")
     public PageResponse<ChallengeResponse.Summary> findAll(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody ChallengeRequest.Read request,
             Pageable pageable
     ) {
-        return challengeService.findAll(request, pageable);
+        User user = userDetails == null ? null : userDetails.getUser();
+        return challengeService.findAll(user, request, pageable);
     }
 
     @PutMapping("/{id}/content")

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
@@ -8,7 +8,9 @@ import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.user.entity.User;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -38,7 +40,7 @@ public class ChallengeController {
     }
 
     @PostMapping("/search")
-    public PageResponse<ChallengeResponse.Summary> findAll(
+    public PageResponse<ChallengeResponse.Preview> findAll(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody ChallengeRequest.Read request,
             Pageable pageable

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
@@ -39,7 +39,7 @@ public class ChallengeResponse {
         }
     }
 
-    public record Summary(
+    public record Preview(
             Long id,
             String title,
             String description,
@@ -49,8 +49,8 @@ public class ChallengeResponse {
             int participantCount,
             Bookmark bookmark
     ) {
-        public static Summary from(Challenge challenge, int participantCount, Bookmark bookmark) {
-            return new Summary(
+        public static Preview from(Challenge challenge, int participantCount, Bookmark bookmark) {
+            return new Preview(
                     challenge.getId(),
                     challenge.getTitle(),
                     challenge.getDescription(),
@@ -59,6 +59,26 @@ public class ChallengeResponse {
                     challenge.getCapacity(),
                     participantCount,
                     bookmark
+            );
+        }
+    }
+
+    public record Summary(
+            Long id,
+            String title,
+            String description,
+            ChallengeStatus status,
+            ChallengeCategory category,
+            int capacity
+    ) {
+        public static Summary from(Challenge challenge) {
+            return new Summary(
+                    challenge.getId(),
+                    challenge.getTitle(),
+                    challenge.getDescription(),
+                    challenge.getStatus(),
+                    challenge.getCategory(),
+                    challenge.getCapacity()
             );
         }
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
@@ -19,9 +19,9 @@ public class ChallengeResponse {
             int participantCount,
             String proofWay,
             int proofCount,
-            Boolean bookmarked
+            Bookmark bookmark
     ) {
-        public static Detail from(Challenge challenge, int participantCount, Boolean bookmarked) {
+        public static Detail from(Challenge challenge, int participantCount, Bookmark bookmark) {
             return new Detail(
                     challenge.getId(),
                     challenge.getTitle(),
@@ -34,7 +34,7 @@ public class ChallengeResponse {
                     participantCount,
                     challenge.getProofWay(),
                     challenge.getProofCount(),
-                    bookmarked
+                    bookmark
             );
         }
     }
@@ -47,9 +47,9 @@ public class ChallengeResponse {
             ChallengeCategory category,
             int capacity,
             int participantCount,
-            Boolean bookmarked
+            Bookmark bookmark
     ) {
-        public static Summary from(Challenge challenge, int participantCount, Boolean bookmarked) {
+        public static Summary from(Challenge challenge, int participantCount, Bookmark bookmark) {
             return new Summary(
                     challenge.getId(),
                     challenge.getTitle(),
@@ -58,13 +58,13 @@ public class ChallengeResponse {
                     challenge.getCategory(),
                     challenge.getCapacity(),
                     participantCount,
-                    bookmarked
+                    bookmark
             );
         }
     }
 
     public record Bookmark(
             int bookmarkCount,
-            boolean bookmarked
+            Boolean bookmarked
     ) { }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
@@ -14,13 +14,14 @@ public class ChallengeResponse {
             LocalDate startDate,
             LocalDate endDate,
             ChallengeStatus status,
-            int capacity,
             ChallengeCategory category,
+            int capacity,
+            int participantCount,
             String proofWay,
-            int proofCount
-            // TODO: 현재 참여 인원수, 참여 인원 필드 추가
+            int proofCount,
+            Boolean bookmarked
     ) {
-        public static Detail from(Challenge challenge) {
+        public static Detail from(Challenge challenge, int participantCount, Boolean bookmarked) {
             return new Detail(
                     challenge.getId(),
                     challenge.getTitle(),
@@ -28,10 +29,12 @@ public class ChallengeResponse {
                     challenge.getStartDate(),
                     challenge.getEndDate(),
                     challenge.getStatus(),
-                    challenge.getCapacity(),
                     challenge.getCategory(),
+                    challenge.getCapacity(),
+                    participantCount,
                     challenge.getProofWay(),
-                    challenge.getProofCount()
+                    challenge.getProofCount(),
+                    bookmarked
             );
         }
     }
@@ -41,18 +44,21 @@ public class ChallengeResponse {
             String title,
             String description,
             ChallengeStatus status,
+            ChallengeCategory category,
             int capacity,
-            ChallengeCategory category
-            // TODO: 현재 참여 인원수 필드 추가
+            int participantCount,
+            Boolean bookmarked
     ) {
-        public static Summary from(Challenge challenge) {
+        public static Summary from(Challenge challenge, int participantCount, Boolean bookmarked) {
             return new Summary(
                     challenge.getId(),
                     challenge.getTitle(),
                     challenge.getDescription(),
                     challenge.getStatus(),
+                    challenge.getCategory(),
                     challenge.getCapacity(),
-                    challenge.getCategory()
+                    participantCount,
+                    bookmarked
             );
         }
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
@@ -56,4 +56,9 @@ public class ChallengeResponse {
             );
         }
     }
+
+    public record Bookmark(
+            int bookmarkCount,
+            boolean bookmarked
+    ) { }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -4,6 +4,8 @@ import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -19,10 +21,12 @@ import java.util.stream.Collectors;
 @Service
 public class ChallengeBookmarkService {
     private final ChallengeRepository challengeRepository;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
     private final RedisTemplate<String, Long> redisTemplate;
 
-    public ChallengeBookmarkService(ChallengeRepository challengeRepository, RedisTemplate<String, Long> redisTemplate) {
+    public ChallengeBookmarkService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, RedisTemplate<String, Long> redisTemplate) {
         this.challengeRepository = challengeRepository;
+        this.challengeParticipationRepository = challengeParticipationRepository;
         this.redisTemplate = redisTemplate;
     }
 
@@ -89,7 +93,11 @@ public class ChallengeBookmarkService {
                 : challengeRepository.findAllByIdIn(challengeIds);
 
         List<ChallengeResponse.Summary> challengeSummaries = sortChallenges(challenges, challengeIds).stream()
-                .map(challenge -> ChallengeResponse.Summary.from(challenge, getChallengeBookmarkCount(challenge.getId()), true))
+                .map(challenge -> {
+                    int participantCount = challengeParticipationRepository.countByChallengeIdAndStatus(challenge.getId(), ParticipationStatus.ACCEPTED);
+                    ChallengeResponse.Bookmark bookmark = new ChallengeResponse.Bookmark(getChallengeBookmarkCount(challenge.getId()), true);
+                    return ChallengeResponse.Summary.from(challenge, participantCount, bookmark);
+                })
                 .collect(Collectors.toList());
 
         Page<ChallengeResponse.Summary> challengePage = new PageImpl<>(challengeSummaries, pageable, getUserBookmarkCount(user.getId()));

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -46,7 +46,7 @@ public class ChallengeBookmarkService {
         String challengeDeletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
         int count = getChallengeBookmarkCount(challengeId);
 
-        if (!redisTemplate.opsForSet().isMember(challengeKey, user.getId())) {
+        if (!isBookmarked(user.getId(), challengeId)) {
             double score = getCurrentTimeInSeconds();
             redisTemplate.opsForZSet().add(userKey, challengeId, score);
             redisTemplate.opsForSet().add(challengeKey, user.getId());
@@ -68,7 +68,7 @@ public class ChallengeBookmarkService {
         String challengeDeletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
         int count = getChallengeBookmarkCount(challengeId);
 
-        if (redisTemplate.opsForSet().isMember(challengeKey, user.getId())) {
+        if(isBookmarked(user.getId(), challengeId)) {
             redisTemplate.opsForZSet().remove(userKey, challengeId);
             redisTemplate.opsForSet().remove(challengeKey, user.getId());
             redisTemplate.opsForSet().add(challengeDeletedKey, user.getId());

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -80,7 +80,7 @@ public class ChallengeBookmarkService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<ChallengeResponse.Summary> getMyBookmarkedChallenges(User user, Pageable pageable) {
+    public PageResponse<ChallengeResponse.Preview> getMyBookmarkedChallenges(User user, Pageable pageable) {
         String userKey = getRedisKey(USER_KEY, user.getId());
 
         int start = pageable.getPageNumber() * pageable.getPageSize();
@@ -92,15 +92,15 @@ public class ChallengeBookmarkService {
                 ? Collections.emptyList()
                 : challengeRepository.findAllByIdIn(challengeIds);
 
-        List<ChallengeResponse.Summary> challengeSummaries = sortChallenges(challenges, challengeIds).stream()
+        List<ChallengeResponse.Preview> challengeSummaries = sortChallenges(challenges, challengeIds).stream()
                 .map(challenge -> {
                     int participantCount = challengeParticipationRepository.countByChallengeIdAndStatus(challenge.getId(), ParticipationStatus.ACCEPTED);
                     ChallengeResponse.Bookmark bookmark = new ChallengeResponse.Bookmark(getChallengeBookmarkCount(challenge.getId()), true);
-                    return ChallengeResponse.Summary.from(challenge, participantCount, bookmark);
+                    return ChallengeResponse.Preview.from(challenge, participantCount, bookmark);
                 })
                 .collect(Collectors.toList());
 
-        Page<ChallengeResponse.Summary> challengePage = new PageImpl<>(challengeSummaries, pageable, getUserBookmarkCount(user.getId()));
+        Page<ChallengeResponse.Preview> challengePage = new PageImpl<>(challengeSummaries, pageable, getUserBookmarkCount(user.getId()));
 
         return new PageResponse<>(challengePage);
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -13,10 +13,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -85,14 +82,14 @@ public class ChallengeBookmarkService {
         int start = pageable.getPageNumber() * pageable.getPageSize();
         int end = start + pageable.getPageSize() - 1;
 
-        Set<Long> challengeIds = Optional.ofNullable(redisTemplate.opsForZSet().reverseRange(userKey, start, end)).orElse(Set.of());
+        Set<Long> challengeIds = Optional.ofNullable(redisTemplate.opsForZSet().reverseRange(userKey, start, end)).orElse(Collections.emptySet());
 
         List<Challenge> challenges = challengeIds.isEmpty()
-                ? List.of()
+                ? Collections.emptyList()
                 : challengeRepository.findAllByIdIn(challengeIds);
 
         List<ChallengeResponse.Summary> challengeSummaries = sortChallenges(challenges, challengeIds).stream()
-                .map(ChallengeResponse.Summary::from)
+                .map(challenge -> ChallengeResponse.Summary.from(challenge, getChallengeBookmarkCount(challenge.getId()), true))
                 .collect(Collectors.toList());
 
         Page<ChallengeResponse.Summary> challengePage = new PageImpl<>(challengeSummaries, pageable, getUserBookmarkCount(user.getId()));
@@ -100,12 +97,24 @@ public class ChallengeBookmarkService {
         return new PageResponse<>(challengePage);
     }
 
+    public boolean isBookmarked(Long userId, Long challengeId) {
+        String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
+        return redisTemplate.opsForSet().isMember(challengeKey, userId);
+    }
+
+    public int getChallengeBookmarkCount(Long challengeId) {
+        String challengeCountKey = getRedisKey(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
+        Long count = redisTemplate.opsForValue().get(challengeCountKey);
+
+        return count == null ? 0 : count.intValue();
+    }
+
     public void removeBookmarksByChallenge(Long challengeId) {
         String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
         String challengeCountKey = getRedisKey(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
         String challengeDeletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
 
-        Set<Long> userIds = Optional.ofNullable(redisTemplate.opsForSet().members(challengeKey)).orElse(Set.of());
+        Set<Long> userIds = Optional.ofNullable(redisTemplate.opsForSet().members(challengeKey)).orElse(Collections.emptySet());
 
         userIds.forEach(userId -> {
             String userKey = getRedisKey(USER_KEY, userId);
@@ -128,13 +137,6 @@ public class ChallengeBookmarkService {
         if (!challengeRepository.existsById(challengeId)) {
             throw new NotFoundChallengeException();
         }
-    }
-
-    private int getChallengeBookmarkCount(Long challengeId) {
-        String challengeCountKey = getRedisKey(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
-        Long count = redisTemplate.opsForValue().get(challengeCountKey);
-
-        return count == null ? 0 : count.intValue();
     }
 
     private int getUserBookmarkCount(Long userId) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -1,0 +1,154 @@
+package com.trybe.moduleapi.challenge.service;
+
+import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.repository.ChallengeRepository;
+import com.trybe.modulecore.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class ChallengeBookmarkService {
+    private final ChallengeRepository challengeRepository;
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    public ChallengeBookmarkService(ChallengeRepository challengeRepository, RedisTemplate<String, Long> redisTemplate) {
+        this.challengeRepository = challengeRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    private final String BOOKMARK_SUFFIX = ":bookmark";
+    private final String USER_KEY = "user:%d" + BOOKMARK_SUFFIX;
+    private final String CHALLENGE_BOOKMARK_KEY = "challenge:%d" + BOOKMARK_SUFFIX;
+    private final String CHALLENGE_BOOKMARK_COUNT_KEY = CHALLENGE_BOOKMARK_KEY + ":count";
+    private final String CHALLENGE_BOOKMARK_DELETED_KEY = CHALLENGE_BOOKMARK_KEY + ":deleted";
+
+    @Transactional
+    public ChallengeResponse.Bookmark addBookmark(User user, Long challengeId) {
+        validateExistChallenge(challengeId);
+
+        String userKey = getRedisKey(USER_KEY, user.getId());
+        String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
+        String challengeCountKey = getRedisKey(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
+        String challengeDeletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
+        int count = getChallengeBookmarkCount(challengeId);
+
+        if (!redisTemplate.opsForSet().isMember(challengeKey, user.getId())) {
+            double score = getCurrentTimeInSeconds();
+            redisTemplate.opsForZSet().add(userKey, challengeId, score);
+            redisTemplate.opsForSet().add(challengeKey, user.getId());
+            redisTemplate.opsForSet().remove(challengeDeletedKey, user.getId());
+            redisTemplate.opsForValue().increment(challengeCountKey, 1L);
+            count++;
+        }
+
+        return new ChallengeResponse.Bookmark(count, true);
+    }
+
+    @Transactional
+    public ChallengeResponse.Bookmark removeBookmark(User user, Long challengeId) {
+        validateExistChallenge(challengeId);
+
+        String userKey = getRedisKey(USER_KEY, user.getId());
+        String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
+        String challengeCountKey = getRedisKey(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
+        String challengeDeletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
+        int count = getChallengeBookmarkCount(challengeId);
+
+        if (redisTemplate.opsForSet().isMember(challengeKey, user.getId())) {
+            redisTemplate.opsForZSet().remove(userKey, challengeId);
+            redisTemplate.opsForSet().remove(challengeKey, user.getId());
+            redisTemplate.opsForSet().add(challengeDeletedKey, user.getId());
+            redisTemplate.opsForValue().decrement(challengeCountKey, 1L);
+            count--;
+        }
+
+        return new ChallengeResponse.Bookmark(count, false);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ChallengeResponse.Summary> getMyBookmarkedChallenges(User user, Pageable pageable) {
+        String userKey = getRedisKey(USER_KEY, user.getId());
+
+        int start = pageable.getPageNumber() * pageable.getPageSize();
+        int end = start + pageable.getPageSize() - 1;
+
+        Set<Long> challengeIds = Optional.ofNullable(redisTemplate.opsForZSet().reverseRange(userKey, start, end)).orElse(Set.of());
+
+        List<Challenge> challenges = challengeIds.isEmpty()
+                ? List.of()
+                : challengeRepository.findAllByIdIn(challengeIds);
+
+        List<ChallengeResponse.Summary> challengeSummaries = sortChallenges(challenges, challengeIds).stream()
+                .map(ChallengeResponse.Summary::from)
+                .collect(Collectors.toList());
+
+        Page<ChallengeResponse.Summary> challengePage = new PageImpl<>(challengeSummaries, pageable, getUserBookmarkCount(user.getId()));
+
+        return new PageResponse<>(challengePage);
+    }
+
+    public void removeBookmarksByChallenge(Long challengeId) {
+        String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
+        String challengeCountKey = getRedisKey(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
+        String challengeDeletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
+
+        Set<Long> userIds = Optional.ofNullable(redisTemplate.opsForSet().members(challengeKey)).orElse(Set.of());
+
+        userIds.forEach(userId -> {
+            String userKey = getRedisKey(USER_KEY, userId);
+            redisTemplate.opsForZSet().remove(userKey, challengeId);
+        });
+
+        redisTemplate.delete(List.of(challengeKey, challengeCountKey, challengeDeletedKey));
+    }
+
+    private List<Challenge> sortChallenges(List<Challenge> challenges, Set<Long> challengeIds) {
+        Map<Long, Challenge> challengeMap = challenges.stream()
+                .collect(Collectors.toMap(Challenge::getId, challenge -> challenge));
+
+        return challengeIds.stream()
+                .map(challengeMap::get)
+                .collect(Collectors.toList());
+    }
+
+    private void validateExistChallenge(Long challengeId) {
+        if (!challengeRepository.existsById(challengeId)) {
+            throw new NotFoundChallengeException();
+        }
+    }
+
+    private int getChallengeBookmarkCount(Long challengeId) {
+        String challengeCountKey = getRedisKey(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
+        Long count = redisTemplate.opsForValue().get(challengeCountKey);
+
+        return count == null ? 0 : count.intValue();
+    }
+
+    private int getUserBookmarkCount(Long userId) {
+        String userKey = getRedisKey(USER_KEY, userId);
+        Long count = redisTemplate.opsForZSet().size(userKey);
+
+        return count == null ? 0 : count.intValue();
+    }
+
+    private String getRedisKey(String key, Long id) {
+        return String.format(key, id);
+    }
+
+    private double getCurrentTimeInSeconds() {
+        return System.currentTimeMillis() / 1000.0;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -51,10 +51,10 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<ChallengeResponse.Summary> findAll(User user, ChallengeRequest.Read request, Pageable pageable) {
+    public PageResponse<ChallengeResponse.Preview> findAll(User user, ChallengeRequest.Read request, Pageable pageable) {
         Page<Challenge> challenges = challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), pageable);
 
-        Page<ChallengeResponse.Summary> challengeSummaries = challenges.map(challenge -> createSummary(user, challenge));
+        Page<ChallengeResponse.Preview> challengeSummaries = challenges.map(challenge -> createPreview(user, challenge));
 
         return new PageResponse<>(challengeSummaries);
     }
@@ -101,10 +101,10 @@ public class ChallengeService {
         return ChallengeResponse.Detail.from(challenge, participantCount, bookmark);
     }
 
-    private ChallengeResponse.Summary createSummary(User user, Challenge challenge) {
+    private ChallengeResponse.Preview createPreview(User user, Challenge challenge) {
         int participantCount = getParticipantCount(challenge.getId());
         ChallengeResponse.Bookmark bookmark = createBookmark(user, challenge.getId());
-        return ChallengeResponse.Summary.from(challenge, participantCount, bookmark);
+        return ChallengeResponse.Preview.from(challenge, participantCount, bookmark);
     }
 
     private ChallengeResponse.Bookmark createBookmark(User user, Long challengeId) {
@@ -115,7 +115,7 @@ public class ChallengeService {
 
     private Challenge getChallenge(Long id) {
         return challengeRepository.findById(id)
-                .orElseThrow(() -> new NotFoundChallengeException());
+                .orElseThrow(NotFoundChallengeException::new);
     }
 
     private int getParticipantCount(Long challengeId) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -59,9 +59,8 @@ public class ChallengeService {
     @Transactional
     public ChallengeResponse.Detail updateContent(User user, Long id, ChallengeRequest.UpdateContent request) {
         Challenge challenge = getChallenge(id);
-        ChallengeParticipation participation = getParticipation(user.getId(), id);
 
-        validateRole(participation, ChallengeRole.LEADER, "리더만 챌린지 정보를 수정할 수 있습니다.");
+        validateLeader(user.getId(), id, "리더만 챌린지 정보를 수정할 수 있습니다.");
         validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 정보를 수정할 수 있습니다.");
 
         challenge.updateContent(request.title(), request.description(), request.startDate(), request.endDate(), request.capacity(), request.category());
@@ -72,9 +71,8 @@ public class ChallengeService {
     @Transactional
     public ChallengeResponse.Detail updateProof(User user, Long id, ChallengeRequest.UpdateProof request) {
         Challenge challenge = getChallenge(id);
-        ChallengeParticipation participation = getParticipation(user.getId(), id);
 
-        validateRole(participation, ChallengeRole.LEADER, "리더만 챌린지 인증 정보를 수정할 수 있습니다.");
+        validateLeader(user.getId(), id, "리더만 챌린지 인증 정보를 수정할 수 있습니다.");
         validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 인증 정보를 수정할 수 있습니다.");
 
         challenge.updateProof(request.proofWay(), request.proofCount());
@@ -85,9 +83,8 @@ public class ChallengeService {
     @Transactional
     public void delete(User user, Long id) {
         Challenge challenge = getChallenge(id);
-        ChallengeParticipation participation = getParticipation(user.getId(), id);
 
-        validateRole(participation, ChallengeRole.LEADER, "리더만 챌린지를 삭제할 수 있습니다.");
+        validateLeader(user.getId(), id, "리더만 챌린지를 삭제할 수 있습니다.");
         validateChallengeStatus(challenge, false, ChallengeStatus.ONGOING, "진행 중인 챌린지는 삭제할 수 없습니다.");
 
         challengeParticipationRepository.deleteAllByChallengeId(id);
@@ -99,20 +96,15 @@ public class ChallengeService {
                 .orElseThrow(() -> new NotFoundChallengeException());
     }
 
-    private ChallengeParticipation getParticipation(Long userId, Long challengeId) {
-        return challengeParticipationRepository.findByUserIdAndChallengeId(userId, challengeId)
-                .orElseThrow(() -> new NotFoundChallengeException());
-    }
-
-    private void validateRole(ChallengeParticipation participation, ChallengeRole role, String message) {
-        if (participation.getRole().isNot(role)) {
-            throw new InvalidChallengeRoleActionException(message);
-        }
-    }
-
     private void validateChallengeStatus(Challenge challenge, boolean shouldBe, ChallengeStatus status, String message) {
         if ((shouldBe && challenge.getStatus().isNot(status)) || (!shouldBe && challenge.getStatus().is(status))) {
             throw new InvalidChallengeStatusException(message);
+        }
+    }
+
+    private void validateLeader(Long userId, Long challengeId, String message) {
+        if (!challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(userId, challengeId, ChallengeRole.LEADER)) {
+            throw new InvalidChallengeRoleActionException(message);
         }
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -23,10 +23,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChallengeService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeParticipationRepository challengeParticipationRepository;
+    private final ChallengeBookmarkService challengeBookmarkService;
 
-    public ChallengeService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository) {
+    public ChallengeService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkService challengeBookmarkService) {
         this.challengeRepository = challengeRepository;
         this.challengeParticipationRepository = challengeParticipationRepository;
+        this.challengeBookmarkService = challengeBookmarkService;
     }
 
     @Transactional
@@ -37,23 +39,24 @@ public class ChallengeService {
         ChallengeParticipation participation = new ChallengeParticipation(user, savedChallenge, ChallengeRole.LEADER, ParticipationStatus.ACCEPTED);
         challengeParticipationRepository.save(participation);
 
-        return ChallengeResponse.Detail.from(savedChallenge);
+        ChallengeResponse.Bookmark bookmark = new ChallengeResponse.Bookmark(0, false);
+        return ChallengeResponse.Detail.from(savedChallenge, 1, bookmark);
     }
 
     @Transactional(readOnly = true)
-    public ChallengeResponse.Detail find(Long id) {
-        // TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
+    public ChallengeResponse.Detail find(User user, Long id) {
         Challenge challenge = getChallenge(id);
 
-        return ChallengeResponse.Detail.from(challenge);
+        return createDetail(user, challenge);
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<ChallengeResponse.Summary> findAll(ChallengeRequest.Read request, Pageable pageable) {
-        // TODO: Challenge bookmark 정보 추가 반환 (북마크 여부)
+    public PageResponse<ChallengeResponse.Summary> findAll(User user, ChallengeRequest.Read request, Pageable pageable) {
         Page<Challenge> challenges = challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), pageable);
 
-        return new PageResponse<>(challenges.map(ChallengeResponse.Summary::from));
+        Page<ChallengeResponse.Summary> challengeSummaries = challenges.map(challenge -> createSummary(user, challenge));
+
+        return new PageResponse<>(challengeSummaries);
     }
 
     @Transactional
@@ -65,7 +68,7 @@ public class ChallengeService {
 
         challenge.updateContent(request.title(), request.description(), request.startDate(), request.endDate(), request.capacity(), request.category());
 
-        return ChallengeResponse.Detail.from(challenge);
+        return createDetail(user, challenge);
     }
 
     @Transactional
@@ -77,7 +80,7 @@ public class ChallengeService {
 
         challenge.updateProof(request.proofWay(), request.proofCount());
 
-        return ChallengeResponse.Detail.from(challenge);
+        return createDetail(user, challenge);
     }
 
     @Transactional
@@ -91,9 +94,31 @@ public class ChallengeService {
         challengeRepository.delete(challenge);
     }
 
+    private ChallengeResponse.Detail createDetail(User user, Challenge challenge) {
+        int participantCount = getParticipantCount(challenge.getId());
+        ChallengeResponse.Bookmark bookmark = createBookmark(user, challenge.getId());
+        return ChallengeResponse.Detail.from(challenge, participantCount, bookmark);
+    }
+
+    private ChallengeResponse.Summary createSummary(User user, Challenge challenge) {
+        int participantCount = getParticipantCount(challenge.getId());
+        ChallengeResponse.Bookmark bookmark = createBookmark(user, challenge.getId());
+        return ChallengeResponse.Summary.from(challenge, participantCount, bookmark);
+    }
+
+    private ChallengeResponse.Bookmark createBookmark(User user, Long challengeId) {
+        int bookmarkCount = challengeBookmarkService.getChallengeBookmarkCount(challengeId);
+        Boolean bookmarked = user == null ? null : challengeBookmarkService.isBookmarked(user.getId(), challengeId);
+        return new ChallengeResponse.Bookmark(bookmarkCount, bookmarked);
+    }
+
     private Challenge getChallenge(Long id) {
         return challengeRepository.findById(id)
                 .orElseThrow(() -> new NotFoundChallengeException());
+    }
+
+    private int getParticipantCount(Long challengeId) {
+        return challengeParticipationRepository.countByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED);
     }
 
     private void validateChallengeStatus(Challenge challenge, boolean shouldBe, ChallengeStatus status, String message) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -90,6 +90,7 @@ public class ChallengeService {
         validateLeader(user.getId(), id, "리더만 챌린지를 삭제할 수 있습니다.");
         validateChallengeStatus(challenge, false, ChallengeStatus.ONGOING, "진행 중인 챌린지는 삭제할 수 없습니다.");
 
+        challengeBookmarkService.removeBookmarksByChallenge(id);
         challengeParticipationRepository.deleteAllByChallengeId(id);
         challengeRepository.delete(challenge);
     }

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -47,7 +47,7 @@ class ChallengeControllerTest extends ControllerTest {
         ChallengeRequest.Create request = ChallengeFixtures.챌린지_생성_요청;
 
         when(challengeService.save(any(User.class), eq(request)))
-                .thenReturn(ChallengeFixtures.챌린지_상세_응답);
+                .thenReturn(ChallengeFixtures.초기_챌린지_상세_응답);
 
         /* when */
         /* then */
@@ -62,10 +62,14 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.startDate").value(request.startDate().toString()),
                 jsonPath("$.endDate").value(request.endDate().toString()),
                 jsonPath("$.status").value(ChallengeFixtures.대기중.toString()),
-                jsonPath("$.capacity").value(request.capacity()),
                 jsonPath("$.category").value(request.category().toString()),
+                jsonPath("$.capacity").value(request.capacity()),
+                jsonPath("$.participantCount").value(ChallengeFixtures.초기_참여자_수),
                 jsonPath("$.proofWay").value(request.proofWay()),
-                jsonPath("$.proofCount").value(request.proofCount())
+                jsonPath("$.proofCount").value(request.proofCount()),
+                jsonPath("$.bookmark").exists(),
+                jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.초기_북마크_수),
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
         );
 
         result.andDo(document(docsPath + "create",
@@ -88,10 +92,14 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("startDate").description("챌린지 시작일"),
                         fieldWithPath("endDate").description("챌린지 종료일"),
                         fieldWithPath("status").description("챌린지 상태"),
-                        fieldWithPath("capacity").description("챌린지 인원"),
                         fieldWithPath("category").description("챌린지 카테고리"),
+                        fieldWithPath("capacity").description("챌린지 인원"),
+                        fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
-                        fieldWithPath("proofCount").description("챌린지 인증 횟수")
+                        fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("bookmark").description("챌린지 북마크 정보"),
+                        fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
+                        fieldWithPath("bookmark.bookmarked").description("북마크 여부")
                 )));
     }
 
@@ -147,12 +155,13 @@ class ChallengeControllerTest extends ControllerTest {
     }
 
     @Test
+    @WithCustomMockUser
     @DisplayName("정상적인 챌린지 단일 조회 요청 시 응답코드 200을 반환한다.")
     void 정상적인_챌린지_단일_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
         /* given */
         Long challengeId = ChallengeFixtures.챌린지_ID;
 
-        when(challengeService.find(challengeId))
+        when(challengeService.find(any(User.class), eq(challengeId)))
                 .thenReturn(ChallengeFixtures.챌린지_상세_응답);
 
         /* when */
@@ -166,10 +175,14 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.startDate").value(ChallengeFixtures.챌린지_상세_응답.startDate().toString()),
                 jsonPath("$.endDate").value(ChallengeFixtures.챌린지_상세_응답.endDate().toString()),
                 jsonPath("$.status").value(ChallengeFixtures.대기중.toString()),
-                jsonPath("$.capacity").value(ChallengeFixtures.챌린지_상세_응답.capacity()),
                 jsonPath("$.category").value(ChallengeFixtures.챌린지_상세_응답.category().toString()),
+                jsonPath("$.capacity").value(ChallengeFixtures.챌린지_상세_응답.capacity()),
+                jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.챌린지_상세_응답.proofWay()),
-                jsonPath("$.proofCount").value(ChallengeFixtures.챌린지_상세_응답.proofCount())
+                jsonPath("$.proofCount").value(ChallengeFixtures.챌린지_상세_응답.proofCount()),
+                jsonPath("$.bookmark").exists(),
+                jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
         );
 
         result.andDo(document(docsPath + "find",
@@ -183,20 +196,25 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("startDate").description("챌린지 시작일"),
                         fieldWithPath("endDate").description("챌린지 종료일"),
                         fieldWithPath("status").description("챌린지 상태"),
-                        fieldWithPath("capacity").description("챌린지 인원"),
                         fieldWithPath("category").description("챌린지 카테고리"),
+                        fieldWithPath("capacity").description("챌린지 인원"),
+                        fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
-                        fieldWithPath("proofCount").description("챌린지 인증 횟수")
+                        fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("bookmark").description("챌린지 북마크 정보"),
+                        fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
+                        fieldWithPath("bookmark.bookmarked").description("북마크 여부")
                 )));
     }
 
     @Test
+    @WithCustomMockUser
     @DisplayName("존재하지 않는 챌린지 단일 조회 요청 시 응답코드 404을 반환한다.")
     void 존재하지_않는_챌린지_단일_조회_요청_시_응답코드_404을_반환한다 () throws Exception {
         /* given */
         Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
 
-        doThrow(new NotFoundChallengeException()).when(challengeService).find(challengeId);
+        doThrow(new NotFoundChallengeException()).when(challengeService).find(any(User.class), eq(challengeId));
 
         /* when */
         /* then */
@@ -219,13 +237,14 @@ class ChallengeControllerTest extends ControllerTest {
     }
 
     @Test
+    @WithCustomMockUser
     @DisplayName("정상적인 챌린지 필터링 조회 요청 시 응답코드 200을 반환한다.")
     void 정상적인_챌린지_필터링_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
         /* given */
         ChallengeRequest.Read request = ChallengeFixtures.챌린지_조회_요청;
 
-        when(challengeService.findAll(request, ChallengeFixtures.페이지_요청))
-                .thenReturn(ChallengeFixtures.챌린지_페이지_응답);
+        when(challengeService.findAll(any(User.class), eq(request), eq(ChallengeFixtures.페이지_요청)))
+                .thenReturn(ChallengeFixtures.챌린지_미리보기_페이지_응답);
 
         /* when */
         /* then */
@@ -256,8 +275,12 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("content[].title").description("챌린지 제목"),
                         fieldWithPath("content[].description").description("챌린지 설명"),
                         fieldWithPath("content[].status").description("챌린지 상태"),
-                        fieldWithPath("content[].capacity").description("챌린지 인원"),
                         fieldWithPath("content[].category").description("챌린지 카테고리"),
+                        fieldWithPath("content[].capacity").description("챌린지 인원"),
+                        fieldWithPath("content[].participantCount").description("챌린지 참여자 수"),
+                        fieldWithPath("content[].bookmark").description("챌린지 북마크 정보"),
+                        fieldWithPath("content[].bookmark.bookmarkCount").description("챌린지 북마크 수"),
+                        fieldWithPath("content[].bookmark.bookmarked").description("북마크 여부"),
                         fieldWithPath("totalPages").description("총 페이지 수"),
                         fieldWithPath("totalElements").description("총 요소 수"),
                         fieldWithPath("size").description("페이지 크기"),
@@ -267,6 +290,7 @@ class ChallengeControllerTest extends ControllerTest {
     }
 
     @Test
+    @WithCustomMockUser
     @DisplayName("비정상적인 챌린지 필터링 조회 요청 시 응답코드 400을 반환한다.")
     void 비정상적인_챌린지_필터링_조회_요청_시_응답코드_400을_반환한다 () throws Exception {
         /* given */
@@ -321,10 +345,14 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.startDate").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.startDate().toString()),
                 jsonPath("$.endDate").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.endDate().toString()),
                 jsonPath("$.status").value(ChallengeFixtures.대기중.toString()),
-                jsonPath("$.capacity").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.capacity()),
                 jsonPath("$.category").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.category().toString()),
+                jsonPath("$.capacity").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.capacity()),
+                jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.proofWay()),
-                jsonPath("$.proofCount").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.proofCount())
+                jsonPath("$.proofCount").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.proofCount()),
+                jsonPath("$.bookmark").exists(),
+                jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
         );
 
         result.andDo(document(docsPath + "update-content",
@@ -346,10 +374,14 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("startDate").description("챌린지 시작일"),
                         fieldWithPath("endDate").description("챌린지 종료일"),
                         fieldWithPath("status").description("챌린지 상태"),
-                        fieldWithPath("capacity").description("챌린지 인원"),
                         fieldWithPath("category").description("챌린지 카테고리"),
+                        fieldWithPath("capacity").description("챌린지 인원"),
+                        fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
-                        fieldWithPath("proofCount").description("챌린지 인증 횟수")
+                        fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("bookmark").description("챌린지 북마크 정보"),
+                        fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
+                        fieldWithPath("bookmark.bookmarked").description("북마크 여부")
                 )));
     }
 
@@ -524,10 +556,14 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.startDate").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.startDate().toString()),
                 jsonPath("$.endDate").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.endDate().toString()),
                 jsonPath("$.status").value(ChallengeFixtures.대기중.toString()),
-                jsonPath("$.capacity").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.capacity()),
                 jsonPath("$.category").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.category().toString()),
+                jsonPath("$.capacity").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.capacity()),
+                jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofWay()),
-                jsonPath("$.proofCount").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofCount())
+                jsonPath("$.proofCount").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofCount()),
+                jsonPath("$.bookmark").exists(),
+                jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
         );
 
         result.andDo(document(docsPath + "update-proof",
@@ -545,10 +581,14 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("startDate").description("챌린지 시작일"),
                         fieldWithPath("endDate").description("챌린지 종료일"),
                         fieldWithPath("status").description("챌린지 상태"),
-                        fieldWithPath("capacity").description("챌린지 인원"),
                         fieldWithPath("category").description("챌린지 카테고리"),
+                        fieldWithPath("capacity").description("챌린지 인원"),
+                        fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
-                        fieldWithPath("proofCount").description("챌린지 인증 횟수")
+                        fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("bookmark").description("챌린지 북마크 정보"),
+                        fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
+                        fieldWithPath("bookmark.bookmarked").description("북마크 여부")
                 )));
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -50,6 +50,11 @@ public class ChallengeFixtures {
     public static final int 잘못된_챌린지_인증_횟수 = 0;
     public static final int 수정된_챌린지_인증_횟수 = 14;
 
+    public static final int 초기_북마크_수 = 0;
+    public static final int 초기_참여자_수 = 1;
+    public static final int 북마크_수 = 5;
+    public static final int 참여자_수 = 3;
+
     /* Request DTO */
     public static final ChallengeRequest.Create 챌린지_생성_요청 = new ChallengeRequest.Create(
             챌린지_제목,
@@ -171,13 +176,62 @@ public class ChallengeFixtures {
     public static ChallengeStatus 대기중 = ChallengeStatus.PENDING;
 
     /* Response DTO */
-    public static final ChallengeResponse.Detail 챌린지_상세_응답 = ChallengeResponse.Detail.from(챌린지());
+    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 초기_참여자_수, 초기_북마크_수, false);
+    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, false);
 
-    public static final ChallengeResponse.Summary 챌린지_요약_응답 = ChallengeResponse.Summary.from(챌린지());
+    public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
+    public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, true);
 
-    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = ChallengeResponse.Detail.from(내용_수정된_챌린지);
-    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = ChallengeResponse.Detail.from(인증_내용_수정된_챌린지);
+    public static final ChallengeResponse.Summary 챌린지_요약_응답 = 챌린지_요약_응답_생성(챌린지());
+
+    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, 참여자_수, 북마크_수, false);
+
+    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, 참여자_수, 북마크_수, false);
 
     public static final List<ChallengeResponse.Summary> 챌린지_목록_응답 = 챌린지_목록.stream().map(ChallengeResponse.Summary::from).collect(Collectors.toList());
+    public static final List<ChallengeResponse.Preview> 챌린지_미리보기_목록_응답 = 챌린지_목록.stream().map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, true)).collect(Collectors.toList());
+
     public static final PageResponse<ChallengeResponse.Summary> 챌린지_페이지_응답 = new PageResponse<>(챌린지_페이지.map(ChallengeResponse.Summary::from));
+    public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, true)));
+
+    private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, boolean Bookmarked) {
+        return new ChallengeResponse.Detail(
+                챌린지_ID,
+                challenge.getTitle(),
+                challenge.getDescription(),
+                challenge.getStartDate(),
+                challenge.getEndDate(),
+                challenge.getStatus(),
+                challenge.getCategory(),
+                challenge.getCapacity(),
+                participantCount,
+                challenge.getProofWay(),
+                challenge.getProofCount(),
+                new ChallengeResponse.Bookmark(bookmarkCount, Bookmarked)
+        );
+    }
+
+    private static ChallengeResponse.Preview 챌린지_미리보기_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, Boolean bookmarked) {
+        return new ChallengeResponse.Preview(
+                챌린지_ID,
+                challenge.getTitle(),
+                challenge.getDescription(),
+                challenge.getStatus(),
+                challenge.getCategory(),
+                challenge.getCapacity(),
+                participantCount,
+                new ChallengeResponse.Bookmark(bookmarkCount, bookmarked)
+        );
+    }
+
+    private static ChallengeResponse.Summary 챌린지_요약_응답_생성(Challenge challenge) {
+        return new ChallengeResponse.Summary(
+                챌린지_ID,
+                challenge.getTitle(),
+                challenge.getDescription(),
+                challenge.getStatus(),
+                challenge.getCategory(),
+                challenge.getCapacity()
+        );
+    }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -54,6 +54,7 @@ public class ChallengeFixtures {
     public static final int 초기_참여자_수 = 1;
     public static final int 북마크_수 = 5;
     public static final int 참여자_수 = 3;
+    public static final Boolean 북마크_여부 = true;
 
     /* Request DTO */
     public static final ChallengeRequest.Create 챌린지_생성_요청 = new ChallengeRequest.Create(
@@ -176,23 +177,23 @@ public class ChallengeFixtures {
     public static ChallengeStatus 대기중 = ChallengeStatus.PENDING;
 
     /* Response DTO */
-    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 초기_참여자_수, 초기_북마크_수, false);
-    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, false);
+    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 초기_참여자_수, 초기_북마크_수, 북마크_여부);
+    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부);
 
-    public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
-    public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, true);
+    public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부);
+    public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부);
 
     public static final ChallengeResponse.Summary 챌린지_요약_응답 = 챌린지_요약_응답_생성(챌린지());
 
-    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, 참여자_수, 북마크_수, false);
+    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부);
 
-    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, 참여자_수, 북마크_수, false);
+    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부);
 
     public static final List<ChallengeResponse.Summary> 챌린지_목록_응답 = 챌린지_목록.stream().map(ChallengeResponse.Summary::from).collect(Collectors.toList());
-    public static final List<ChallengeResponse.Preview> 챌린지_미리보기_목록_응답 = 챌린지_목록.stream().map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, true)).collect(Collectors.toList());
+    public static final List<ChallengeResponse.Preview> 챌린지_미리보기_목록_응답 = 챌린지_목록.stream().map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부)).collect(Collectors.toList());
 
     public static final PageResponse<ChallengeResponse.Summary> 챌린지_페이지_응답 = new PageResponse<>(챌린지_페이지.map(ChallengeResponse.Summary::from));
-    public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, true)));
+    public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부)));
 
     private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, boolean Bookmarked) {
         return new ChallengeResponse.Detail(

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -5,14 +5,16 @@ import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
-import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeParticipationFixtures;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.challenge.enums.ChallengeRole;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,14 +41,17 @@ class ChallengeServiceTest {
     @Mock
     private ChallengeParticipationRepository challengeParticipationRepository;
 
+    @Mock
+    private ChallengeBookmarkService challengeBookmarkService;
+
     @Test
     @DisplayName("챌린지 생성 시 저장된 챌린지 정보를 반환한다.")
     void 챌린지_생성_시_저장된_챌린지_정보를_반환한다 () {
         /* given */
-        ChallengeRequest.Create request = ChallengeFixtures.챌린지_생성_요청;
+        ChallengeRequest.Create request = 챌린지_생성_요청;
 
         when(challengeRepository.save(any(Challenge.class)))
-                .thenReturn(ChallengeFixtures.챌린지());
+                .thenReturn(챌린지());
         when(challengeParticipationRepository.save(any(ChallengeParticipation.class)))
                 .thenReturn(ChallengeParticipationFixtures.챌린지_리더_참여());
 
@@ -53,86 +59,137 @@ class ChallengeServiceTest {
         ChallengeResponse.Detail response = challengeService.save(UserFixtures.회원, request);
 
         /* then */
-        verifyChallengeResponse(ChallengeFixtures.챌린지(), response);
+        verifyChallengeResponse(챌린지(), response);
+        assertEquals(초기_참여자_수, response.participantCount());
+        assertEquals(초기_북마크_수, response.bookmark().bookmarkCount());
+        assertEquals(false, response.bookmark().bookmarked());
     }
 
     @Test
     @DisplayName("챌린지 단일 조회 시 챌린지 정보를 반환한다.")
     void 챌린지_단일_조회_시_챌린지_정보를_반환한다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        Challenge challenge = ChallengeFixtures.챌린지();
+        Long challengeId = 챌린지_ID;
+        Challenge challenge = 챌린지();
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
+        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(참여자_수);
+        when(challengeBookmarkService.getChallengeBookmarkCount(any()))
+                .thenReturn(북마크_수);
+        when(challengeBookmarkService.isBookmarked(any(), any()))
+                .thenReturn(false);
 
         /* when */
-        ChallengeResponse.Detail response = challengeService.find(challengeId);
+        ChallengeResponse.Detail response = challengeService.find(UserFixtures.회원, challengeId);
 
         /* then */
         verifyChallengeResponse(challenge, response);
+        assertEquals(참여자_수, response.participantCount());
+        assertEquals(북마크_수, response.bookmark().bookmarkCount());
+        assertEquals(false, response.bookmark().bookmarked());
+    }
+
+    @Test
+    @DisplayName("챌린지 단일 조회 시 로그아웃 상태인 경우 null 북마크 정보를 담은 챌린지 정보를 반환한다.")
+    void 챌린지_단일_조회_시_로그아웃_상태인_경우_null_북마크_정보를_담은_챌린지_정보를_반환한다 () {
+        /* given */
+        Long challengeId = 챌린지_ID;
+        Challenge challenge = 챌린지();
+
+        when(challengeRepository.findById(challengeId))
+                .thenReturn(Optional.of(challenge));
+        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(참여자_수);
+        when(challengeBookmarkService.getChallengeBookmarkCount(any()))
+                .thenReturn(북마크_수);
+
+        /* when */
+        ChallengeResponse.Detail response = challengeService.find(null, challengeId);
+
+        /* then */
+        verifyChallengeResponse(challenge, response);
+        assertEquals(참여자_수, response.participantCount());
+        assertEquals(북마크_수, response.bookmark().bookmarkCount());
+        assertEquals(null, response.bookmark().bookmarked());
     }
 
     @Test
     @DisplayName("챌린지 단일 조회 시 존재하지 않는 챌린지 ID가 주어지면 예외를 던진다.")
     void 챌린지_단일_조회_시_존재하지_않는_챌린지_ID가_주어지면_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long challengeId = 챌린지_ID;
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.empty());
 
         /* when */
         /* then */
-        assertThrows(NotFoundChallengeException.class, () -> challengeService.find(challengeId));
+        assertThrows(NotFoundChallengeException.class, () -> challengeService.find(UserFixtures.회원, challengeId));
     }
 
     @Test
-    @DisplayName("챌린지 조회 시 요청에 따른 필터링된 챌린지 정보를 반환한다.")
-    void 챌린지_조회_시_요청에_따른_필터링된_챌린지_정보를_반환한다 () {
+    @DisplayName("챌린지 목록 조회 시 요청에 따른 필터링된 챌린지 정보를 반환한다.")
+    void 챌린지_목록_조회_시_요청에_따른_필터링된_챌린지_정보를_반환한다 () {
         /* given */
-        ChallengeRequest.Read request = ChallengeFixtures.챌린지_조회_요청;
+        ChallengeRequest.Read request = 챌린지_조회_요청;
 
-        when(challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), ChallengeFixtures.페이지_요청))
-                .thenReturn(ChallengeFixtures.챌린지_페이지);
+        when(challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), 페이지_요청))
+                .thenReturn(챌린지_페이지);
+        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(참여자_수);
+        when(challengeBookmarkService.getChallengeBookmarkCount(any()))
+                .thenReturn(북마크_수);
+        when(challengeBookmarkService.isBookmarked(any(), any()))
+                .thenReturn(false);
 
         /* when */
-        PageResponse<ChallengeResponse.Summary> response = challengeService.findAll(request, ChallengeFixtures.페이지_요청);
+        PageResponse<ChallengeResponse.Preview> response = challengeService.findAll(UserFixtures.회원, request, 페이지_요청);
 
         /* then */
-        assertEquals(ChallengeFixtures.챌린지_페이지_응답.totalElements(), response.totalElements());
+        assertEquals(챌린지_페이지_응답.totalElements(), response.totalElements());
     }
 
     @Test
     @DisplayName("챌린지 정보 수정 시 수정된 챌린지 정보를 반환한다.")
     void 챌린지_정보_수정_시_수정된_챌린지_정보를_반환한다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateContent request = 챌린지_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+                .thenReturn(Optional.of(챌린지()));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), eq(challengeId), eq(ChallengeRole.LEADER)))
+                .thenReturn(true);
+        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(참여자_수);
+        when(challengeBookmarkService.getChallengeBookmarkCount(any()))
+                .thenReturn(북마크_수);
+        when(challengeBookmarkService.isBookmarked(any(), any()))
+                .thenReturn(false);
 
         /* when */
         ChallengeResponse.Detail response = challengeService.updateContent(UserFixtures.회원, challengeId, request);
 
         /* then */
-        verifyChallengeResponse(ChallengeFixtures.내용_수정된_챌린지, response);
+        verifyChallengeResponse(내용_수정된_챌린지, response);
+        assertEquals(참여자_수, response.participantCount());
+        assertEquals(북마크_수, response.bookmark().bookmarkCount());
+        assertEquals(false, response.bookmark().bookmarked());
     }
 
     @Test
     @DisplayName("챌린지 정보 수정 시 리더가 아닌 경우 예외를 던진다.")
     void 챌린지_정보_수정_시_리더가_아닌_경우_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateContent request = 챌린지_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_멤버_참여()));
+                .thenReturn(Optional.of(챌린지()));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), eq(challengeId), eq(ChallengeRole.LEADER)))
+                .thenReturn(false);
 
         /* when */
         /* then */
@@ -143,13 +200,13 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 정보 수정 시 진행 예정 챌린지가 아닌 경우 예외를 던진다.")
     void 챌린지_정보_수정_시_진행_예정_챌린지가_아닌_경우_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateContent request = 챌린지_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+                .thenReturn(Optional.of(진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), eq(challengeId), eq(ChallengeRole.LEADER)))
+                .thenReturn(true);
 
         /* when */
         /* then */
@@ -160,8 +217,8 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 정보 수정 시 존재하지 않는 챌린지 ID가 주어지면 예외를 던진다.")
     void 챌린지_정보_수정_시_존재하지_않는_챌린지_ID가_주어지면_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateContent request = 챌린지_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.empty());
@@ -175,32 +232,41 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 인증 정보 수정 시 수정된 챌린지 정보를 반환한다.")
     void 챌린지_인증_정보_수정_시_수정된_챌린지_정보를_반환한다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateProof request = 챌린지_인증_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+                .thenReturn(Optional.of(챌린지()));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
+                .thenReturn(true);
+        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(참여자_수);
+        when(challengeBookmarkService.getChallengeBookmarkCount(any()))
+                .thenReturn(북마크_수);
+        when(challengeBookmarkService.isBookmarked(any(), any()))
+                .thenReturn(false);
 
         /* when */
         ChallengeResponse.Detail response = challengeService.updateProof(UserFixtures.회원, challengeId, request);
 
         /* then */
-        verifyChallengeResponse(ChallengeFixtures.인증_내용_수정된_챌린지, response);
+        verifyChallengeResponse(인증_내용_수정된_챌린지, response);
+        assertEquals(참여자_수, response.participantCount());
+        assertEquals(북마크_수, response.bookmark().bookmarkCount());
+        assertEquals(false, response.bookmark().bookmarked());
     }
 
     @Test
     @DisplayName("챌린지 인증 정보 수정 시 리더가 아닌 경우 예외를 던진다.")
     void 챌린지_인증_정보_수정_시_리더가_아닌_경우_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateProof request = 챌린지_인증_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_멤버_참여()));
+                .thenReturn(Optional.of(챌린지()));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
+                .thenReturn(false);
 
         /* when */
         /* then */
@@ -211,13 +277,13 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 인증 정보 수정 시 진행 예정 챌린지가 아닌 경우 예외를 던진다")
     void 챌린지_인증_정보_수정_시_진행_예정_챌린지가_아닌_경우_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateProof request = 챌린지_인증_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+                .thenReturn(Optional.of(진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
+                .thenReturn(true);
 
         /* when */
         /* then */
@@ -228,8 +294,8 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 인증 정보 수정 시 존재하지 않는 챌린지 ID가 주어지면 예외를 던진다.")
     void 챌린지_인증_정보_수정_시_존재하지_않는_챌린지_ID가_주어지면_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
-        ChallengeRequest.UpdateProof request = ChallengeFixtures.챌린지_인증_내용_수정_요청;
+        Long challengeId = 챌린지_ID;
+        ChallengeRequest.UpdateProof request = 챌린지_인증_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.empty());
@@ -243,15 +309,16 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 삭제 시 챌린지를 삭제한다.")
     void 챌린지_삭제_시_챌린지를_삭제한다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long challengeId = 챌린지_ID;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+                .thenReturn(Optional.of(챌린지()));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
+                .thenReturn(true);
 
         doNothing().when(challengeRepository).delete(any(Challenge.class));
         doNothing().when(challengeParticipationRepository).deleteAllByChallengeId(challengeId);
+        doNothing().when(challengeBookmarkService).removeBookmarksByChallenge(challengeId);
 
         /* when */
         /* then */
@@ -259,18 +326,19 @@ class ChallengeServiceTest {
 
         verify(challengeRepository, atLeastOnce()).delete(any(Challenge.class));
         verify(challengeParticipationRepository, atLeastOnce()).deleteAllByChallengeId(challengeId);
+        verify(challengeBookmarkService, atLeastOnce()).removeBookmarksByChallenge(challengeId);
     }
 
     @Test
     @DisplayName("챌린지 삭제 시 리더가 아닌 경우 예외를 던진다.")
     void 챌린지_삭제_시_리더가_아닌_경우_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long challengeId = 챌린지_ID;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.챌린지()));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_멤버_참여()));
+                .thenReturn(Optional.of(챌린지()));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
+                .thenReturn(false);
 
         /* when */
         /* then */
@@ -281,12 +349,12 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 삭제 시 진행 중인 챌린지인 경우 예외를 던진다.")
     void 챌린지_삭제_시_진행_중인_챌린지인_경우_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long challengeId = 챌린지_ID;
 
         when(challengeRepository.findById(challengeId))
-                .thenReturn(Optional.of(ChallengeFixtures.진행중인_챌린지));
-        when(challengeParticipationRepository.findByUserIdAndChallengeId(UserFixtures.회원.getId(), challengeId))
-                .thenReturn(Optional.of(ChallengeParticipationFixtures.챌린지_리더_참여()));
+                .thenReturn(Optional.of(진행중인_챌린지));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
+                .thenReturn(true);
 
         /* when */
         /* then */
@@ -297,7 +365,7 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 삭제 시 존재하지 않는 챌린지 ID가 주어지면 예외를 던진다.")
     void 챌린지_삭제_시_존재하지_않는_챌린지_ID가_주어지면_예외를_던진다 () {
         /* given */
-        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long challengeId = 챌린지_ID;
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.empty());

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/entity/ChallengeBookmark.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/entity/ChallengeBookmark.java
@@ -1,0 +1,31 @@
+package com.trybe.modulecore.challenge.entity;
+
+import com.trybe.modulecore.common.entity.BaseEntity;
+import com.trybe.modulecore.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "challenge_bookmarks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChallengeBookmark extends BaseEntity {
+    public ChallengeBookmark(Challenge challenge, User user) {
+        this.challenge = challenge;
+        this.user = user;
+    }
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id", nullable = false, updatable = false)
+    private Challenge challenge;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, updatable = false)
+    private User user;
+}

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeBookmarkRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeBookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.trybe.modulecore.challenge.repository;
+
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChallengeBookmarkRepository extends JpaRepository<ChallengeBookmark, Long> {
+}


### PR DESCRIPTION
- `Challenge` 관련 서비스, 컨트롤러 코드 수정
  - 챌린지 수정 및 삭제 시 수행자가 리더인지 확인하는 로직 간소화
  - 챌린지 목록 조회 시, Preview 응답을 담아 반환하도록 수정
  - 챌린지 응답에 현재 참여 인원 수와 북마크 정보 추가
  - 챌린지 삭제 시 북마크 정보도 함께 삭제될 수 있도록 수정
  - 코드 변경에 따른 테스트코드 수정
- `ChallengeBookmark` 엔티티 및 리포지토리 구현
- `ChallengeBookmarkService`, `ChallengeBookmarkController` 구현
  - 북마크 추가, 북마크 삭제, 나의 북마크 챌린지 목록 조회
- `ChallengeBookmarkController`에 대한 HTTP 요청 파일 작성