### PR TITLE
[#63] 챌린지 검색 기능 구현

### DIFF
--- a/module-api/http/challenge.http
+++ b/module-api/http/challenge.http
@@ -33,11 +33,12 @@ GET http://localhost:8080/api/v1/challenges/1
 Authorization: {{accessToken}}
 
 ### 3. 챌린지 검색 조회
-POST http://localhost:8080/api/v1/challenges/search?page=0&size=10
+POST http://localhost:8080/api/v1/challenges/search?page=0&size=10&sort=createdAt,desc
 Authorization: {{accessToken}}
 Content-Type: application/json
 
 {
+  "keyword": "도서",
   "statuses": ["PENDING","ONGOING"],
   "categories": ["STUDY"]
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeRequest.java
@@ -109,7 +109,8 @@ public class ChallengeRequest {
     }
 
     public record Read(
-            // TODO: Filter
+            String keyword,
+
             @NotEmptyList(message = STATUSES_NOT_EMPTY_MESSAGE)
             List<ChallengeStatus> statuses,
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -65,7 +65,7 @@ public class ChallengeService {
 
     @Transactional(readOnly = true)
     public PageResponse<ChallengeResponse.Preview> findAll(User user, ChallengeRequest.Read request, Pageable pageable) {
-        Page<Challenge> challenges = challengeRepository.getFilteredChallenges(request.keyword(), request.categories(), request.statuses(), pageable);
+        Page<Challenge> challenges = challengeRepository.getFilteredChallenges(request.keyword(), request.statuses(), request.categories(), pageable);
 
         Page<ChallengeResponse.Preview> challengeSummaries = challenges.map(challenge -> createPreview(user, challenge));
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -65,7 +65,7 @@ public class ChallengeService {
 
     @Transactional(readOnly = true)
     public PageResponse<ChallengeResponse.Preview> findAll(User user, ChallengeRequest.Read request, Pageable pageable) {
-        Page<Challenge> challenges = challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), pageable);
+        Page<Challenge> challenges = challengeRepository.getFilteredChallenges(request.keyword(), request.categories(), request.statuses(), pageable);
 
         Page<ChallengeResponse.Preview> challengeSummaries = challenges.map(challenge -> createPreview(user, challenge));
 

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -262,6 +262,7 @@ class ChallengeControllerTest extends ControllerTest {
                         parameterWithName("size").description("페이지 크기")
                 ),
                 requestFields(
+                        fieldWithPath("keyword").description("챌린지 검색 키워드"),
                         fieldWithPath("statuses").description("챌린지 상태"),
                         fieldWithPath("categories").description("챌린지 카테고리")
                 ),

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -30,11 +30,11 @@ public class ChallengeFixtures {
 
     public static final LocalDate 챌린지_시작_날짜 = LocalDate.now().plus(1, ChronoUnit.DAYS);
     public static final LocalDate 잘못된_챌린지_시작_날짜 = LocalDate.of(2001, 5, 12);
-    public static final LocalDate 수정된_챌린지_시작_날짜 = LocalDate.of(2025, 4, 8);
+    public static final LocalDate 수정된_챌린지_시작_날짜 = LocalDate.now().plus(2, ChronoUnit.DAYS);
 
     public static final LocalDate 챌린지_종료_날짜 = 챌린지_시작_날짜.plus(2, ChronoUnit.WEEKS);
     public static final LocalDate 잘못된_챌린지_종료_날짜 = LocalDate.of(2001, 11, 14);
-    public static final LocalDate 수정된_챌린지_종료_날짜 = LocalDate.of(2025, 4, 14);
+    public static final LocalDate 수정된_챌린지_종료_날짜 = LocalDate.now().plus(3, ChronoUnit.WEEKS);
 
     public static final int 챌린지_인원 = 6;
     public static final int 잘못된_챌린지_인원 = 30;
@@ -81,12 +81,16 @@ public class ChallengeFixtures {
             잘못된_챌린지_인증_횟수
     );
 
+    private static final String 챌린지_키워드 = "디톡스";
+
     public static final ChallengeRequest.Read 챌린지_조회_요청 = new ChallengeRequest.Read(
+            챌린지_키워드,
             List.of(ChallengeStatus.PENDING, ChallengeStatus.ONGOING),
             List.of(ChallengeCategory.LIFE)
     );
 
     public static final ChallengeRequest.Read 잘못된_챌린지_조회_요청 = new ChallengeRequest.Read(
+            챌린지_키워드,
             List.of(),
             List.of()
     );

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -152,7 +152,7 @@ class ChallengeServiceTest {
         /* given */
         ChallengeRequest.Read request = 챌린지_조회_요청;
 
-        when(challengeRepository.findAllByStatusInAndCategoryIn(request.statuses(), request.categories(), 페이지_요청))
+        when(challengeRepository.getFilteredChallenges(request.keyword(), request.statuses(), request.categories(), 페이지_요청))
                 .thenReturn(챌린지_페이지);
         when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
                 .thenReturn(참여자_수);

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepository.java
@@ -2,9 +2,13 @@ package com.trybe.modulecore.challenge.repository;
 
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
+import com.trybe.modulecore.challenge.enums.ChallengeStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ChallengeCustomRepository {
+    Page<Challenge> getFilteredChallenges(String keyword, List<ChallengeCategory> categories, List<ChallengeStatus> statuses, Pageable pageable);
     List<Challenge> getByCategoriesOrKeywords(List<ChallengeCategory> categories, List<String> keywords, int limit);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ChallengeCustomRepository {
-    Page<Challenge> getFilteredChallenges(String keyword, List<ChallengeCategory> categories, List<ChallengeStatus> statuses, Pageable pageable);
+    Page<Challenge> getFilteredChallenges(String keyword, List<ChallengeStatus> statuses, List<ChallengeCategory> categories, Pageable pageable);
     List<Challenge> getRecommendedChallenges(List<ChallengeCategory> categories, List<String> keywords, int limit);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 public interface ChallengeCustomRepository {
     Page<Challenge> getFilteredChallenges(String keyword, List<ChallengeCategory> categories, List<ChallengeStatus> statuses, Pageable pageable);
-    List<Challenge> getByCategoriesOrKeywords(List<ChallengeCategory> categories, List<String> keywords, int limit);
+    List<Challenge> getRecommendedChallenges(List<ChallengeCategory> categories, List<String> keywords, int limit);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -1,15 +1,21 @@
 package com.trybe.modulecore.challenge.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
+import com.trybe.modulecore.challenge.enums.ChallengeStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 import static com.trybe.modulecore.challenge.entity.QChallenge.challenge;
+import static com.trybe.modulecore.utils.QueryUtils.getSort;
 import static com.trybe.modulecore.utils.QueryUtils.nullSafeBuilder;
 
 @Repository
@@ -18,6 +24,28 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
 
     public ChallengeCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
         this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Page<Challenge> getFilteredChallenges(String keyword, List<ChallengeCategory> categories, List<ChallengeStatus> statuses, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(titleOrDescriptionContains(keyword))
+                .and(categoryIn(categories))
+                .and(statusIn(statuses));
+
+        QueryResults<Challenge> challenges = jpaQueryFactory
+                .selectFrom(challenge)
+                .where(builder)
+                .orderBy(getSort(pageable, challenge))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+
+        List<Challenge> content = challenges.getResults();
+        long total = challenges.getTotal();
+
+        return new PageImpl<>(content, pageable, total);
     }
 
     @Override
@@ -34,13 +62,31 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
         return categoryIn(categories).or(titleContains(keywords));
     }
 
+    private BooleanBuilder titleContains(List<String> keywords) {
+        BooleanBuilder builder = new BooleanBuilder();
+        keywords.forEach(keyword -> builder.or(titleContains(keyword)));
+        return builder;
+    }
+
+    private BooleanBuilder titleOrDescriptionContains(String keyword) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.or(titleContains(keyword)).or(descriptionContains(keyword));
+        return builder;
+    }
+
     private BooleanBuilder categoryIn(List<ChallengeCategory> categories) {
         return nullSafeBuilder(() -> challenge.category.in(categories));
     }
 
-    private BooleanBuilder titleContains(List<String> keywords) {
-        BooleanBuilder builder = new BooleanBuilder();
-        keywords.forEach(keyword -> builder.or(challenge.title.containsIgnoreCase(keyword)));
-        return builder;
+    private BooleanBuilder statusIn(List<ChallengeStatus> statuses) {
+        return nullSafeBuilder(() -> challenge.status.in(statuses));
+    }
+
+    private BooleanBuilder titleContains(String keyword) {
+        return nullSafeBuilder(() -> challenge.title.containsIgnoreCase(keyword));
+    }
+
+    private BooleanBuilder descriptionContains(String keyword) {
+        return nullSafeBuilder(() -> challenge.description.containsIgnoreCase(keyword));
     }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -27,12 +27,12 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
     }
 
     @Override
-    public Page<Challenge> getFilteredChallenges(String keyword, List<ChallengeCategory> categories, List<ChallengeStatus> statuses, Pageable pageable) {
+    public Page<Challenge> getFilteredChallenges(String keyword, List<ChallengeStatus> statuses, List<ChallengeCategory> categories, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
 
         builder.and(titleOrDescriptionContains(keyword))
-                .and(categoryIn(categories))
-                .and(statusIn(statuses));
+                .and(statusIn(statuses))
+                .and(categoryIn(categories));
 
         QueryResults<Challenge> challenges = jpaQueryFactory
                 .selectFrom(challenge)

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -49,17 +49,13 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
     }
 
     @Override
-    public List<Challenge> getByCategoriesOrKeywords(List<ChallengeCategory> categories, List<String> keywords, int limit) {
+    public List<Challenge> getRecommendedChallenges(List<ChallengeCategory> categories, List<String> keywords, int limit) {
         return jpaQueryFactory.select(challenge)
                 .from(challenge)
-                .where(categoryInOrTitleContains(categories, keywords))
+                .where(categoryIn(categories).or(titleContains(keywords)))
                 .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
                 .limit(limit)
                 .fetch();
-    }
-
-    private BooleanBuilder categoryInOrTitleContains(List<ChallengeCategory> categories, List<String> keywords) {
-        return categoryIn(categories).or(titleContains(keywords));
     }
 
     private BooleanBuilder titleContains(List<String> keywords) {

--- a/module-core/src/main/java/com/trybe/modulecore/utils/QueryUtils.java
+++ b/module-core/src/main/java/com/trybe/modulecore/utils/QueryUtils.java
@@ -1,7 +1,12 @@
 package com.trybe.modulecore.utils;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.Expressions;
+import org.springframework.data.domain.Pageable;
 
 import java.util.function.Supplier;
 
@@ -16,5 +21,20 @@ public class QueryUtils {
         } catch (NullPointerException e) {
             return new BooleanBuilder();
         }
+    }
+
+    public static <T> OrderSpecifier<?>[] getSort(Pageable pageable, EntityPathBase<T> qClass) {
+        return pageable.getSort().stream()
+                .map(order ->
+                    new OrderSpecifier(
+                            Order.valueOf(order.getDirection().name()),
+                            Expressions.path(
+                                    qClass.getType(),
+                                    qClass,
+                                    order.getProperty()
+                            )
+                    )
+                )
+                .toArray(OrderSpecifier[]::new);
     }
 }

--- a/module-recommendation/src/main/java/com/trybe/modulerecommendation/challenge/service/ChallengeRecommendationService.java
+++ b/module-recommendation/src/main/java/com/trybe/modulerecommendation/challenge/service/ChallengeRecommendationService.java
@@ -37,7 +37,7 @@ public class ChallengeRecommendationService {
         List<ChallengeCategory> categories = challengePreferenceCache.getPreferenceCategories(userId, RECOMMENDATION_CATEGORY_COUNT);
         List<String> keywords = challengePreferenceCache.getPreferenceKeywords(userId, RECOMMENDATION_KEYWORD_COUNT);
 
-        List<Challenge> recommendations = challengeRepository.getByCategoriesOrKeywords(categories, keywords, MAX_LIMIT);
+        List<Challenge> recommendations = challengeRepository.getRecommendedChallenges(categories, keywords, MAX_LIMIT);
         LinkedHashSet<Challenge> challengeSet = new LinkedHashSet<>(recommendations);
 
         challengeSet.addAll(getMostBookmarkedChallenges(MIN_LIMIT));


### PR DESCRIPTION
- 챌린지 목록 조회 요청 시 키워드 필터링 조건 추가
  - `ChallengeRequest.Read`에 keyword 추가
  - `ChallengeCustomRepository`에 키워드, 카테고리, 상태에 따른 페이지 목록을 요청하는 메서드 추가
  - `ChallengeService`의 챌린지 목록 조회 시 키워드 조건을 포함하도록 추가
  - `ChallengeFixtures` 내 `ChallengeRequest.Read`요청 값에 키워드 추가
  - 코드 변경에 따른 HTTP 요청 파일, 테스트 코드 수정
- `ChallengeFixtures` 내 수정 날짜 값을 오류가 발생하지 않도록 수정