### PR TITLE
[#62] 인증 히스토리 투표 Redis 접근 로직 분리

### DIFF
--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
@@ -3,23 +3,22 @@ package com.trybe.moduleapi.proof.service;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
-import org.springframework.data.redis.core.RedisTemplate;
+import com.trybe.modulecore.proof.repository.vote.ProofHistoryVoteCache;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class ProofHistoryScheduler {
     private final ProofHistoryRepository proofHistoryRepository;
-    private final RedisTemplate<String, Long> redisTemplate;
+    private final ProofHistoryVoteCache proofHistoryVoteCache;
 
-    public ProofHistoryScheduler(ProofHistoryRepository proofHistoryRepository, RedisTemplate<String, Long> redisTemplate) {
+    public ProofHistoryScheduler(ProofHistoryRepository proofHistoryRepository, ProofHistoryVoteCache proofHistoryVoteCache) {
         this.proofHistoryRepository = proofHistoryRepository;
-        this.redisTemplate = redisTemplate;
+        this.proofHistoryVoteCache = proofHistoryVoteCache;
     }
 
     @Scheduled(cron = "0 0 0 * * *")
@@ -35,11 +34,8 @@ public class ProofHistoryScheduler {
     }
 
     private boolean isApproved(ProofHistory proofHistory) {
-        String approvedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:approvedCount";
-        String disapprovedCountKey = "proofHistory:" + proofHistory.getId() + ":votes:disapprovedCount";
-
-        long approvedCount = Optional.ofNullable(redisTemplate.opsForValue().get(approvedCountKey)).orElse(0L);
-        long disapprovedCount = Optional.ofNullable(redisTemplate.opsForValue().get(disapprovedCountKey)).orElse(0L);
+        int approvedCount = proofHistoryVoteCache.getVoteCount(proofHistory.getId(), true);
+        int disapprovedCount = proofHistoryVoteCache.getVoteCount(proofHistory.getId(), false);
 
         return approvedCount >= disapprovedCount;
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -17,6 +17,8 @@ import com.trybe.modulecore.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 public class ProofHistoryVoteService {
     private final ProofHistoryRepository proofHistoryRepository;
@@ -53,8 +55,9 @@ public class ProofHistoryVoteService {
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 이력을 조회할 수 없습니다.");
 
         String vote = proofHistoryVoteCache.findUserVote(userId, proofHistoryId);
+        Boolean voteStatus = vote == null ? null : ProofHistoryVoteStatus.fromValue(vote).toBoolean();
 
-        return new ProofHistoryVoteResponse.My(ProofHistoryVoteStatus.toBoolean(vote));
+        return new ProofHistoryVoteResponse.My(voteStatus);
     }
 
     @Transactional(readOnly = true)

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteService.java
@@ -10,55 +10,36 @@ import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+import com.trybe.modulecore.proof.enums.ProofHistoryVoteStatus;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
+import com.trybe.modulecore.proof.repository.vote.ProofHistoryVoteCache;
 import com.trybe.modulecore.user.entity.User;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 public class ProofHistoryVoteService {
     private final ProofHistoryRepository proofHistoryRepository;
     private final ChallengeParticipationRepository challengeParticipationRepository;
-    private final RedisTemplate<String, Long> redisTemplate;
+    private final ProofHistoryVoteCache proofHistoryVoteCache;
 
-    public ProofHistoryVoteService(ProofHistoryRepository proofHistoryRepository, ChallengeParticipationRepository challengeParticipationRepository, RedisTemplate<String, Long> redisTemplate) {
+    public ProofHistoryVoteService(ProofHistoryRepository proofHistoryRepository, ChallengeParticipationRepository challengeParticipationRepository, ProofHistoryVoteCache proofHistoryVoteCache) {
         this.proofHistoryRepository = proofHistoryRepository;
         this.challengeParticipationRepository = challengeParticipationRepository;
-        this.redisTemplate = redisTemplate;
+        this.proofHistoryVoteCache = proofHistoryVoteCache;
     }
-
-    private final String USER_KEY = "user:%d";
-    private final String PROOF_HISTORY_VOTES_KEY = "proofHistory:%d:votes";
-    private final String PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY = "proofHistory:%d:votes:approvedCount";
-    private final String PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY = "proofHistory:%d:votes:disapprovedCount";
-    private final String APPROVED = "approved";
-    private final String DISAPPROVED = "disapproved";
 
     @Transactional
     public ProofHistoryVoteResponse.My save(User user, Long proofHistoryId, boolean approved) {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
+        Long userId = user.getId();
 
-        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 인증 기록에 대해 투표할 수 있습니다.");
+        validateMemberParticipation(userId, proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 인증 기록에 대해 투표할 수 있습니다.");
         validateProofHistoryOwner(user, false, proofHistory, "자신의 인증 기록에 투표할 수 없습니다.");
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대해 투표할 수 없습니다.");
 
-        String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());
-        String userKey = getRedisKey(USER_KEY, user.getId());
-
-        validateDuplicatedVote(key, userKey);
-
-        String approvedCountKey = getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistory.getId());
-        String disapprovedCountKey = getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistory.getId());
-
-        if (approved) {
-            redisTemplate.opsForValue().increment(approvedCountKey, 1);
-        } else {
-            redisTemplate.opsForValue().increment(disapprovedCountKey, 1);
-        }
-        redisTemplate.opsForHash().put(key, userKey, (approved ? APPROVED : DISAPPROVED));
+        validateDuplicatedVote(userId, proofHistoryId);
+        proofHistoryVoteCache.saveVote(userId, proofHistoryId, approved);
 
         return new ProofHistoryVoteResponse.My(approved);
     }
@@ -66,15 +47,14 @@ public class ProofHistoryVoteService {
     @Transactional(readOnly = true)
     public ProofHistoryVoteResponse.My findMyVote(User user, Long proofHistoryId) {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
+        Long userId = user.getId();
 
-        validateMemberParticipation(user.getId(), proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 이력을 조회할 수 있습니다.");
+        validateMemberParticipation(userId, proofHistory.getProof().getChallenge().getId(), "챌린지 멤버만 투표 이력을 조회할 수 있습니다.");
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 이력을 조회할 수 없습니다.");
 
-        String key = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistory.getId());
-        String userKey = getRedisKey(USER_KEY, user.getId());
-        String vote = (String) redisTemplate.opsForHash().get(key, userKey);
+        String vote = proofHistoryVoteCache.findUserVote(userId, proofHistoryId);
 
-        return new ProofHistoryVoteResponse.My(vote == null ? null : vote.equals(APPROVED));
+        return new ProofHistoryVoteResponse.My(ProofHistoryVoteStatus.toBoolean(vote));
     }
 
     @Transactional(readOnly = true)
@@ -84,11 +64,8 @@ public class ProofHistoryVoteService {
         validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 투표 결과를 조회할 수 있습니다.");
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록에 대한 투표 결과를 조회할 수 없습니다.");
 
-        String approvedCountKey = getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistory.getId());
-        String disapprovedCountKey = getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistory.getId());
-
-        int approvedCount = Optional.ofNullable(redisTemplate.opsForValue().get(approvedCountKey)).map(Long::intValue).orElse(0);
-        int disapprovedCount = Optional.ofNullable(redisTemplate.opsForValue().get(disapprovedCountKey)).map(Long::intValue).orElse(0);
+        int approvedCount = proofHistoryVoteCache.getVoteCount(proofHistoryId, true);
+        int disapprovedCount = proofHistoryVoteCache.getVoteCount(proofHistoryId, false);
 
         int participantCount = challengeParticipationRepository.countByChallengeIdAndStatus(proofHistory.getProof().getChallenge().getId(), ParticipationStatus.ACCEPTED) - 1;
 
@@ -118,13 +95,9 @@ public class ProofHistoryVoteService {
         }
     }
 
-    private void validateDuplicatedVote(String key, String userKey) {
-        if (redisTemplate.opsForHash().get(key, userKey) != null) {
+    private void validateDuplicatedVote(Long userId, Long proofHistoryId) {
+        if (proofHistoryVoteCache.hasUserVoted(userId, proofHistoryId)) {
             throw new DuplicatedProofHistoryVoteException();
         }
-    }
-
-    private String getRedisKey(String key, Long id) {
-        return String.format(key, id);
     }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryVoteServiceTest.java
@@ -11,16 +11,16 @@ import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.enums.ProofHistoryVoteStatus;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
+import com.trybe.modulecore.proof.repository.vote.ProofHistoryVoteCache;
 import com.trybe.modulecore.user.entity.User;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.RedisTemplate;
 
 import java.util.Optional;
 
@@ -41,13 +41,7 @@ public class ProofHistoryVoteServiceTest {
     private ChallengeParticipationRepository challengeParticipationRepository;
 
     @Mock
-    private RedisTemplate<String, Long> redisTemplate;
-
-    @BeforeEach
-    void setUp() {
-        lenient().when(redisTemplate.opsForHash()).thenReturn(mock());
-        lenient().when(redisTemplate.opsForValue()).thenReturn(mock());
-    }
+    private ProofHistoryVoteCache proofHistoryVoteCache;
 
     @Test
     @DisplayName("인증 기록 투표 생성 시 투표 결과를 반환한다.")
@@ -63,17 +57,12 @@ public class ProofHistoryVoteServiceTest {
                 .thenReturn(Optional.of(대기_인증_기록));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
                 .thenReturn(true);
-        when(redisTemplate.opsForHash().get(any(String.class), any(String.class)))
-                .thenReturn(null);
-        when(redisTemplate.opsForValue().increment(any(String.class), anyLong()))
-                .thenReturn(1L);
 
         /* when */
         ProofHistoryVoteResponse.My result = proofHistoryVoteService.save(user, proofHistoryId, approved);
 
         /* then */
-        verify(redisTemplate.opsForValue(), atLeastOnce()).increment(any(String.class), anyLong());
-        verify(redisTemplate.opsForHash(), atLeastOnce()).put(any(String.class), any(String.class), any(String.class));
+        verify(proofHistoryVoteCache, times(1)).saveVote(userId, proofHistoryId, approved);
         assertEquals(approved, result.approved());
     }
 
@@ -154,15 +143,14 @@ public class ProofHistoryVoteServiceTest {
         Long userId = UserFixtures.회원_PK;
         User user = spy(UserFixtures.회원);
         boolean approved = true;
-        String approvedValue = approved ? "approved" : "disapproved";
 
         when(user.getId()).thenReturn(userId);
         when(proofHistoryRepository.findById(proofHistoryId))
                 .thenReturn(Optional.of(대기_인증_기록));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
                 .thenReturn(true);
-        when(redisTemplate.opsForHash().get(any(String.class), any(String.class)))
-                .thenReturn(approvedValue);
+        when(proofHistoryVoteCache.hasUserVoted(userId, proofHistoryId))
+                .thenReturn(true);
 
         /* when */
         /* then */
@@ -175,14 +163,14 @@ public class ProofHistoryVoteServiceTest {
         /* given */
         Long proofHistoryId = 인증_기록_ID;
         Boolean approved = true;
-        String approvedValue = approved ? "approved" : "disapproved";
+        String voteStatus = ProofHistoryVoteStatus.fromBoolean(approved).getValue();
 
         when(proofHistoryRepository.findById(proofHistoryId))
                 .thenReturn(Optional.of(대기_인증_기록));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
                 .thenReturn(true);
-        when(redisTemplate.opsForHash().get(any(String.class), any(String.class)))
-                .thenReturn(approvedValue);
+        when(proofHistoryVoteCache.findUserVote(any(), any(Long.class)))
+                .thenReturn(voteStatus);
 
         /* when */
         ProofHistoryVoteResponse.My result = proofHistoryVoteService.findMyVote(UserFixtures.회원, proofHistoryId);
@@ -242,19 +230,15 @@ public class ProofHistoryVoteServiceTest {
     void 인증_기록에_대한_투표_결과_조회_시_투표_결과를_반환한다 () {
         /* given */
         Long proofHistoryId = 인증_기록_ID;
-        ProofHistory proofHistory = spy(대기_인증_기록);
-        Long approvedCount = 1L;
-        Long disapprovedCount = 1L;
+        ProofHistory proofHistory = 대기_인증_기록;
+        int approvedCount = 1;
+        int disapprovedCount = 1;
 
-        String approvedCountKey = String.format("proofHistory:%d:votes:approvedCount", proofHistoryId);
-        String disapprovedCountKey = String.format("proofHistory:%d:votes:disapprovedCount", proofHistoryId);
-
-        when(proofHistory.getId()).thenReturn(proofHistoryId);
         when(proofHistoryRepository.findById(proofHistoryId))
                 .thenReturn(Optional.of(proofHistory));
-        when(redisTemplate.opsForValue().get(approvedCountKey))
+        when(proofHistoryVoteCache.getVoteCount(proofHistoryId, true))
                 .thenReturn(approvedCount);
-        when(redisTemplate.opsForValue().get(disapprovedCountKey))
+        when(proofHistoryVoteCache.getVoteCount(proofHistoryId, false))
                 .thenReturn(disapprovedCount);
         when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
                 .thenReturn(ChallengeFixtures.참여자_수);
@@ -263,10 +247,10 @@ public class ProofHistoryVoteServiceTest {
         ProofHistoryVoteResponse.Result result = proofHistoryVoteService.getResult(UserFixtures.회원, proofHistoryId);
         
         /* then */
-        int nonParticipatedCount = (ChallengeFixtures.참여자_수 - 1) - (approvedCount.intValue() + disapprovedCount.intValue());
+        int nonParticipatedCount = (ChallengeFixtures.참여자_수 - 1) - (approvedCount + disapprovedCount);
 
-        assertEquals(approvedCount.intValue(), result.approvedCount());
-        assertEquals(disapprovedCount.intValue(), result.disapprovedCount());
+        assertEquals(approvedCount, result.approvedCount());
+        assertEquals(disapprovedCount, result.disapprovedCount());
         assertEquals(nonParticipatedCount, result.nonParticipatedCount());
     }
 

--- a/module-core/src/main/java/com/trybe/modulecore/proof/enums/ProofHistoryVoteStatus.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/enums/ProofHistoryVoteStatus.java
@@ -1,0 +1,24 @@
+package com.trybe.modulecore.proof.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ProofHistoryVoteStatus {
+    APPROVED("approved"),
+    DISAPPROVED("disapproved");
+
+    private final String value;
+    ProofHistoryVoteStatus(String value) {
+        this.value = value;
+    }
+
+    public static ProofHistoryVoteStatus fromBoolean(boolean approved) {
+        return approved ? APPROVED : DISAPPROVED;
+    }
+
+    public static Boolean toBoolean(String value) {
+        if (APPROVED.getValue().equals(value)) return true;
+        if (DISAPPROVED.getValue().equals(value)) return false;
+        return null;
+    }
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/enums/ProofHistoryVoteStatus.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/enums/ProofHistoryVoteStatus.java
@@ -16,9 +16,15 @@ public enum ProofHistoryVoteStatus {
         return approved ? APPROVED : DISAPPROVED;
     }
 
-    public static Boolean toBoolean(String value) {
-        if (APPROVED.getValue().equals(value)) return true;
-        if (DISAPPROVED.getValue().equals(value)) return false;
-        return null;
+    public static ProofHistoryVoteStatus fromValue(String value) {
+        return switch (value) {
+            case "approved" -> APPROVED;
+            case "disapproved" -> DISAPPROVED;
+            default -> null;
+        };
+    }
+
+    public boolean toBoolean() {
+        return this == APPROVED;
     }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/vote/ProofHistoryVoteCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/vote/ProofHistoryVoteCache.java
@@ -1,0 +1,8 @@
+package com.trybe.modulecore.proof.repository.vote;
+
+public interface ProofHistoryVoteCache {
+    void saveVote(Long userId, Long proofHistoryId, boolean approved);
+    String findUserVote(Long userId, Long proofHistoryId);
+    int getVoteCount(Long proofHistoryId, boolean approved);
+    boolean hasUserVoted(Long userId, Long proofHistoryId);
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/vote/ProofHistoryVoteRedisCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/vote/ProofHistoryVoteRedisCache.java
@@ -1,0 +1,56 @@
+package com.trybe.modulecore.proof.repository.vote;
+
+import com.trybe.modulecore.proof.enums.ProofHistoryVoteStatus;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProofHistoryVoteRedisCache implements ProofHistoryVoteCache {
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    public ProofHistoryVoteRedisCache(RedisTemplate<String, Long> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    private final String PROOF_HISTORY_VOTES_KEY = "proofHistory:%d:votes";
+    private final String PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY = "proofHistory:%d:votes:approvedCount";
+    private final String PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY = "proofHistory:%d:votes:disapprovedCount";
+
+    @Override
+    public void saveVote(Long userId, Long proofHistoryId, boolean approved) {
+        String voteKey = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistoryId);
+        String countKey = approved
+                ? getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistoryId)
+                : getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistoryId);
+        String voteStatus = ProofHistoryVoteStatus.fromBoolean(approved).getValue();
+
+        redisTemplate.opsForValue().increment(countKey, 1);
+        redisTemplate.opsForHash().put(voteKey, userId.toString(), voteStatus);
+    }
+
+    @Override
+    public String findUserVote(Long userId, Long proofHistoryId) {
+        String voteKey = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistoryId);
+        return (String) redisTemplate.opsForHash().get(voteKey, userId.toString());
+    }
+
+    @Override
+    public int getVoteCount(Long proofHistoryId, boolean approved) {
+        String countKey = approved
+                ? getRedisKey(PROOF_HISTORY_VOTES_APPROVED_COUNT_KEY, proofHistoryId)
+                : getRedisKey(PROOF_HISTORY_VOTES_DISAPPROVED_COUNT_KEY, proofHistoryId);
+        Long count = redisTemplate.opsForValue().get(countKey);
+
+        return count == null ? 0 : count.intValue();
+    }
+
+    @Override
+    public boolean hasUserVoted(Long userId, Long proofHistoryId) {
+        String voteKey = getRedisKey(PROOF_HISTORY_VOTES_KEY, proofHistoryId);
+        return redisTemplate.opsForHash().hasKey(voteKey, userId.toString());
+    }
+
+    private String getRedisKey(String key, Long id) {
+        return String.format(key, id);
+    }
+}


### PR DESCRIPTION
- `ProofHistoryVoteCache` 인터페이스와 `ProofHistoryVoteRedisCache` 구현체 작성
- ProofHistoryVoteStatus 추가 (approved / disapproved)
- `ProofHistoryVoteService`, `ProofHistoryScheduler` 내 레디스 로직을 `ProofHistoryVoteCache`의 메서드로 변경
- 변경 사항에 따른 테스트 코드 수정