### PR TITLE
[#41] 인증 히스토리 테스트 코드 작성

### DIFF
--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -676,7 +676,135 @@ include::{snippets}/proof-controller-test/delete/invalid/forbidden/response-fiel
 include::{snippets}/proof-controller-test/delete/invalid/bad-request/http-response.adoc[]
 include::{snippets}/proof-controller-test/delete/invalid/bad-request/response-fields.adoc[]
 
----
+== 챌린지 인증 기록 API
+
+=== 챌린지 인증 기록 생성
+챌린지 인증 기록을 생성합니다.
+
+==== 정상 요청
+include::{snippets}/proof-history-controller-test/save/http-request.adoc[]
+include::{snippets}/proof-history-controller-test/save/path-parameters.adoc[]
+include::{snippets}/proof-history-controller-test/save/request-fields.adoc[]
+
+- 응답
+include::{snippets}/proof-history-controller-test/save/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/save/response-fields.adoc[]
+
+==== 비정상 요청 (잘못된 요청)
+유효성 검증에 실패하는 요청 시 다음과 같이 반환합니다.
+include::{snippets}/proof-history-controller-test/save/invalid/bad-request/http-request.adoc[]
+
+- 응답
+include::{snippets}/proof-history-controller-test/save/invalid/bad-request/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/save/invalid/bad-request/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지 인증)
+존재하지 않는 챌린지 인증 ID로 인증 기록을 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/save/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/save/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (챌린지 멤버가 아닌 사용자)
+챌린지 멤버가 아닌 사용자가 인증 기록을 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/save/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/save/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (인증 날짜가 아닌 경우)
+인증 날짜가 아닌 날짜에 인증 기록을 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/save/invalid/bad-request/date/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/save/invalid/bad-request/date/response-fields.adoc[]
+
+==== 비정상 요청 (이미 인증 기록이 존재하는 경우)
+인증 기록이 이미 존재하는 경우, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/save/invalid/conflict/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/save/invalid/conflict/response-fields.adoc[]
+
+=== 챌린지 인증 기록 목록 조회
+챌린지 인증 ID에 대한 챌린지 인증 기록 목록을 조회합니다.
+
+==== 정상 요청
+include::{snippets}/proof-history-controller-test/findAll/http-request.adoc[]
+include::{snippets}/proof-history-controller-test/findAll/path-parameters.adoc[]
+include::{snippets}/proof-history-controller-test/findAll/query-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-history-controller-test/findAll/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/findAll/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지 인증)
+존재하지 않는 챌린지 인증 ID로 인증 기록 목록을 조회했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/findAll/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/findAll/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (챌린지 멤버가 아닌 사용자)
+챌린지 멤버가 아닌 사용자가 인증 기록 목록 조회를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/findAll/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/findAll/invalid/forbidden/response-fields.adoc[]
+
+=== 챌린지 인증 기록 수정
+챌린지 인증 기록을 수정합니다.
+
+==== 정상 요청
+include::{snippets}/proof-history-controller-test/update/http-request.adoc[]
+include::{snippets}/proof-history-controller-test/update/path-parameters.adoc[]
+include::{snippets}/proof-history-controller-test/update/request-fields.adoc[]
+
+- 응답
+include::{snippets}/proof-history-controller-test/update/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/update/response-fields.adoc[]
+
+==== 비정상 요청 (잘못된 요청)
+유효성 검증에 실패하는 요청 시 다음과 같이 반환합니다.
+include::{snippets}/proof-history-controller-test/update/invalid/bad-request/http-request.adoc[]
+
+- 응답
+include::{snippets}/proof-history-controller-test/update/invalid/bad-request/response-fields.adoc[]
+include::{snippets}/proof-history-controller-test/update/invalid/bad-request/http-response.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지 인증 기록)
+존재하지 않는 챌린지 인증 기록 ID로 인증 기록을 수정했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/update/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/update/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (작성자가 아닌 사용자)
+작성자가 아닌 사용자가 인증 기록을 수정했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/update/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/update/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (이미 처리된 인증 기록)
+이미 처리된 인증 기록을 수정했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/update/invalid/conflict/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/update/invalid/conflict/response-fields.adoc[]
+
+=== 챌린지 인증 기록 삭제
+챌린지 인증 기록을 삭제합니다.
+
+==== 정상 요청
+include::{snippets}/proof-history-controller-test/delete/http-request.adoc[]
+include::{snippets}/proof-history-controller-test/delete/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-history-controller-test/delete/http-response.adoc[]
+
+==== 비정상 요청 (존재하지 않는 챌린지 인증 기록)
+존재하지 않는 챌린지 인증 기록 ID로 인증 기록을 삭제했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/delete/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/delete/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (작성자가 아닌 사용자)
+작성자가 아닌 사용자가 인증 기록을 삭제했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-controller-test/delete/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-history-controller-test/delete/invalid/forbidden/response-fields.adoc[]
 
 == 게시글
 

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -806,6 +806,109 @@ include::{snippets}/proof-history-controller-test/delete/invalid/not-found/respo
 include::{snippets}/proof-history-controller-test/delete/invalid/forbidden/http-response.adoc[]
 include::{snippets}/proof-history-controller-test/delete/invalid/forbidden/response-fields.adoc[]
 
+
+== 챌린지 인증 기록 투표 API
+
+=== 챌린지 인증 기록 투표 생성
+챌린지 인증 기록에 대한 투표를 생성합니다.
+
+==== 정상 요청
+include::{snippets}/proof-history-vote-controller-test/save/http-request.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/path-parameters.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/query-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-history-vote-controller-test/save/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 인증 기록)
+존재하지 않는 챌린지 인증 기록 ID로 투표를 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/save/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (챌린지 멤버가 아닌 사용자)
+챌린지 멤버가 아닌 사용자가 투표를 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/save/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (자신의 인증 기록에 투표)
+자신의 인증 기록에 투표를 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/save/invalid/forbidden/self/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/invalid/forbidden/self/response-fields.adoc[]
+
+==== 비정상 요청 (이미 처리된 인증 기록)
+이미 처리된 인증 기록에 투표를 생성했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/save/invalid/conflict/status/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/invalid/conflict/status/response-fields.adoc[]
+
+==== 비정상 요청 (이미 투표한 경우)
+인증 기록에 대해 이미 투표한 경우, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/save/invalid/conflict/duplicated/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/save/invalid/conflict/duplicated/response-fields.adoc[]
+
+=== 챌린지 인증 기록 투표 이력 조회
+챌린지 인증 기록 ID에 대한 챌린지 인증 기록 투표 이력을 조회합니다.
+
+==== 정상 요청
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/http-request.adoc[]
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 인증 기록)
+존재하지 않는 챌린지 인증 기록 ID로 투표 이력을 조회했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (챌린지 멤버가 아닌 사용자)
+챌린지 멤버가 아닌 사용자가 투표 이력 조회를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (이미 처리된 인증 기록)
+이미 처리된 인증 기록에 대한 투표 이력 조회를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/invalid/conflict/status/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/find-my-vote/invalid/conflict/status/response-fields.adoc[]
+
+=== 챌린지 인증 기록 투표 결과 조회
+챌린지 인증 기록 ID에 대한 챌린지 인증 기록 투표 결과를 조회합니다.
+
+==== 정상 요청
+include::{snippets}/proof-history-vote-controller-test/get-result/http-request.adoc[]
+include::{snippets}/proof-history-vote-controller-test/get-result/path-parameters.adoc[]
+
+- 응답
+include::{snippets}/proof-history-vote-controller-test/get-result/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/get-result/response-fields.adoc[]
+
+==== 비정상 요청 (존재하지 않는 인증 기록)
+존재하지 않는 챌린지 인증 기록 ID로 투표 결과를 조회했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/get-result/invalid/not-found/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/get-result/invalid/not-found/response-fields.adoc[]
+
+==== 비정상 요청 (작성자가 아닌 사용자)
+작성자가 아닌 사용자가 투표 결과 조회를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/get-result/invalid/forbidden/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/get-result/invalid/forbidden/response-fields.adoc[]
+
+==== 비정상 요청 (이미 처리된 인증 기록)
+이미 처리된 인증 기록에 대한 투표 결과 조회를 요청했을 때, 다음과 같은 응답이 반환됩니다.
+
+include::{snippets}/proof-history-vote-controller-test/get-result/invalid/conflict/status/http-response.adoc[]
+include::{snippets}/proof-history-vote-controller-test/get-result/invalid/conflict/status/response-fields.adoc[]
+
 == 게시글
 
 === 게시글 생성 API

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/DuplicatedProofHistoryException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/exception/history/DuplicatedProofHistoryException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.proof.exception.history;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicatedProofHistoryException extends BusinessException {
+    public DuplicatedProofHistoryException() {
+        super("해당 인증에 대한 기록이 이미 존재합니다.", HttpStatus.CONFLICT.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -5,6 +5,7 @@ import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
 import com.trybe.moduleapi.proof.exception.*;
+import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryException;
 import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
 import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
 import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
@@ -41,6 +42,7 @@ public class ProofHistoryService {
 
         validateMemberParticipation(user.getId(), proof.getChallenge().getId(), "멤버만 인증 기록을 등록할 수 있습니다.");
         validateDate(proof);
+        validateDuplicateProofHistory(proof, user);
 
         ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
         return ProofHistoryResponse.Summary.from(savedProofHistory);
@@ -108,6 +110,12 @@ public class ProofHistoryService {
     private void validateProofHistoryStatus(ProofHistory proofHistory, ProofHistoryStatus status, String message) {
         if (proofHistory.getStatus().isNot(status)) {
             throw new InvalidProofHistoryStatusException(message);
+        }
+    }
+
+    private void validateDuplicateProofHistory(Proof proof, User user) {
+        if (proofHistoryRepository.existsByProofAndUser(proof, user)) {
+            throw new DuplicatedProofHistoryException();
         }
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -42,7 +42,7 @@ public class ProofHistoryService {
 
         validateMemberParticipation(user.getId(), proof.getChallenge().getId(), "멤버만 인증 기록을 등록할 수 있습니다.");
         validateDate(proof);
-        validateDuplicateProofHistory(proof, user);
+        validateDuplicateProofHistory(proof.getId(), user.getId());
 
         ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
         return ProofHistoryResponse.Summary.from(savedProofHistory);
@@ -113,8 +113,8 @@ public class ProofHistoryService {
         }
     }
 
-    private void validateDuplicateProofHistory(Proof proof, User user) {
-        if (proofHistoryRepository.existsByProofAndUser(proof, user)) {
+    private void validateDuplicateProofHistory(Long proofId, Long userId) {
+        if (proofHistoryRepository.existsByProofIdAndUserId(proofId, userId)) {
             throw new DuplicatedProofHistoryException();
         }
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -42,7 +42,7 @@ public class ProofHistoryVoteService {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
 
         validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 인증 기록에 대해 투표할 수 있습니다.");
-        validateProofHistoryOwner(user, false, proofHistory, "자기 자신의 인증 기록에 투표할 수 없습니다.");
+        validateProofHistoryOwner(user, false, proofHistory, "자신의 인증 기록에 투표할 수 없습니다.");
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대해 투표할 수 없습니다.");
 
         String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());
@@ -67,8 +67,8 @@ public class ProofHistoryVoteService {
     public ProofHistoryVoteResponse.My findMyVote(User user, Long proofHistoryId) {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
 
-        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 내역을 조회할 수 있습니다.");
-        validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 내역을 조회할 수 없습니다.");
+        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 이력을 조회할 수 있습니다.");
+        validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 이력을 조회할 수 없습니다.");
 
         String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());
         String userKey = getRedisKey(USER_KEY, user.getId());

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -67,7 +67,7 @@ public class ProofHistoryVoteService {
     public ProofHistoryVoteResponse.My findMyVote(User user, Long proofHistoryId) {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
 
-        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 내역을 조회할 수 있슶니다.");
+        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 내역을 조회할 수 있습니다.");
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 내역을 조회할 수 없습니다.");
 
         String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
@@ -80,7 +80,7 @@ public class ProofHistoryControllerTest extends ControllerTest {
                         parameterWithName("proofId").description("인증 ID")
                 ),
                 requestFields(
-                        fieldWithPath("content").description("인증 기록 내용")
+                        fieldWithPath("content").description("인증 기록 내용 (최대 1,000자)")
                 ),
                 responseFields(
                         fieldWithPath("id").description("인증 기록 ID"),
@@ -405,7 +405,7 @@ public class ProofHistoryControllerTest extends ControllerTest {
                         parameterWithName("proofHistoryId").description("인증 기록 ID")
                 ),
                 requestFields(
-                        fieldWithPath("content").description("인증 기록 내용")
+                        fieldWithPath("content").description("인증 기록 내용 (최대 1,000자)")
                 ),
                 responseFields(
                         fieldWithPath("id").description("인증 기록 ID"),

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
@@ -1,0 +1,633 @@
+package com.trybe.moduleapi.proof.controller;
+
+import com.trybe.moduleapi.annotation.WithCustomMockUser;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.common.ControllerTest;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
+import com.trybe.moduleapi.proof.exception.InvalidProofDateException;
+import com.trybe.moduleapi.proof.exception.NotFoundProofException;
+import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
+import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
+import com.trybe.moduleapi.proof.fixtures.ProofFixtures;
+import com.trybe.moduleapi.proof.service.ProofHistoryService;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.Mockito.*;
+import static com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProofHistoryController.class)
+public class ProofHistoryControllerTest extends ControllerTest {
+    @MockitoBean
+    private ProofHistoryService proofHistoryService;
+
+    private final String endpoint = "/api/v1/proofs/histories";
+
+    private final String docsPath = "proof-history-controller-test/";
+    private final String invalidBadRequestPath = "/invalid/bad-request/";
+    private final String invalidNotFoundPath = "/invalid/not-found/";
+    private final String invalidConflictPath = "/invalid/conflict/";
+    private final String invalidForbiddenPath = "/invalid/forbidden/";
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 기록 생성 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_기록_생성_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+
+        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+                .thenReturn(대기_인증_기록_요약_응답);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.id").value(대기_인증_기록_요약_응답.id()),
+                jsonPath("$.content").value(대기_인증_기록_요약_응답.content()),
+                jsonPath("$.status").value(대기_인증_기록_요약_응답.status().toString()),
+                jsonPath("$.createdAt").value(대기_인증_기록_요약_응답.createdAt().toString())
+        );
+        
+        result.andDo(document(docsPath + "save",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("proofId").description("인증 ID")
+                ),
+                requestFields(
+                        fieldWithPath("content").description("인증 기록 내용")
+                ),
+                responseFields(
+                        fieldWithPath("id").description("인증 기록 ID"),
+                        fieldWithPath("content").description("인증 기록 내용"),
+                        fieldWithPath("status").description("인증 기록 상태"),
+                        fieldWithPath("createdAt").description("인증 기록 생성 시간")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("비정상적인 인증 기록 생성 요청 시 응답코드 400을 반환한다.")
+    void 비정상적인_인증_기록_생성_요청_시_응답코드_400을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 잘못된_인증_기록_생성_요청;
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+        
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.status").value(400),
+                jsonPath("$.message").doesNotExist(),
+                jsonPath("$.data.content").exists()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidBadRequestPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data.content").description("인증 기록 내용 에러 메시지")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증에 대한 인증 기록 생성 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증에_대한_인증_기록_생성_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+        
+        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+                .thenThrow(new NotFoundProofException());
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+        
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 생성 요청 시 챌린지 멤버가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_기록_생성_요청_시_챌린지_멤버가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+        
+        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+                .thenThrow(new InvalidParticipationStatusActionException("멤버만 인증 기록을 등록할 수 있습니다."));
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+        
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 생성 요청 시 인증 날짜가 아닌 경우 응답코드 400을 반환한다.")
+    void 인증_기록_생성_요청_시_인증_날짜가_아닌_경우_응답코드_400을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+        
+        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+                .thenThrow(new InvalidProofDateException());
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+        
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.status").value(400),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidBadRequestPath + "date",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 생성 요청 시 인증에 대한 중복된 인증 기록이 있는 경우 응답코드 409을 반환한다.")
+    void 인증_기록_생성_요청_시_인증에_대한_중복된_인증_기록이_있는_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+        
+        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+                .thenThrow(new DuplicatedProofHistoryException());
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+        
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidConflictPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 기록 목록 조회 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_기록_목록_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        PageResponse<ProofHistoryResponse.Summary> response = 인증_기록_목록_페이지_응답;
+        
+        when(proofHistoryService.findAll(any(User.class), eq(proofId), any(Pageable.class)))
+                .thenReturn(response);
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/all/{proofId}", proofId)
+                        .param("page", "0").param("size", "10"));
+        
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.content").isArray(),
+                jsonPath("$.content.size()").value(response.content().size()),
+                jsonPath("$.totalPages").value(response.totalPages()),
+                jsonPath("$.totalElements").value(response.totalElements()),
+                jsonPath("$.size").value(response.size()),
+                jsonPath("$.number").value(response.number()),
+                jsonPath("$.last").value(response.last())
+        );
+        
+        result.andDo(document(docsPath + "findAll",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("proofId").description("인증 ID")
+                ),
+                queryParameters(
+                        parameterWithName("page").description("페이지 번호"),
+                        parameterWithName("size").description("페이지 크기")
+                ),
+                responseFields(
+                        fieldWithPath("content").description("인증 기록 요약 목록"),
+                        fieldWithPath("content[].id").description("인증 기록 ID"),
+                        fieldWithPath("content[].content").description("인증 기록 내용"),
+                        fieldWithPath("content[].status").description("인증 기록 상태"),
+                        fieldWithPath("content[].createdAt").description("인증 기록 생성 시간"),
+                        fieldWithPath("totalPages").description("총 페이지 수"),
+                        fieldWithPath("totalElements").description("총 요소 수"),
+                        fieldWithPath("size").description("페이지 크기"),
+                        fieldWithPath("number").description("현재 페이지 번호"),
+                        fieldWithPath("last").description("마지막 페이지 여부")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증에 대한 인증 기록 목록 조회 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증에_대한_인증_기록_목록_조회_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        
+        when(proofHistoryService.findAll(any(User.class), eq(proofId), any(Pageable.class)))
+                .thenThrow(new NotFoundProofException());
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/all/{proofId}", proofId)
+                        .param("page", "0").param("size", "10"));
+        
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "findAll" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 목록 조회 요청 시 챌린지 멤버가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_기록_목록_조회_요청_시_챌린지_멤버가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        
+        when(proofHistoryService.findAll(any(User.class), eq(proofId), any(Pageable.class)))
+                .thenThrow(new InvalidParticipationStatusActionException("멤버만 인증 기록을 조회할 수 있습니다."));
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/all/{proofId}", proofId)
+                        .param("page", "0").param("size", "10"));
+        
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "findAll" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 기록 수정 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_기록_수정_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request =인증_기록_수정_요청;
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+                .thenReturn(대기_인증_기록_요약_응답);
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.id").value(대기_인증_기록_요약_응답.id()),
+                jsonPath("$.content").value(대기_인증_기록_요약_응답.content()),
+                jsonPath("$.status").value(대기_인증_기록_요약_응답.status().toString()),
+                jsonPath("$.createdAt").value(대기_인증_기록_요약_응답.createdAt().toString())
+        );
+
+        result.andDo(document(docsPath + "update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("proofHistoryId").description("인증 기록 ID")
+                ),
+                requestFields(
+                        fieldWithPath("content").description("인증 기록 내용")
+                ),
+                responseFields(
+                        fieldWithPath("id").description("인증 기록 ID"),
+                        fieldWithPath("content").description("인증 기록 내용"),
+                        fieldWithPath("status").description("인증 기록 상태"),
+                        fieldWithPath("createdAt").description("인증 기록 생성 시간")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("비정상적인 인증 기록 수정 요청 시 응답코드 400을 반환한다.")
+    void 비정상적인_인증_기록_수정_요청_시_응답코드_400을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request = 잘못된_인증_기록_수정_요청;
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isBadRequest(),
+                jsonPath("$.status").value(400),
+                jsonPath("$.message").doesNotExist(),
+                jsonPath("$.data.content").exists()
+        );
+
+        result.andDo(document(docsPath + "update" + invalidBadRequestPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data.content").description("인증 기록 내용 에러 메시지")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증 기록에 대한 인증 기록 수정 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증_기록에_대한_인증_기록_수정_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+                .thenThrow(new NotFoundProofHistoryException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "update" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 수정 요청 시 인증 기록의 작성자가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_기록_수정_요청_시_인증_기록의_작성자가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+                .thenThrow(new ForbiddenProofHistoryException("인증 기록의 작성자만 수정할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "update" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 수정 요청 시 이미 처리된 인증 기록인 경우 응답코드 409을 반환한다.")
+    void 인증_기록_수정_요청_시_이미_처리된_인증_기록인_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+                .thenThrow(new InvalidProofHistoryStatusException("인증 기록의 작성자만 수정할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "update" + invalidConflictPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 기록 삭제 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_기록_삭제_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{proofHistoryId}", proofHistoryId));
+
+        result.andExpect(status().isOk());
+        verify(proofHistoryService, atLeastOnce()).delete(any(User.class), eq(proofHistoryId));
+        
+        result.andDo(document(docsPath + "delete",
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("proofHistoryId").description("인증 기록 ID"))
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증 기록에 대한 인증 기록 삭제 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증_기록에_대한_인증_기록_삭제_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+
+        doThrow(new NotFoundProofHistoryException())
+                .when(proofHistoryService).delete(any(User.class), eq(proofHistoryId));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{proofHistoryId}", proofHistoryId));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "delete" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 삭제 요청 시 인증 기록의 작성자가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_기록_삭제_요청_시_인증_기록의_작성자가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+
+        doThrow(new ForbiddenProofHistoryException("인증 기록의 작성자만 삭제할 수 있습니다."))
+                .when(proofHistoryService).delete(any(User.class), eq(proofHistoryId));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(endpoint + "/{proofHistoryId}", proofHistoryId));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").exists(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "delete" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
@@ -524,7 +524,7 @@ public class ProofHistoryControllerTest extends ControllerTest {
         ProofHistoryRequest.Update request = 인증_기록_수정_요청;
 
         when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
-                .thenThrow(new InvalidProofHistoryStatusException("인증 기록의 작성자만 수정할 수 있습니다."));
+                .thenThrow(new InvalidProofHistoryStatusException("이미 처리된 인증 기록은 수정할 수 없습니다."));
 
         /* when */
         /* then */

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
@@ -163,7 +163,7 @@ public class ProofHistoryVoteControllerTest extends ControllerTest {
                 jsonPath("$.data").doesNotExist()
         );
         
-        result.andDo(document(docsPath + "save" + invalidConflictPath,
+        result.andDo(document(docsPath + "save" + invalidForbiddenPath + "self",
                 preprocessResponse(prettyPrint()),
                 responseFields(
                         fieldWithPath("status").description("응답 상태 코드"),

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
@@ -1,0 +1,492 @@
+package com.trybe.moduleapi.proof.controller;
+
+import com.trybe.moduleapi.annotation.WithCustomMockUser;
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.common.ControllerTest;
+import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryVoteException;
+import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
+import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
+import com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures;
+import com.trybe.moduleapi.proof.service.ProofHistoryVoteService;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static com.trybe.moduleapi.proof.fixtures.ProofHistoryVoteFixtures.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProofHistoryVoteController.class)
+public class ProofHistoryVoteControllerTest extends ControllerTest {
+    @MockitoBean
+    private ProofHistoryVoteService proofHistoryVoteService;
+
+    private final String endpoint = "/api/v1/proofs/histories/votes";
+
+    private final String docsPath = "proof-history-vote-controller-test/";
+    private final String invalidBadRequestPath = "/invalid/bad-request/";
+    private final String invalidNotFoundPath = "/invalid/not-found/";
+    private final String invalidConflictPath = "/invalid/conflict/";
+    private final String invalidForbiddenPath = "/invalid/forbidden/";
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 기록 투표 생성 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_기록_투표_생성_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = 1L;
+        boolean approved = 찬성_여부;
+
+        when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))
+            .thenReturn(나의_투표_응답);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofHistoryId}?approved={approved}", proofHistoryId, approved));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.approved").value(approved)
+        );
+
+        result.andDo(document(docsPath + "save",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("proofHistoryId").description("인증 기록 ID")
+                ),
+                queryParameters(
+                        parameterWithName("approved").description("찬성 여부 (true: 찬성, false: 반대)")
+                ),
+                responseFields(
+                        fieldWithPath("approved").description("찬성 여부")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증 기록에 대한 투표 생성 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증_기록에_대한_투표_생성_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+        boolean approved = 찬성_여부;
+
+        when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))
+            .thenThrow(new NotFoundProofHistoryException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .param("approved", String.valueOf(approved)));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 생성 요청 시 챌린지 멤버가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_기록_투표_생성_요청_시_챌린지_멤버가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+        boolean approved = 찬성_여부;
+
+        when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))
+            .thenThrow(new InvalidParticipationStatusActionException("챌린지 멤버만 인증 기록에 대해 투표할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .param("approved", String.valueOf(approved)));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "save" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 생성 요청 시 자신의 인증 기록에 대한 투표인 경우 응답코드 403을 반환한다.")
+    void 인증_기록_투표_생성_요청_시_자신의_인증_기록에_대한_투표인_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+        boolean approved = 찬성_여부;
+
+        when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))
+            .thenThrow(new ForbiddenProofHistoryException("자기 자신의 인증 기록에 투표할 수 없습니다."));
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .param("approved", String.valueOf(approved)));
+        
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidConflictPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 생성 요청 시 이미 처리된 인증 기록일 경우 응답코드 409을 반환한다.")
+    void 인증_기록_투표_생성_요청_시_이미_처리된_인증_기록일_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+        boolean approved = 찬성_여부;
+
+        when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))
+            .thenThrow(new InvalidProofHistoryStatusException("이미 처리된 인증 기록에 대해 투표할 수 없습니다."));
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .param("approved", String.valueOf(approved)));
+        
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidConflictPath + "status",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 생성 요청 시 이미 투표한 경우 응답코드 409을 반환한다.")
+    void 인증_기록_투표_생성_요청_시_이미_투표한_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+        boolean approved = 찬성_여부;
+
+        when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))
+            .thenThrow(new DuplicatedProofHistoryVoteException());
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofHistoryId}", proofHistoryId)
+                .param("approved", String.valueOf(approved)));
+        
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+        
+        result.andDo(document(docsPath + "save" + invalidConflictPath + "duplicated",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+    
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 기록 투표 이력 조회 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_기록_투표_이력_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.findMyVote(any(User.class), eq(proofHistoryId)))
+            .thenReturn(나의_투표_응답);
+        
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}", proofHistoryId));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.approved").value(찬성_여부)
+        );
+
+        result.andDo(document(docsPath + "find-my-vote",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("proofHistoryId").description("인증 기록 ID")
+                ),
+                responseFields(
+                        fieldWithPath("approved").description("찬성 여부")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증 기록에 대한 투표 이력 조회 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증_기록에_대한_투표_이력_조회_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.findMyVote(any(User.class), eq(proofHistoryId)))
+            .thenThrow(new NotFoundProofHistoryException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}", proofHistoryId));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "find-my-vote" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 이력 조회 시 챌린지 멤버가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_기록_투표_이력_조회_시_챌린지_멤버가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.findMyVote(any(User.class), eq(proofHistoryId)))
+            .thenThrow(new InvalidParticipationStatusActionException("챌린지 멤버만 투표 내역을 조회할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}", proofHistoryId));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "find-my-vote" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 이력 조회 시 이미 처리된 인증 기록일 경우 응답코드 409을 반환한다.")
+    void 인증_기록_투표_이력_조회_시_이미_처리된_인증_기록일_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.findMyVote(any(User.class), eq(proofHistoryId)))
+            .thenThrow(new InvalidProofHistoryStatusException("이미 처리된 인증 기록에 대한 투표 내역을 조회할 수 없습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}", proofHistoryId));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "find-my-vote" + invalidConflictPath + "status",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("정상적인 인증 기록 투표 결과 조회 요청 시 응답코드 200을 반환한다.")
+    void 정상적인_인증_기록_투표_결과_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.getResult(any(User.class), eq(proofHistoryId)))
+            .thenReturn(투표_결과_응답);
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}/result", proofHistoryId));
+
+        result.andExpectAll(
+                status().isOk(),
+                jsonPath("$.approvedCount").value(찬성_투표_수),
+                jsonPath("$.disapprovedCount").value(반대_투표_수),
+                jsonPath("$.nonParticipatedCount").value(투표_미참여_인원_수)
+        );
+
+        result.andDo(document(docsPath + "get-result",
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("proofHistoryId").description("인증 기록 ID")
+                ),
+                responseFields(
+                        fieldWithPath("approvedCount").description("찬성 투표 수"),
+                        fieldWithPath("disapprovedCount").description("반대 투표 수"),
+                        fieldWithPath("nonParticipatedCount").description("투표 미참여 인원 수")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("존재하지 않는 인증 기록에 대한 투표 결과 조회 요청 시 응답코드 404을 반환한다.")
+    void 존재하지_않는_인증_기록에_대한_투표_결과_조회_요청_시_응답코드_404을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.getResult(any(User.class), eq(proofHistoryId)))
+            .thenThrow(new NotFoundProofHistoryException());
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}/result", proofHistoryId));
+
+        result.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "get-result" + invalidNotFoundPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 결과 조회 요청 시 인증 기록 작성자가 아닌 경우 응답코드 403을 반환한다.")
+    void 인증_기록_투표_결과_조회_요청_시_인증_기록_작성자가_아닌_경우_응답코드_403을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.getResult(any(User.class), eq(proofHistoryId)))
+            .thenThrow(new ForbiddenProofHistoryException("인증 기록의 작성자만 투표 결과를 조회할 수 있습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}/result", proofHistoryId));
+
+        result.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "get-result" + invalidForbiddenPath,
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("인증 기록 투표 결과 조회 요청 시 이미 처리된 인증 기록인 경우 응답코드 409을 반환한다.")
+    void 인증_기록_투표_결과_조회_요청_시_이미_처리된_인증_기록인_경우_응답코드_409을_반환한다 () throws Exception {
+        /* given */
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
+
+        when(proofHistoryVoteService.getResult(any(User.class), eq(proofHistoryId)))
+            .thenThrow(new InvalidProofHistoryStatusException("이미 처리된 인증 기록에 대한 투표 결과를 조회할 수 없습니다."));
+
+        /* when */
+        /* then */
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(endpoint + "/{proofHistoryId}/result", proofHistoryId));
+
+        result.andExpectAll(
+                status().isConflict(),
+                jsonPath("$.status").value(409),
+                jsonPath("$.message").isNotEmpty(),
+                jsonPath("$.data").doesNotExist()
+        );
+
+        result.andDo(document(docsPath + "get-result" + invalidConflictPath + "status",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("status").description("응답 상태 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("추가 데이터")
+                )
+        ));
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
@@ -36,7 +36,6 @@ public class ProofHistoryVoteControllerTest extends ControllerTest {
     private final String endpoint = "/api/v1/proofs/histories/votes";
 
     private final String docsPath = "proof-history-vote-controller-test/";
-    private final String invalidBadRequestPath = "/invalid/bad-request/";
     private final String invalidNotFoundPath = "/invalid/not-found/";
     private final String invalidConflictPath = "/invalid/conflict/";
     private final String invalidForbiddenPath = "/invalid/forbidden/";
@@ -46,7 +45,7 @@ public class ProofHistoryVoteControllerTest extends ControllerTest {
     @DisplayName("정상적인 인증 기록 투표 생성 요청 시 응답코드 200을 반환한다.")
     void 정상적인_인증_기록_투표_생성_요청_시_응답코드_200을_반환한다 () throws Exception {
         /* given */
-        Long proofHistoryId = 1L;
+        Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
         boolean approved = 찬성_여부;
 
         when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryVoteControllerTest.java
@@ -149,7 +149,7 @@ public class ProofHistoryVoteControllerTest extends ControllerTest {
         boolean approved = 찬성_여부;
 
         when(proofHistoryVoteService.save(any(User.class), eq(proofHistoryId), eq(approved)))
-            .thenThrow(new ForbiddenProofHistoryException("자기 자신의 인증 기록에 투표할 수 없습니다."));
+            .thenThrow(new ForbiddenProofHistoryException("자신의 인증 기록에 투표할 수 없습니다."));
         
         /* when */
         /* then */
@@ -308,7 +308,7 @@ public class ProofHistoryVoteControllerTest extends ControllerTest {
         Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
 
         when(proofHistoryVoteService.findMyVote(any(User.class), eq(proofHistoryId)))
-            .thenThrow(new InvalidParticipationStatusActionException("챌린지 멤버만 투표 내역을 조회할 수 있습니다."));
+            .thenThrow(new InvalidParticipationStatusActionException("챌린지 멤버만 투표 이력을 조회할 수 있습니다."));
 
         /* when */
         /* then */
@@ -339,7 +339,7 @@ public class ProofHistoryVoteControllerTest extends ControllerTest {
         Long proofHistoryId = ProofHistoryFixtures.인증_기록_ID;
 
         when(proofHistoryVoteService.findMyVote(any(User.class), eq(proofHistoryId)))
-            .thenThrow(new InvalidProofHistoryStatusException("이미 처리된 인증 기록에 대한 투표 내역을 조회할 수 없습니다."));
+            .thenThrow(new InvalidProofHistoryStatusException("이미 처리된 인증 기록에 대한 투표 이력을 조회할 수 없습니다."));
 
         /* when */
         /* then */

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofFixtures.java
@@ -25,7 +25,7 @@ public class ProofFixtures {
     public static final ProofRequest.Create 잘못된_날짜_인증_생성_요청 = new ProofRequest.Create(ChallengeFixtures.챌린지_ID, 잘못된_인증_날짜);
 
     /* Entity */
-    private static final Proof 인증_생성(LocalDate date, int round) {
+    public static final Proof 인증_생성(LocalDate date, int round) {
         return new Proof(ChallengeFixtures.진행중인_챌린지, date, round);
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
@@ -1,0 +1,69 @@
+package com.trybe.moduleapi.proof.fixtures;
+
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+import com.trybe.modulecore.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ProofHistoryFixtures {
+    public static final Long 인증_기록_ID = 1L;
+
+    public static final String 인증_기록_내용 = "인증 기록 내용";
+    public static final String 수정된_인증_기록_내용 = "수정된 인증 기록 내용";
+    public static final String 잘못된_인증_기록_내용 = "";
+
+    public static final ProofHistoryStatus 인증_기록_대기_상태 = ProofHistoryStatus.PENDING;
+    public static final ProofHistoryStatus 인증_기록_성공_상태 = ProofHistoryStatus.PASSED;
+    public static final ProofHistoryStatus 인증_기록_실패_상태 = ProofHistoryStatus.FAILED;
+
+    public static final LocalDateTime 인증_기록_생성_시간 = LocalDateTime.now();
+
+    /* Request DTO */
+    public static final ProofHistoryRequest.Create 인증_기록_생성_요청 = new ProofHistoryRequest.Create(인증_기록_내용);
+    public static final ProofHistoryRequest.Update 인증_기록_수정_요청 = new ProofHistoryRequest.Update(수정된_인증_기록_내용);
+
+    public static final ProofHistoryRequest.Create 잘못된_인증_기록_생성_요청 = new ProofHistoryRequest.Create(잘못된_인증_기록_내용);
+    public static final ProofHistoryRequest.Update 잘못된_인증_기록_수정_요청 = new ProofHistoryRequest.Update(잘못된_인증_기록_내용);
+
+    /* Entity */
+    private static ProofHistory 인증_기록_생성(Proof proof, User user, String content, ProofHistoryStatus status) {
+        ProofHistory proofHistory = new ProofHistory(proof, user, content);
+        proofHistory.updateStatus(status);
+        return proofHistory;
+    }
+
+    public static final Proof 오늘_인증 = ProofFixtures.인증_생성(LocalDate.now(), ProofFixtures.인증_라운드);
+    public static final Proof 내일_인증 = ProofFixtures.인증_생성(LocalDate.now().plusDays(1), ProofFixtures.인증_라운드);
+    public static final ProofHistory 대기_인증_기록 = 인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_대기_상태);
+    public static final ProofHistory 성공_인증_기록 = 인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_성공_상태);
+    public static final ProofHistory 실패_인증_기록 = 인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_실패_상태);
+
+    public static Pageable 페이지_요청 = PageRequest.of(0, 10);
+
+    private static final List<ProofHistory> 인증_기록_목록 = List.of(
+            인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_대기_상태),
+            인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_대기_상태),
+            인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_대기_상태)
+    );
+
+    public static final Page<ProofHistory> 인증_기록_목록_페이지 = new PageImpl<>(인증_기록_목록, 페이지_요청, 인증_기록_목록.size());
+
+    /* Response DTO */
+    public static final ProofHistoryResponse.Summary 대기_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, 인증_기록_내용, 인증_기록_대기_상태, 인증_기록_생성_시간);
+    public static final ProofHistoryResponse.Summary 성공_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, 인증_기록_내용, 인증_기록_성공_상태, 인증_기록_생성_시간);
+    public static final ProofHistoryResponse.Summary 실패_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, 인증_기록_내용, 인증_기록_실패_상태, 인증_기록_생성_시간);
+
+    public static final PageResponse<ProofHistoryResponse.Summary> 인증_기록_목록_페이지_응답 = new PageResponse<>(인증_기록_목록_페이지.map(ProofHistoryResponse.Summary::from));
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryVoteFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryVoteFixtures.java
@@ -1,0 +1,14 @@
+package com.trybe.moduleapi.proof.fixtures;
+
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryVoteResponse;
+
+public class ProofHistoryVoteFixtures {
+    public static final boolean 찬성_여부 = true;
+    public static final int 찬성_투표_수 = 3;
+    public static final int 반대_투표_수 = 2;
+    public static final int 투표_미참여_인원_수 = 1;
+
+    /* Response DTO */
+    public static final ProofHistoryVoteResponse.My 나의_투표_응답 = new ProofHistoryVoteResponse.My(찬성_여부);
+    public static final ProofHistoryVoteResponse.Result 투표_결과_응답 = new ProofHistoryVoteResponse.Result(찬성_투표_수, 반대_투표_수, 투표_미참여_인원_수);
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryServiceTest.java
@@ -1,0 +1,309 @@
+package com.trybe.moduleapi.proof.service;
+
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
+import com.trybe.moduleapi.proof.exception.InvalidProofDateException;
+import com.trybe.moduleapi.proof.exception.NotFoundProofException;
+import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
+import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
+import com.trybe.moduleapi.proof.fixtures.ProofFixtures;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
+import com.trybe.modulecore.proof.repository.ProofRepository;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProofHistoryServiceTest {
+    @InjectMocks
+    private ProofHistoryService proofHistoryService;
+
+    @Mock
+    private ProofHistoryRepository proofHistoryRepository;
+
+    @Mock
+    private ProofRepository proofRepository;
+
+    @Mock
+    private ChallengeParticipationRepository challengeParticipationRepository;
+
+    @Test
+    @DisplayName("인증 기록 생성 시 저장된 인증 기록 정보를 반환한다.")
+    void 인증_기록_생성_시_저장된_인증_기록_정보를_반환한다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+        ProofHistory proofHistory = 대기_인증_기록;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(오늘_인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        when(proofHistoryRepository.existsByProofAndUser(any(Proof.class), any(User.class)))
+                .thenReturn(false);
+        when(proofHistoryRepository.save(any(ProofHistory.class)))
+                .thenReturn(proofHistory);
+
+        /* when */
+        ProofHistoryResponse.Summary result = proofHistoryService.save(UserFixtures.회원, proofId, request);
+
+        /* then */
+        assertEquals(proofHistory.getId(), result.id());
+        assertEquals(proofHistory.getContent(), result.content());
+        assertEquals(proofHistory.getStatus(), result.status());
+//        assertEquals(proofHistory.getCreatedAt(), result.createdAt());
+    }
+    
+    @Test
+    @DisplayName("인증 기록 생성 시 존재하지 않는 인증 ID가 주어지면 예외를 던진다.")
+    void 인증_기록_생성_시_존재하지_않는_인증_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.empty());
+        
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+    }
+    
+    @Test
+    @DisplayName("인증 기록 생성 시 챌린지 멤버가 아닌 경우 예외를 던진다.")
+    void 인증_기록_생성_시_챌린지_멤버가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(오늘_인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(false);
+        
+        /* when */
+        /* then */
+        assertThrows(InvalidParticipationStatusActionException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+    }
+    
+    @Test
+    @DisplayName("인증 기록 생성 시 인증 날짜가 오늘이 아닌 경우 예외를 던진다.")
+    void 인증_기록_생성_시_인증_날짜가_오늘이_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(내일_인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidProofDateException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+    }
+
+    @Test
+    @DisplayName("인증 기록 생성 시 인증에 대한 기록이 이미 존재하는 경우 예외를 던진다.")
+    void 인증_기록_생성_시_인증에_대한_기록이_이미_존재하는_경우_예외를_던진다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+        ProofHistoryRequest.Create request = 인증_기록_생성_요청;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(오늘_인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        when(proofHistoryRepository.existsByProofAndUser(any(Proof.class), any(User.class)))
+                .thenReturn(true);
+
+        /* when */
+        /* then */
+        assertThrows(DuplicatedProofHistoryException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+    }
+
+    @Test
+    @DisplayName("인증 기록 목록 조회 시 주어진 인증에 대한 인증 기록 목록을 반환한다.")
+    void 인증_기록_목록_조회_시_주어진_인증에_대한_인증_기록_목록을_반환한다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(오늘_인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        when(proofHistoryRepository.findAllByProofId(any(), any()))
+                .thenReturn(인증_기록_목록_페이지);
+
+        /* when */
+        PageResponse<ProofHistoryResponse.Summary> result = proofHistoryService.findAll(UserFixtures.회원, proofId, 페이지_요청);
+
+        /* then */
+        assertEquals(인증_기록_목록_페이지_응답.content().size(), result.content().size());
+        assertEquals(인증_기록_목록_페이지_응답.totalElements(), result.totalElements());
+    }
+
+    @Test
+    @DisplayName("인증 기록 목록 조회 시 존재하지 않는 인증 ID가 주어지면 예외를 던진다.")
+    void 인증_기록_목록_조회_시_존재하지_않는_인증_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofException.class, () -> proofHistoryService.findAll(UserFixtures.회원, proofId, 페이지_요청));
+    }
+    @Test
+    @DisplayName("인증 기록 목록 조회 시 챌린지 멤버가 아닌 경우 예외를 던진다.")
+    void 인증_기록_목록_조회_시_챌린지_멤버가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofId = ProofFixtures.인증_ID;
+
+        when(proofRepository.findById(proofId))
+                .thenReturn(Optional.of(오늘_인증));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidParticipationStatusActionException.class, () -> proofHistoryService.findAll(UserFixtures.회원, proofId, 페이지_요청));
+    }
+
+    @Test
+    @DisplayName("인증 기록 수정 시 수정된 인증 기록 정보를 반환한다.")
+    void 인증_기록_수정_시_수정된_인증_기록_정보를_반환한다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+
+        /* when */
+        ProofHistoryResponse.Summary result = proofHistoryService.update(UserFixtures.회원, proofHistoryId, request);
+
+        /* then */
+        assertEquals(대기_인증_기록.getId(), result.id());
+        assertEquals(request.content(), result.content());
+        assertEquals(대기_인증_기록.getStatus(), result.status());
+//        assertEquals(대기_인증_기록.getCreatedAt(), result.createdAt());
+    }
+
+    @Test
+    @DisplayName("인증 기록 수정 시 존재하지 않는 인증 기록 ID가 주어지면 예외를 던진다.")
+    void 인증_기록_수정_시_존재하지_않는_인증_기록_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofHistoryException.class, () -> proofHistoryService.update(UserFixtures.회원, proofHistoryId, request));
+    }
+
+    @Test
+    @DisplayName("인증 기록 수정 시 인증 기록의 작성자가 아닌 경우 예외를 던진다.")
+    void 인증_기록_수정_시_인증_기록의_작성자가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        Long userId = 1L;
+        User user = spy(UserFixtures.회원);
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
+
+        when(user.getId()).thenReturn(userId);
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+
+        /* when */
+        /* then */
+        assertThrows(ForbiddenProofHistoryException.class, () -> proofHistoryService.update(user, proofHistoryId, request));
+    }
+
+    @Test
+    @DisplayName("인증 기록 수정 시 인증 기록이 대기 상태가 아닌 경우 예외를 던진다.")
+    void 인증_기록_수정_시_인증_기록이_대기_상태가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(성공_인증_기록));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidProofHistoryStatusException.class, () -> proofHistoryService.update(UserFixtures.회원, proofHistoryId, request));
+    }
+
+    @Test
+    @DisplayName("인증 기록 삭제 시 인증 기록을 삭제한다.")
+    void 인증_기록_삭제_시_인증_기록을_삭제한다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+
+        /* when */
+        proofHistoryService.delete(UserFixtures.회원, proofHistoryId);
+
+        /* then */
+        verify(proofHistoryRepository, atLeastOnce()).delete(any(ProofHistory.class));
+    }
+
+    @Test
+    @DisplayName("인증 기록 삭제 시 존재하지 않는 인증 기록 ID가 주어지면 예외를 던진다.")
+    void 인증_기록_삭제_시_존재하지_않는_인증_기록_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofHistoryException.class, () -> proofHistoryService.delete(UserFixtures.회원, proofHistoryId));
+    }
+
+    @Test
+    @DisplayName("인증 기록 삭제 시 인증 기록의 작성자가 아닌 경우 예외를 던진다.")
+    void 인증_기록_삭제_시_인증_기록의_작성자가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        Long userId = 1L;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+
+        /* when */
+        /* then */
+        assertThrows(ForbiddenProofHistoryException.class, () -> proofHistoryService.delete(user, proofHistoryId));
+    }
+}

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteServiceTest.java
@@ -154,7 +154,7 @@ public class ProofHistoryVoteServiceTest {
         Long userId = UserFixtures.회원_PK;
         User user = spy(UserFixtures.회원);
         boolean approved = true;
-        String approvedValue = approved ? "APPROVED" : "DISAPPROVED";
+        String approvedValue = approved ? "approved" : "disapproved";
 
         when(user.getId()).thenReturn(userId);
         when(proofHistoryRepository.findById(proofHistoryId))

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteServiceTest.java
@@ -1,0 +1,317 @@
+package com.trybe.moduleapi.proof.service;
+
+import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
+import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
+import com.trybe.moduleapi.proof.dto.response.ProofHistoryVoteResponse;
+import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryVoteException;
+import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
+import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
+import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
+import com.trybe.modulecore.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Optional;
+
+import static com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProofHistoryVoteServiceTest {
+    @InjectMocks
+    private ProofHistoryVoteService proofHistoryVoteService;
+
+    @Mock
+    private ProofHistoryRepository proofHistoryRepository;
+
+    @Mock
+    private ChallengeParticipationRepository challengeParticipationRepository;
+
+    @Mock
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(redisTemplate.opsForHash()).thenReturn(mock());
+        lenient().when(redisTemplate.opsForValue()).thenReturn(mock());
+    }
+
+    @Test
+    @DisplayName("인증 기록 투표 생성 시 투표 결과를 반환한다.")
+    void 인증_기록_투표_생성_시_투표_결과를_반환한다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        boolean approved = true;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        when(redisTemplate.opsForHash().get(any(String.class), any(String.class)))
+                .thenReturn(null);
+        when(redisTemplate.opsForValue().increment(any(String.class), anyLong()))
+                .thenReturn(1L);
+
+        /* when */
+        ProofHistoryVoteResponse.My result = proofHistoryVoteService.save(user, proofHistoryId, approved);
+
+        /* then */
+        verify(redisTemplate.opsForValue(), atLeastOnce()).increment(any(String.class), anyLong());
+        verify(redisTemplate.opsForHash(), atLeastOnce()).put(any(String.class), any(String.class), any(String.class));
+        assertEquals(approved, result.approved());
+    }
+
+    @Test
+    @DisplayName("인증 기록 투표 생성 시 존재하지 않는 인증 기록 ID가 주어지면 예외를 던진다.")
+    void 인증_기록_투표_생성_시_존재하지_않는_인증_기록_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        boolean approved = true;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofHistoryException.class, () -> proofHistoryVoteService.save(UserFixtures.회원, proofHistoryId, approved));
+    }
+
+    @Test
+    @DisplayName("인증 기록 투표 생성 시 챌린지 멤버가 아닌 경우 예외를 던진다.")
+    void 인증_기록_투표_생성_시_챌린지_멤버가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        boolean approved = true;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(false);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidParticipationStatusActionException.class, () -> proofHistoryVoteService.save(UserFixtures.회원, proofHistoryId, approved));
+    }
+
+    @Test
+    @DisplayName("인증 기록 투표 생성 시 자신의 인증 기록에 투표하는 경우 예외를 던진다.")
+    void 인증_기록_투표_생성_시_자신의_인증_기록에_투표하는_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        boolean approved = true;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+
+        /* when */
+        /* then */
+        assertThrows(ForbiddenProofHistoryException.class, () -> proofHistoryVoteService.save(UserFixtures.회원, proofHistoryId, approved));
+    }
+
+    @Test
+    @DisplayName("인증 기록 투표 생성 시 이미 처리된 인증 기록에 투표하는 경우 예외를 던진다.")
+    void 인증_기록_투표_생성_시_이미_처리된_인증_기록에_투표하는_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+        boolean approved = true;
+
+        when(user.getId()).thenReturn(userId);
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(성공_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+
+        /* when */
+        /* then */
+        assertThrows(InvalidProofHistoryStatusException.class, () -> proofHistoryVoteService.save(user, proofHistoryId, approved));
+    }
+
+    @Test
+    @DisplayName("인증 기록 투표 생성 시 인증 기록에 이미 투표한 경우 예외를 던진다.")
+    void 인증_기록_투표_생성_시_인증_기록에_이미_투표한_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+        boolean approved = true;
+        String approvedValue = approved ? "APPROVED" : "DISAPPROVED";
+
+        when(user.getId()).thenReturn(userId);
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        when(redisTemplate.opsForHash().get(any(String.class), any(String.class)))
+                .thenReturn(approvedValue);
+
+        /* when */
+        /* then */
+        assertThrows(DuplicatedProofHistoryVoteException.class, () -> proofHistoryVoteService.save(user, proofHistoryId, approved));
+    }
+    
+    @Test
+    @DisplayName("인증 기록에 대한 나의 투표 이력 조회 시 투표 이력을 반환한다.")
+    void 인증_기록에_대한_나의_투표_이력_조회_시_투표_이력을_반환한다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        Boolean approved = true;
+        String approvedValue = approved ? "approved" : "disapproved";
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        when(redisTemplate.opsForHash().get(any(String.class), any(String.class)))
+                .thenReturn(approvedValue);
+
+        /* when */
+        ProofHistoryVoteResponse.My result = proofHistoryVoteService.findMyVote(UserFixtures.회원, proofHistoryId);
+
+        /* then */
+        assertEquals(approved, result.approved());
+    }
+    
+    @Test
+    @DisplayName("인증 기록에 대한 나의 투표 이력 조회 시 존재하지 않는 인증 기록 ID가 주어지면 예외를 던진다.")
+    void 인증_기록에_대한_나의_투표_이력_조회_시_존재하지_않는_인증_기록_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.empty());
+        
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofHistoryException.class, () -> proofHistoryVoteService.findMyVote(UserFixtures.회원, proofHistoryId));
+    }
+    
+    @Test
+    @DisplayName("인증 기록에 대한 나의 투표 이력 조회 시 챌린지 멤버가 아닌 경우 예외를 던진다.")
+    void 인증_기록에_대한_나의_투표_이력_조회_시_챌린지_멤버가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(false);
+        
+        /* when */
+        /* then */
+        assertThrows(InvalidParticipationStatusActionException.class, () -> proofHistoryVoteService.findMyVote(UserFixtures.회원, proofHistoryId));
+    }
+    
+    @Test
+    @DisplayName("인증 기록에 대한 나의 투표 이력 조회 시 이미 처리된 인증 기록에 대한 조회인 경우 예외를 던진다.")
+    void 인증_기록에_대한_나의_투표_이력_조회_시_이미_처리된_인증_기록에_대한_조회인_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(성공_인증_기록));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(true);
+        
+        /* when */
+        /* then */
+        assertThrows(InvalidProofHistoryStatusException.class, () -> proofHistoryVoteService.findMyVote(UserFixtures.회원, proofHistoryId));
+    }
+    
+    @Test
+    @DisplayName("인증 기록에 대한 투표 결과 조회 시 투표 결과를 반환한다.")
+    void 인증_기록에_대한_투표_결과_조회_시_투표_결과를_반환한다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        ProofHistory proofHistory = spy(대기_인증_기록);
+        Long approvedCount = 1L;
+        Long disapprovedCount = 1L;
+
+        String approvedCountKey = String.format("proofHistory:%d:votes:approvedCount", proofHistoryId);
+        String disapprovedCountKey = String.format("proofHistory:%d:votes:disapprovedCount", proofHistoryId);
+
+        when(proofHistory.getId()).thenReturn(proofHistoryId);
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(proofHistory));
+        when(redisTemplate.opsForValue().get(approvedCountKey))
+                .thenReturn(approvedCount);
+        when(redisTemplate.opsForValue().get(disapprovedCountKey))
+                .thenReturn(disapprovedCount);
+        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
+                .thenReturn(ChallengeFixtures.참여자_수);
+
+        /* when */
+        ProofHistoryVoteResponse.Result result = proofHistoryVoteService.getResult(UserFixtures.회원, proofHistoryId);
+        
+        /* then */
+        int nonParticipatedCount = (ChallengeFixtures.참여자_수 - 1) - (approvedCount.intValue() + disapprovedCount.intValue());
+
+        assertEquals(approvedCount.intValue(), result.approvedCount());
+        assertEquals(disapprovedCount.intValue(), result.disapprovedCount());
+        assertEquals(nonParticipatedCount, result.nonParticipatedCount());
+    }
+
+    @Test
+    @DisplayName("인증 기록에 대한 투표 결과 조회 시 존재하지 않는 인증 기록 ID가 주어지면 예외를 던진다.")
+    void 인증_기록에_대한_투표_결과_조회_시_존재하지_않는_인증_기록_ID가_주어지면_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.empty());
+
+        /* when */
+        /* then */
+        assertThrows(NotFoundProofHistoryException.class, () -> proofHistoryVoteService.getResult(UserFixtures.회원, proofHistoryId));
+    }
+
+    @Test
+    @DisplayName("인증 기록에 대한 투표 결과 조회 시 인증 기록의 작성자가 아닌 경우 예외를 던진다.")
+    void 인증_기록에_대한_투표_결과_조회_시_인증_기록의_작성자가_아닌_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
+
+        when(user.getId()).thenReturn(userId);
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(대기_인증_기록));
+
+        /* when */
+        /* then */
+        assertThrows(ForbiddenProofHistoryException.class, () -> proofHistoryVoteService.getResult(user, proofHistoryId));
+    }
+
+    @Test
+    @DisplayName("인증 기록에 대한 투표 결과 조회 시 이미 처리된 인증 기록에 대한 조회인 경우 예외를 던진다.")
+    void 인증_기록에_대한_투표_결과_조회_시_이미_처리된_인증_기록에_대한_조회인_경우_예외를_던진다 () {
+        /* given */
+        Long proofHistoryId = 인증_기록_ID;
+
+        when(proofHistoryRepository.findById(proofHistoryId))
+                .thenReturn(Optional.of(성공_인증_기록));
+
+        /* when */
+        /* then */
+        assertThrows(InvalidProofHistoryStatusException.class, () -> proofHistoryVoteService.getResult(UserFixtures.회원, proofHistoryId));
+    }
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
@@ -1,6 +1,8 @@
 package com.trybe.modulecore.proof.repository;
 
+import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +15,5 @@ import java.util.List;
 public interface ProofHistoryRepository extends JpaRepository<ProofHistory, Long> {
     Page<ProofHistory> findAllByProofId(Long proofId, Pageable pageable);
     List<ProofHistory> findAllByProof_Date(LocalDate date);
+    boolean existsByProofAndUser(Proof proof, User user);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
@@ -1,8 +1,6 @@
 package com.trybe.modulecore.proof.repository;
 
-import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
-import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,5 +13,5 @@ import java.util.List;
 public interface ProofHistoryRepository extends JpaRepository<ProofHistory, Long> {
     Page<ProofHistory> findAllByProofId(Long proofId, Pageable pageable);
     List<ProofHistory> findAllByProof_Date(LocalDate date);
-    boolean existsByProofAndUser(Proof proof, User user);
+    boolean existsByProofIdAndUserId(Long proofId, Long userId);
 }


### PR DESCRIPTION
- 인증 히스토리 관련 코드 수정
  - 인증 히스토리 생성 시, 인증에 대한 해당 유저의 기록이 존재하는지 검증하는 로직 추가
  - 예외 메세지 오탈자 수정
- 인증 히스토리에 대한 테스트 코드 작성
  - `ProofHistoryFixtures` 작성
  - `ProofHistoryServiceTest` 작성
  - `ProofHistoryControllerTest` 작성
- 인증 히스토리 투표에 대한 테스트 코드 작성
  - `ProofHistoryVoteFixtures` 작성
  - `ProofHistoryVoteServiceTest` 작성
  - `ProofHistoryVoteControllerTest` 작성
- Spring Rest Docs의 index.adoc 파일 수정
  - 인증 히스토리 API에 대한 문서 추가
  - 인증 히스토리 투표 API에 대한 문서 추가