### PR TITLE
[#44] 챌린지 북마크 테스트 코드 작성

### DIFF
--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -348,7 +348,51 @@ include::{snippets}/challenge-controller-test/delete/invalid/conflict/response-f
 include::{snippets}/challenge-controller-test/delete/invalid/not-found/http-response.adoc[]
 include::{snippets}/challenge-controller-test/delete/invalid/not-found/response-fields.adoc[]
 
----
+== 챌린지 북마크 API
+
+=== 챌린지 북마크 추가
+챌린지 ID에 해당하는 챌린지를 북마크에 추가합니다.
+
+==== 정상 요청
+include::{snippets}/challenge-bookmark-controller-test/add/http-request.adoc[]
+include::{snippets}/challenge-bookmark-controller-test/add/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/challenge-bookmark-controller-test/add/http-response.adoc[]
+include::{snippets}/challenge-bookmark-controller-test/add/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지)
+존재하지 않는 챌린지 ID로 북마크 추가를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/challenge-bookmark-controller-test/add/invalid/not-found/http-response.adoc[]
+include::{snippets}/challenge-bookmark-controller-test/add/invalid/not-found/response-fields.adoc[]
+
+=== 챌린지 북마크 삭제
+챌린지 ID에 해당하는 챌린지를 북마크에서 삭제합니다.
+
+==== 정상 요청
+include::{snippets}/challenge-bookmark-controller-test/remove/http-request.adoc[]
+include::{snippets}/challenge-bookmark-controller-test/remove/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/challenge-bookmark-controller-test/remove/http-response.adoc[]
+include::{snippets}/challenge-bookmark-controller-test/remove/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지)
+존재하지 않는 챌린지 ID로 북마크 삭제를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/challenge-bookmark-controller-test/remove/invalid/not-found/http-response.adoc[]
+include::{snippets}/challenge-bookmark-controller-test/remove/invalid/not-found/response-fields.adoc[]
+
+=== 나의 챌린지 북마크 목록 조회
+나의 챌린지 북마크 목록을 조회합니다.
+
+==== 정상 요청
+include::{snippets}/challenge-bookmark-controller-test/my/http-request.adoc[]
+
+- 응답
+include::{snippets}/challenge-bookmark-controller-test/my/http-response.adoc[]
+include::{snippets}/challenge-bookmark-controller-test/my/response-fields.adoc[]
 
 == 챌린지 참여 API
 

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkControllerTest.java
@@ -1,0 +1,215 @@
+package com.trybe.moduleapi.challenge.controller;
+
+import com.trybe.moduleapi.annotation.WithCustomMockUser;
+import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
+import com.trybe.moduleapi.challenge.service.ChallengeBookmarkService;
+import com.trybe.moduleapi.common.ControllerTest;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static com.trybe.moduleapi.challenge.fixtures.ChallengeBookmarkFixtures.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ChallengeBookmarkController.class)
+class ChallengeBookmarkControllerTest extends ControllerTest {
+    @MockitoBean
+    private ChallengeBookmarkService challengeBookmarkService;
+
+    private final String endpoint = "/api/v1/challenges/bookmarks";
+
+    private final String docsPath = "challenge-bookmark-controller-test/";
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("챌린지 북마크 추가 요청 시 응답코드 200을 반환한다.")
+    void 챌린지_북마크_추가_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(challengeBookmarkService.addBookmark(any(User.class), eq(challengeId)))
+                .thenReturn(북마크_참_응답);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{challengeId}", challengeId));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.bookmarkCount").value(북마크_참_응답.bookmarkCount()),
+                jsonPath("$.bookmarked").value(북마크_참_응답.bookmarked())
+        );
+
+        result.andDo(document(docsPath + "add",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("challengeId").description("북마크 추가할 챌린지 ID")
+                ),
+                responseFields(
+                        fieldWithPath("bookmarkCount").description("챌린지의 북마크 수"),
+                        fieldWithPath("bookmarked").description("북마크 여부")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 챌린지에 대해 북마크 추가 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_챌린지에_대해_북마크_추가_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
+
+        when(challengeBookmarkService.addBookmark(any(User.class), eq(challengeId)))
+                .thenThrow(new NotFoundChallengeException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{challengeId}", challengeId));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "add" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("챌린지 북마크 삭제 요청 시 응답코드 200을 반환한다.")
+    void 챌린지_북마크_삭제_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+
+        when(challengeBookmarkService.removeBookmark(any(User.class), eq(challengeId)))
+                .thenReturn(북마크_거짓_응답);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{challengeId}", challengeId));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.bookmarkCount").value(북마크_거짓_응답.bookmarkCount()),
+                jsonPath("$.bookmarked").value(북마크_거짓_응답.bookmarked())
+        );
+
+        result.andDo(document(docsPath + "remove",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("challengeId").description("북마크 삭제할 챌린지 ID")
+                ),
+                responseFields(
+                        fieldWithPath("bookmarkCount").description("챌린지의 북마크 수"),
+                        fieldWithPath("bookmarked").description("북마크 여부")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 챌린지에 대해 북마크 삭제 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_챌린지에_대해_북마크_삭제_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
+
+        when(challengeBookmarkService.removeBookmark(any(User.class), eq(challengeId)))
+                .thenThrow(new NotFoundChallengeException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{challengeId}", challengeId));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "remove" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("나의 북마크 챌린지 목록 조회 요청 시 응답코드 200을 반환한다.")
+    void 나의_북마크_챌린지_목록_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        PageResponse<ChallengeResponse.Preview> response = ChallengeFixtures.챌린지_미리보기_페이지_응답;
+
+        when(challengeBookmarkService.getMyBookmarkedChallenges(any(User.class), any()))
+                .thenReturn(response);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/my"));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.content").isArray(),
+                jsonPath("$.content[0].id").value(response.content().get(0).id()),
+                jsonPath("$.content[0].title").value(response.content().get(0).title()),
+                jsonPath("$.content[0].description").value(response.content().get(0).description()),
+                jsonPath("$.content[0].status").value(response.content().get(0).status().name()),
+                jsonPath("$.content[0].category").value(response.content().get(0).category().name()),
+                jsonPath("$.content[0].capacity").value(response.content().get(0).capacity()),
+                jsonPath("$.content[0].participantCount").value(response.content().get(0).participantCount()),
+                jsonPath("$.content[0].bookmark.bookmarkCount").value(response.content().get(0).bookmark().bookmarkCount()),
+                jsonPath("$.content[0].bookmark.bookmarked").value(response.content().get(0).bookmark().bookmarked()),
+                jsonPath("$.totalPages").value(response.totalPages()),
+                jsonPath("$.totalElements").value(response.totalElements()),
+                jsonPath("$.size").value(response.size()),
+                jsonPath("$.number").value(response.number()),
+                jsonPath("$.last").value(response.last())
+        );
+
+        result.andDo(document(docsPath + "my",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("content").description("챌린지 목록"),
+                        fieldWithPath("content[].id").description("챌린지 ID"),
+                        fieldWithPath("content[].title").description("챌린지 제목"),
+                        fieldWithPath("content[].description").description("챌린지 설명"),
+                        fieldWithPath("content[].status").description("챌린지 상태"),
+                        fieldWithPath("content[].category").description("챌린지 카테고리"),
+                        fieldWithPath("content[].capacity").description("챌린지 인원"),
+                        fieldWithPath("content[].participantCount").description("참여자 수"),
+                        fieldWithPath("content[].bookmark.bookmarkCount").description("북마크 수"),
+                        fieldWithPath("content[].bookmark.bookmarked").description("북마크 여부"),
+                        fieldWithPath("totalPages").description("전체 페이지 수"),
+                        fieldWithPath("totalElements").description("전체 요소 수"),
+                        fieldWithPath("size").description("페이지 크기"),
+                        fieldWithPath("number").description("현재 페이지 번호"),
+                        fieldWithPath("last").description("마지막 페이지 여부")
+                )
+        ));
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -34,10 +34,6 @@ class ChallengeControllerTest extends ControllerTest {
     private String endpoint = "/api/v1/challenges";
 
     private String docsPath = "challenge-controller-test/";
-    private final String invalidBadRequestPath = "invalid/bad-request/";
-    private final String invalidNotFoundPath = "invalid/not-found/";
-    private final String invalidForbiddenPath = "invalid/forbidden/";
-    private final String invalidConflictPath = "invalid/conflict/";
 
     @Test
     @WithCustomMockUser
@@ -69,7 +65,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.proofCount").value(request.proofCount()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.초기_북마크_수),
-                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_거짓)
         );
 
         result.andDo(document(docsPath + "create",
@@ -182,7 +178,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.proofCount").value(ChallengeFixtures.챌린지_상세_응답.proofCount()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
-                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)
         );
 
         result.andDo(document(docsPath + "find",
@@ -352,7 +348,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.proofCount").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.proofCount()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
-                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)
         );
 
         result.andDo(document(docsPath + "update-content",
@@ -563,7 +559,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.proofCount").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofCount()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
-                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부)
+                jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)
         );
 
         result.andDo(document(docsPath + "update-proof",

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeBookmarkFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeBookmarkFixtures.java
@@ -1,0 +1,33 @@
+package com.trybe.moduleapi.challenge.fixtures;
+
+import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ChallengeBookmarkFixtures {
+    public static final int 초기_북마크_수 = 0;
+    public static final int 북마크_수 = 5;
+    public static final Boolean 북마크_여부_참 = true;
+    public static final Boolean 북마크_여부_거짓 = false;
+
+    public static final Set<Long> 북마크된_챌린지_ID_목록 = new LinkedHashSet<>(List.of(2L, 3L, 1L));
+    public static final Set<Long> 빈_북마크된_챌린지_ID_목록 = new LinkedHashSet<>();
+
+    /* Response DTO */
+    public static final ChallengeResponse.Bookmark 초기_북마크_응답 = new ChallengeResponse.Bookmark(
+            초기_북마크_수,
+            false
+    );
+
+    public static final ChallengeResponse.Bookmark 북마크_참_응답 = new ChallengeResponse.Bookmark(
+            북마크_수,
+            북마크_여부_참
+    );
+
+    public static final ChallengeResponse.Bookmark 북마크_거짓_응답 = new ChallengeResponse.Bookmark(
+            북마크_수,
+            북마크_여부_거짓
+    );
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -50,11 +50,12 @@ public class ChallengeFixtures {
     public static final int 잘못된_챌린지_인증_횟수 = 0;
     public static final int 수정된_챌린지_인증_횟수 = 14;
 
-    public static final int 초기_북마크_수 = 0;
+    public static final int 초기_북마크_수 = ChallengeBookmarkFixtures.초기_북마크_수;
     public static final int 초기_참여자_수 = 1;
-    public static final int 북마크_수 = 5;
+    public static final int 북마크_수 = ChallengeBookmarkFixtures.북마크_수;
     public static final int 참여자_수 = 3;
-    public static final Boolean 북마크_여부 = true;
+    public static final Boolean 북마크_여부_참 = ChallengeBookmarkFixtures.북마크_여부_참;
+    public static final Boolean 북마크_여부_거짓 = ChallengeBookmarkFixtures.북마크_여부_거짓;
 
     /* Request DTO */
     public static final ChallengeRequest.Create 챌린지_생성_요청 = new ChallengeRequest.Create(
@@ -177,23 +178,23 @@ public class ChallengeFixtures {
     public static ChallengeStatus 대기중 = ChallengeStatus.PENDING;
 
     /* Response DTO */
-    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 초기_참여자_수, 초기_북마크_수, 북마크_여부);
-    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부);
+    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 초기_참여자_수, 초기_북마크_수, 북마크_여부_거짓);
+    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부_참);
 
-    public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부);
-    public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부);
+    public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
+    public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부_참);
 
     public static final ChallengeResponse.Summary 챌린지_요약_응답 = 챌린지_요약_응답_생성(챌린지());
 
-    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부);
+    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부_참);
 
-    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부);
+    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부_참);
 
     public static final List<ChallengeResponse.Summary> 챌린지_목록_응답 = 챌린지_목록.stream().map(ChallengeResponse.Summary::from).collect(Collectors.toList());
-    public static final List<ChallengeResponse.Preview> 챌린지_미리보기_목록_응답 = 챌린지_목록.stream().map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부)).collect(Collectors.toList());
+    public static final List<ChallengeResponse.Preview> 챌린지_미리보기_목록_응답 = 챌린지_목록.stream().map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부_참)).collect(Collectors.toList());
 
     public static final PageResponse<ChallengeResponse.Summary> 챌린지_페이지_응답 = new PageResponse<>(챌린지_페이지.map(ChallengeResponse.Summary::from));
-    public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부)));
+    public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부_참)));
 
     private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, boolean Bookmarked) {
         return new ChallengeResponse.Detail(

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkServiceTest.java
@@ -1,0 +1,319 @@
+package com.trybe.moduleapi.challenge.service;
+
+import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
+import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.challenge.repository.ChallengeRepository;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.trybe.moduleapi.challenge.fixtures.ChallengeBookmarkFixtures.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeBookmarkServiceTest {
+    @InjectMocks
+    private ChallengeBookmarkService challengeBookmarkService;
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @Mock
+    private ChallengeParticipationRepository challengeParticipationRepository;
+
+    @Mock
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @BeforeEach
+    void setUpd() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(mock());
+        lenient().when(redisTemplate.opsForSet()).thenReturn(mock());
+        lenient().when(redisTemplate.opsForZSet()).thenReturn(mock());
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 추가 시 북마크 정보를 반환한다.")
+    void 챌린지_북마크_추가_시_북마크_정보를_반환한다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(challengeRepository.existsById(challengeId))
+                .thenReturn(true);
+        when(redisTemplate.opsForValue().get(any(String.class)))
+                .thenReturn((long) 북마크_수);
+        when(redisTemplate.opsForSet().isMember(any(String.class), any(Long.class)))
+                .thenReturn(false);
+
+        /* when */
+        ChallengeResponse.Bookmark result = challengeBookmarkService.addBookmark(user, challengeId);
+
+        /* then */
+        verify(redisTemplate.opsForZSet(), times(1)).add(any(String.class), any(Long.class), any(Double.class));
+        verify(redisTemplate.opsForSet(), times(1)).add(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForSet(), times(1)).remove(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForValue(), times(1)).increment(any(String.class), any(Long.class));
+
+        assertEquals(북마크_수 + 1, result.bookmarkCount());
+        assertEquals(북마크_여부_참, result.bookmarked());
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 추가 시 이미 북마크 한 경우 북마크 정보를 반환한다.")
+    void 챌린지_북마크_추가_시_이미_북마크_한_경우_북마크_정보를_반환한다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(challengeRepository.existsById(challengeId))
+                .thenReturn(true);
+        when(redisTemplate.opsForValue().get(any(String.class)))
+                .thenReturn((long) 북마크_수);
+        when(redisTemplate.opsForSet().isMember(any(String.class), any(Long.class)))
+                .thenReturn(true);
+
+        /* when */
+        ChallengeResponse.Bookmark result = challengeBookmarkService.addBookmark(user, challengeId);
+
+        /* then */
+        verify(redisTemplate.opsForZSet(), never()).add(any(String.class), any(Long.class), any(Double.class));
+        verify(redisTemplate.opsForSet(), never()).add(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForSet(), never()).remove(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForValue(), never()).increment(any(String.class), any(Long.class));
+
+        assertEquals(북마크_수, result.bookmarkCount());
+        assertEquals(북마크_여부_참, result.bookmarked());
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 추가 시 존재하지 않는 챌린지인 경우 예외를 던진다.")
+    void 챌린지_북마크_추가_시_존재하지_않는_챌린지인_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
+
+        when(challengeRepository.existsById(challengeId))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundChallengeException.class, () -> challengeBookmarkService.addBookmark(UserFixtures.회원, challengeId));
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 삭제 시 북마크 정보를 반환한다.")
+    void 챌린지_북마크_삭제_시_북마크_정보를_반환한다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(challengeRepository.existsById(challengeId))
+                .thenReturn(true);
+        when(redisTemplate.opsForValue().get(any(String.class)))
+                .thenReturn((long) 북마크_수);
+        when(redisTemplate.opsForSet().isMember(any(String.class), any(Long.class)))
+                .thenReturn(true);
+
+        /* when */
+        ChallengeResponse.Bookmark result = challengeBookmarkService.removeBookmark(user, challengeId);
+
+        /* then */
+        verify(redisTemplate.opsForZSet(), times(1)).remove(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForSet(), times(1)).remove(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForSet(), times(1)).add(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForValue(), times(1)).decrement(any(String.class), any(Long.class));
+
+        assertEquals(북마크_수 - 1, result.bookmarkCount());
+        assertEquals(북마크_여부_거짓, result.bookmarked());
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 삭제 시 북마크 하지 않은 경우 북마크 정보를 반환한다.")
+    void 챌린지_북마크_삭제_시_북마크_하지_않은_경우_북마크_정보를_반환한다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(challengeRepository.existsById(challengeId))
+                .thenReturn(true);
+        when(redisTemplate.opsForValue().get(any(String.class)))
+                .thenReturn((long) 북마크_수);
+        when(redisTemplate.opsForSet().isMember(any(String.class), any(Long.class)))
+                .thenReturn(false);
+
+        /* when */
+        ChallengeResponse.Bookmark result = challengeBookmarkService.removeBookmark(user, challengeId);
+
+        /* then */
+        verify(redisTemplate.opsForZSet(), never()).remove(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForSet(), never()).remove(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForSet(), never()).add(any(String.class), any(Long.class));
+        verify(redisTemplate.opsForValue(), never()).decrement(any(String.class), any(Long.class));
+
+        assertEquals(북마크_수, result.bookmarkCount());
+        assertEquals(북마크_여부_거짓, result.bookmarked());
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 삭제 시 존재하지 않는 챌린지인 경우 예외를 던진다.")
+    void 챌린지_북마크_삭제_시_존재하지_않는_챌린지인_경우_예외를_던진다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
+
+        when(challengeRepository.existsById(challengeId))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundChallengeException.class, () -> challengeBookmarkService.removeBookmark(UserFixtures.회원, challengeId));
+    }
+
+    @Test
+    @DisplayName("나의 북마크 챌린지 목록 조회 시 북마크된 챌린지 목록을 반환한다.")
+    void 나의_북마크_챌린지_목록_조회_시_북마크된_챌린지_목록을_반환한다 () {
+        /* given */
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+        Set<Long> challengeIds = 북마크된_챌린지_ID_목록;
+
+        List<Challenge> challenges = List.of(spy(ChallengeFixtures.챌린지()), spy(ChallengeFixtures.챌린지()), spy(ChallengeFixtures.챌린지()));
+
+        for(int i = 0; i < challenges.size(); i++) {
+            when(challenges.get(i).getId()).thenReturn((long) i + 1);
+        }
+
+        when(user.getId()).thenReturn(userId);
+        when(redisTemplate.opsForZSet().reverseRange(any(String.class), any(Long.class), any(Long.class)))
+                .thenReturn(challengeIds);
+        when(challengeRepository.findAllByIdIn(any(Set.class)))
+                .thenReturn(challenges);
+        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(Long.class), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(ChallengeFixtures.참여자_수);
+        when(redisTemplate.opsForValue().get(any(String.class)))
+                .thenReturn((long) 북마크_수);
+        when(redisTemplate.opsForZSet().size(any(String.class)))
+                .thenReturn((long) challengeIds.size());
+
+        /* when */
+        PageResponse<ChallengeResponse.Preview> result = challengeBookmarkService.getMyBookmarkedChallenges(user, ChallengeFixtures.페이지_요청);
+
+        /* then */
+        List<Long> expectedOrder = new ArrayList<>(challengeIds);
+        List<Long> actualOrder = result.content().stream()
+                .map(ChallengeResponse.Preview::id)
+                .collect(Collectors.toList());
+
+        assertEquals(expectedOrder, actualOrder);
+
+        assertEquals(challengeIds.size(), result.content().size());
+        assertEquals(challengeIds.size(), result.totalElements());
+    }
+
+    @Test
+    @DisplayName("나의 북마크 챌린지 목록 조회 시 북마크된 챌린지가 없는 경우 빈 목록을 반환한다.")
+    void 나의_북마크_챌린지_목록_조회_시_북마크된_챌린지가_없는_경우_빈_목록을_반환한다 () {
+        /* given */
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(redisTemplate.opsForZSet().reverseRange(any(String.class), any(Long.class), any(Long.class)))
+                .thenReturn(빈_북마크된_챌린지_ID_목록);
+        when(redisTemplate.opsForZSet().size(any(String.class)))
+                .thenReturn(0L);
+
+        /* when */
+        PageResponse<ChallengeResponse.Preview> result = challengeBookmarkService.getMyBookmarkedChallenges(user, ChallengeFixtures.페이지_요청);
+
+        /* then */
+        verify(challengeRepository, never()).findAllByIdIn(any(Set.class));
+        verify(challengeParticipationRepository, never()).countByChallengeIdAndStatus(any(Long.class), eq(ParticipationStatus.ACCEPTED));
+        verify(redisTemplate.opsForValue(), never()).get(any(String.class));
+
+        assertEquals(0, result.content().size());
+        assertEquals(0, result.totalElements());
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 여부 조회 시 북마크 여부를 반환한다.")
+    void 챌린지_북마크_여부_조회_시_북마크_여부를_반환한다 () {
+        /* given */
+        Long userId = UserFixtures.회원_PK;
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        boolean bookmarked = true;
+
+        when(redisTemplate.opsForSet().isMember(any(String.class), any(Long.class)))
+                .thenReturn(bookmarked);
+
+        /* when */
+        boolean result = challengeBookmarkService.isBookmarked(userId, challengeId);
+
+        /* then */
+        assertEquals(bookmarked, result);
+    }
+
+    @Test
+    @DisplayName("챌린지 북마크 수 조회 시 북마크 수를 반환한다.")
+    void 챌린지_북마크_수_조회_시_북마크_수를_반환한다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        int bookmarkCount = 북마크_수;
+
+        when(redisTemplate.opsForValue().get(any(String.class)))
+                .thenReturn((long) bookmarkCount);
+
+        /* when */
+        int result = challengeBookmarkService.getChallengeBookmarkCount(challengeId);
+
+        /* then */
+        assertEquals(bookmarkCount, result);
+    }
+
+    @Test
+    @DisplayName("챌린지에 대한 모든 북마크를 삭제한다.")
+    void 챌린지에_대한_모든_북마크를_삭제한다 () {
+        /* given */
+        Long challengeId = ChallengeFixtures.챌린지_ID;
+        Set<Long> userIds = Set.of(1L, 2L);
+
+        when(redisTemplate.opsForSet().members(any(String.class)))
+                .thenReturn(userIds);
+        when(redisTemplate.opsForZSet().remove(any(String.class), any(Long.class)))
+                .thenReturn(1L);
+        when(redisTemplate.delete(any(List.class)))
+                .thenReturn(3L);
+
+        /* when */
+        challengeBookmarkService.removeBookmarksByChallenge(challengeId);
+
+        /* then */
+        verify(redisTemplate.opsForZSet(), times(userIds.size())).remove(any(String.class), any(Long.class));
+        verify(redisTemplate, times(1)).delete(any(List.class));
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/common/ControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/common/ControllerTest.java
@@ -34,4 +34,9 @@ public abstract class ControllerTest {
 
     @MockitoBean
     protected CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    protected final String invalidBadRequestPath = "/invalid/bad-request/";
+    protected final String invalidNotFoundPath = "/invalid/not-found/";
+    protected final String invalidForbiddenPath = "/invalid/forbidden/";
+    protected final String invalidConflictPath = "/invalid/conflict/";
 }


### PR DESCRIPTION
- ControllerTest 내에 Rest Docs 관련 Invalid Path 선언
- 챌린지 북마크에 대한 테스트 코드 작성
  - `ChallengeBookmarkFixtures` 작성
  - `ChallengeBookmarkServiceTest` 작성
  - `ChallengeBookmarkControllerTest` 작성
- Spring Rest Docs의 index.adoc 파일 수정
  - 챌린지 북마크 API에 대한 문서 추가