### PR TITLE
[#61] Redis 내 북마크 데이터 DB 저장 배치 처리

### DIFF
--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeRecommendationClientService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeRecommendationClientService.java
@@ -53,7 +53,7 @@ public class ChallengeRecommendationClientService {
 
     private ChallengeResponse.Bookmark createBookmark(Long userId, Long challengeId) {
         int bookmarkCount = challengeBookmarkCache.getBookmarkCount(challengeId);
-        Boolean bookmarked = challengeBookmarkCache.isBookmarked(userId, challengeId);
+        Boolean bookmarked = userId == null ? null : challengeBookmarkCache.isBookmarked(userId, challengeId);
         return new ChallengeResponse.Bookmark(bookmarkCount, bookmarked);
     }
 }

--- a/module-batch/src/main/java/com/trybe/modulebatch/ModuleBatchApplication.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/ModuleBatchApplication.java
@@ -1,20 +1,19 @@
 package com.trybe.modulebatch;
 
-import com.trybe.moduleapi.config.RedisConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(scanBasePackages = {"com.trybe.modulebatch", "com.trybe.modulecore"})
-@Import(RedisConfig.class)
 public class ModuleBatchApplication {
 	public static void main(String[] args) {
 		SpringApplication springApplication = new SpringApplication(ModuleBatchApplication.class);
 		springApplication.setWebApplicationType(WebApplicationType.NONE);
+
 		ConfigurableApplicationContext context = springApplication.run(args);
 		int exitCode = SpringApplication.exit(context);
+
 		System.exit(exitCode);
 	}
 }

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/config/ChallengeBookmarkJobConfig.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/config/ChallengeBookmarkJobConfig.java
@@ -1,0 +1,100 @@
+package com.trybe.modulebatch.challenge.config;
+
+import com.trybe.modulebatch.challenge.job.dto.ChallengeBookmarkDto;
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class ChallengeBookmarkJobConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final ItemReader<ChallengeBookmarkDto> challengeBookmarkInsertReader;
+    private final ItemReader<ChallengeBookmarkDto> challengeBookmarkDeleteReader;
+
+    private final ItemProcessor<ChallengeBookmarkDto, ChallengeBookmark> challengeBookmarkProcessor;
+
+    private final ItemWriter<ChallengeBookmark> challengeBookmarkInsertWriter;
+    private final ItemWriter<ChallengeBookmark> challengeBookmarkDeleteWriter;
+
+    private final ItemReader<String> deleteChallengeBookmarkRedisKeyReader;
+    private final ItemWriter<String> deleteChallengeBookmarkRedisKeyWriter;
+
+    public ChallengeBookmarkJobConfig(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            @Qualifier("challengeBookmarkInsertReader") ItemReader<ChallengeBookmarkDto> challengeBookmarkInsertReader,
+            @Qualifier("challengeBookmarkDeleteReader") ItemReader<ChallengeBookmarkDto> challengeBookmarkDeleteReader,
+            @Qualifier("challengeBookmarkProcessor") ItemProcessor<ChallengeBookmarkDto, ChallengeBookmark> challengeBookmarkProcessor,
+            @Qualifier("challengeBookmarkInsertWriter") ItemWriter<ChallengeBookmark> challengeBookmarkInsertWriter,
+            @Qualifier("challengeBookmarkDeleteWriter") ItemWriter<ChallengeBookmark> challengeBookmarkDeleteWriter,
+            @Qualifier("deleteChallengeBookmarkRedisKeyReader") ItemReader<String> deleteChallengeBookmarkRedisKeyReader,
+            @Qualifier("deleteChallengeBookmarkRedisKeyWriter") ItemWriter<String> deleteChallengeBookmarkRedisKeyWriter
+    ) {
+        this.jobRepository = jobRepository;
+        this.transactionManager = transactionManager;
+        this.challengeBookmarkInsertReader = challengeBookmarkInsertReader;
+        this.challengeBookmarkDeleteReader = challengeBookmarkDeleteReader;
+        this.challengeBookmarkProcessor = challengeBookmarkProcessor;
+        this.challengeBookmarkInsertWriter = challengeBookmarkInsertWriter;
+        this.challengeBookmarkDeleteWriter = challengeBookmarkDeleteWriter;
+        this.deleteChallengeBookmarkRedisKeyReader = deleteChallengeBookmarkRedisKeyReader;
+        this.deleteChallengeBookmarkRedisKeyWriter = deleteChallengeBookmarkRedisKeyWriter;
+    }
+
+    private static final int CHUNK_SIZE = 100;
+
+    private static final String JOB_NAME = "syncChallengeBookmarkJob";
+    private static final String INSERT_STEP_NAME = "insertChallengeBookmarkStep";
+    private static final String DELETE_STEP_NAME = "deleteChallengeBookmarkStep";
+    private static final String DELETE_REDIS_STEP_NAME = "deleteChallengeBookmarkRedisStep";
+
+    @Bean
+    public Job syncChallengeBookmarkJob() {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(insertChallengeBookmarkStep())
+                .next(deleteChallengeBookmarkStep())
+                .next(deleteChallengeBookmarkRedisKeyStep())
+                .build();
+    }
+
+    @Bean
+    public Step insertChallengeBookmarkStep() {
+        return new StepBuilder(INSERT_STEP_NAME, jobRepository)
+                .<ChallengeBookmarkDto, ChallengeBookmark>chunk(CHUNK_SIZE, transactionManager)
+                .reader(challengeBookmarkInsertReader)
+                .processor(challengeBookmarkProcessor)
+                .writer(challengeBookmarkInsertWriter)
+                .build();
+    }
+
+    @Bean
+    public Step deleteChallengeBookmarkStep() {
+        return new StepBuilder(DELETE_STEP_NAME, jobRepository)
+                .<ChallengeBookmarkDto, ChallengeBookmark>chunk(CHUNK_SIZE, transactionManager)
+                .reader(challengeBookmarkDeleteReader)
+                .processor(challengeBookmarkProcessor)
+                .writer(challengeBookmarkDeleteWriter)
+                .build();
+    }
+
+    @Bean
+    public Step deleteChallengeBookmarkRedisKeyStep() {
+        return new StepBuilder(DELETE_REDIS_STEP_NAME, jobRepository)
+                .<String, String>chunk(CHUNK_SIZE, transactionManager)
+                .reader(deleteChallengeBookmarkRedisKeyReader)
+                .writer(deleteChallengeBookmarkRedisKeyWriter)
+                .build();
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/dto/ChallengeBookmarkDto.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/dto/ChallengeBookmarkDto.java
@@ -1,0 +1,14 @@
+package com.trybe.modulebatch.challenge.job.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChallengeBookmarkDto {
+    public ChallengeBookmarkDto(Long userId, Long challengeId) {
+        this.challengeId = challengeId;
+        this.userId = userId;
+    }
+
+    private final Long challengeId;
+    private final Long userId;
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/processor/ChallengeBookmarkProcessor.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/processor/ChallengeBookmarkProcessor.java
@@ -1,0 +1,14 @@
+package com.trybe.modulebatch.challenge.job.processor;
+
+import com.trybe.modulebatch.challenge.job.dto.ChallengeBookmarkDto;
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChallengeBookmarkProcessor implements ItemProcessor<ChallengeBookmarkDto, ChallengeBookmark> {
+    @Override
+    public ChallengeBookmark process(ChallengeBookmarkDto item) throws Exception {
+        return new ChallengeBookmark(item.getChallengeId(), item.getUserId());
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/ChallengeBookmarkDeleteReader.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/ChallengeBookmarkDeleteReader.java
@@ -1,0 +1,29 @@
+package com.trybe.modulebatch.challenge.job.reader;
+
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRedisCache;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class ChallengeBookmarkDeleteReader extends ChallengeBookmarkReader {
+    public ChallengeBookmarkDeleteReader(ChallengeBookmarkRedisCache challengeBookmarkCache) {
+        super(challengeBookmarkCache);
+    }
+
+    @Override
+    protected String getPattern() {
+        return ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_DELETED_PATTERN;
+    }
+
+    @Override
+    protected Long getChallengeId(String key) {
+        String[] tokens = key.split(":");
+        return Long.parseLong(tokens[1]);
+    }
+
+    @Override
+    protected Set<Long> getUserIds(Long challengeId) {
+        return challengeBookmarkCache.getBookmarkDeletedUsers(challengeId);
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/ChallengeBookmarkInsertReader.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/ChallengeBookmarkInsertReader.java
@@ -1,0 +1,29 @@
+package com.trybe.modulebatch.challenge.job.reader;
+
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRedisCache;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class ChallengeBookmarkInsertReader extends ChallengeBookmarkReader {
+    public ChallengeBookmarkInsertReader(ChallengeBookmarkRedisCache challengeBookmarkCache) {
+        super(challengeBookmarkCache);
+    }
+
+    @Override
+    protected String getPattern() {
+        return ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_ADDED_PATTERN;
+    }
+
+    @Override
+    protected Long getChallengeId(String key) {
+        String[] tokens = key.split(":");
+        return Long.parseLong(tokens[1]);
+    }
+
+    @Override
+    protected Set<Long> getUserIds(Long challengeId) {
+        return challengeBookmarkCache.getBookmarkAddedUsers(challengeId);
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/ChallengeBookmarkReader.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/ChallengeBookmarkReader.java
@@ -1,0 +1,61 @@
+package com.trybe.modulebatch.challenge.job.reader;
+
+import com.trybe.modulebatch.challenge.job.dto.ChallengeBookmarkDto;
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRedisCache;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.data.redis.core.Cursor;
+
+import java.util.Iterator;
+import java.util.Set;
+
+public abstract class ChallengeBookmarkReader implements ItemReader<ChallengeBookmarkDto> {
+    protected final ChallengeBookmarkRedisCache challengeBookmarkCache;
+
+    public ChallengeBookmarkReader(ChallengeBookmarkRedisCache challengeBookmarkCache) {
+        this.challengeBookmarkCache = challengeBookmarkCache;
+    }
+
+    private Cursor<String> cursor;
+    private Iterator<Long> currentUserIdsIterator;
+    private Long currentChallengeId;
+
+    private static final int REDIS_SCAN_COUNT = 100;
+
+    protected abstract String getPattern();
+    protected abstract Long getChallengeId(String key);
+    protected abstract Set<Long> getUserIds(Long challengeId);
+
+    @Override
+    public ChallengeBookmarkDto read() throws Exception {
+        if (cursor == null) {
+            initializeCursor();
+        }
+
+        if (currentUserIdsIterator == null || !currentUserIdsIterator.hasNext()) {
+            if (!loadNextChallenge()) {
+                return null;
+            }
+        }
+
+        Long userId = currentUserIdsIterator.next();
+        return new ChallengeBookmarkDto(userId, currentChallengeId);
+    }
+
+    private void initializeCursor() {
+        cursor = challengeBookmarkCache.getKeysByPattern(getPattern(), REDIS_SCAN_COUNT);
+    }
+
+    private boolean loadNextChallenge() {
+        while (cursor.hasNext()) {
+            String key = cursor.next();
+            currentChallengeId = getChallengeId(key);
+
+            Set<Long> userIds = getUserIds(currentChallengeId);
+            if (userIds != null && !userIds.isEmpty()) {
+                currentUserIdsIterator = userIds.iterator();
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/DeleteChallengeBookmarkRedisKeyReader.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/reader/DeleteChallengeBookmarkRedisKeyReader.java
@@ -1,0 +1,43 @@
+package com.trybe.modulebatch.challenge.job.reader;
+
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRedisCache;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.NonTransientResourceException;
+import org.springframework.batch.item.ParseException;
+import org.springframework.batch.item.UnexpectedInputException;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeleteChallengeBookmarkRedisKeyReader implements ItemReader<String> {
+    private final ChallengeBookmarkRedisCache challengeBookmarkRedisCache;
+
+    public DeleteChallengeBookmarkRedisKeyReader(ChallengeBookmarkRedisCache challengeBookmarkRedisCache) {
+        this.challengeBookmarkRedisCache = challengeBookmarkRedisCache;
+    }
+
+    private Cursor<String> addedCursor;
+    private Cursor<String> deletedCursor;
+
+    private static final int REDIS_SCAN_COUNT = 100;
+
+    @Override
+    public String read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+        if (addedCursor == null && deletedCursor == null) {
+            initializeCursors();
+        }
+
+        if (addedCursor != null && addedCursor.hasNext()) {
+            return addedCursor.next();
+        } else if (deletedCursor != null && deletedCursor.hasNext()) {
+            return deletedCursor.next();
+        } else {
+            return null;
+        }
+    }
+
+    private void initializeCursors() {
+        addedCursor = challengeBookmarkRedisCache.getKeysByPattern(ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_ADDED_PATTERN, REDIS_SCAN_COUNT);
+        deletedCursor = challengeBookmarkRedisCache.getKeysByPattern(ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_DELETED_PATTERN, REDIS_SCAN_COUNT);
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/ChallengeBookmarkDeleteWriter.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/ChallengeBookmarkDeleteWriter.java
@@ -1,0 +1,19 @@
+package com.trybe.modulebatch.challenge.job.writer;
+
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ChallengeBookmarkDeleteWriter extends ChallengeBookmarkWriter {
+    public ChallengeBookmarkDeleteWriter(ChallengeBookmarkRepository challengeBookmarkRepository) {
+        super(challengeBookmarkRepository);
+    }
+
+    @Override
+    protected void writeBookmarks(List<ChallengeBookmark> bookmarks) {
+        challengeBookmarkRepository.bulkDelete(bookmarks);
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/ChallengeBookmarkInsertWriter.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/ChallengeBookmarkInsertWriter.java
@@ -1,0 +1,19 @@
+package com.trybe.modulebatch.challenge.job.writer;
+
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ChallengeBookmarkInsertWriter extends ChallengeBookmarkWriter {
+    public ChallengeBookmarkInsertWriter(ChallengeBookmarkRepository challengeBookmarkRepository) {
+        super(challengeBookmarkRepository);
+    }
+
+    @Override
+    protected void writeBookmarks(List<ChallengeBookmark> bookmarks) {
+        challengeBookmarkRepository.bulkInsert(bookmarks);
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/ChallengeBookmarkWriter.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/ChallengeBookmarkWriter.java
@@ -1,0 +1,29 @@
+package com.trybe.modulebatch.challenge.job.writer;
+
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRepository;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+import java.util.List;
+
+public abstract class ChallengeBookmarkWriter implements ItemWriter<ChallengeBookmark> {
+    protected final ChallengeBookmarkRepository challengeBookmarkRepository;
+
+    public ChallengeBookmarkWriter(ChallengeBookmarkRepository challengeBookmarkRepository) {
+        this.challengeBookmarkRepository = challengeBookmarkRepository;
+    }
+
+    protected abstract void writeBookmarks(List<ChallengeBookmark> bookmarks);
+
+    @Override
+    public void write(Chunk<? extends ChallengeBookmark> chunk) throws Exception {
+        List<ChallengeBookmark> items = chunk.getItems().stream()
+                .map(item -> (ChallengeBookmark) item)
+                .toList();
+
+        if (items.isEmpty()) return;
+
+        writeBookmarks(items);
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/DeleteChallengeBookmarkRedisKeyWriter.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/challenge/job/writer/DeleteChallengeBookmarkRedisKeyWriter.java
@@ -1,0 +1,28 @@
+package com.trybe.modulebatch.challenge.job.writer;
+
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRedisCache;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DeleteChallengeBookmarkRedisKeyWriter implements ItemWriter<String> {
+    private final ChallengeBookmarkRedisCache challengeBookmarkRedisCache;
+
+    public DeleteChallengeBookmarkRedisKeyWriter(ChallengeBookmarkRedisCache challengeBookmarkRedisCache) {
+        this.challengeBookmarkRedisCache = challengeBookmarkRedisCache;
+    }
+
+    @Override
+    public void write(Chunk<? extends String> chunk) throws Exception {
+        List<String> items = chunk.getItems().stream()
+                .map(item -> (String) item)
+                .toList();
+
+        if (items.isEmpty()) return;
+
+        challengeBookmarkRedisCache.deleteKeys(items);
+    }
+}

--- a/module-batch/src/main/java/com/trybe/modulebatch/post/config/PostLikeJobConfig.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/post/config/PostLikeJobConfig.java
@@ -1,4 +1,4 @@
-package com.trybe.modulebatch.config;
+package com.trybe.modulebatch.post.config;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;

--- a/module-batch/src/main/java/com/trybe/modulebatch/post/job/reader/PostLikeDeleteReader.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/post/job/reader/PostLikeDeleteReader.java
@@ -1,18 +1,19 @@
-package com.trybe.modulebatch.job.reader;
+package com.trybe.modulebatch.post.job.reader;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PostLikeInsertReader extends PostLikeReader {
-    public PostLikeInsertReader(RedisTemplate<String, Long> redisTemplate) {
+public class PostLikeDeleteReader extends PostLikeReader {
+    public PostLikeDeleteReader(RedisTemplate<String, Long> redisTemplate) {
         super(redisTemplate);
     }
 
-    private final String REDIS_SCAN_PATTERN = "post:*:liked:users";
+    private final String REDIS_SCAN_PATTERN = "post:*:liked:users:deleted";
 
     @Override
     protected String getRedisScanPattern() {
         return REDIS_SCAN_PATTERN;
     }
+
 }

--- a/module-batch/src/main/java/com/trybe/modulebatch/post/job/reader/PostLikeInsertReader.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/post/job/reader/PostLikeInsertReader.java
@@ -1,19 +1,18 @@
-package com.trybe.modulebatch.job.reader;
+package com.trybe.modulebatch.post.job.reader;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PostLikeDeleteReader extends PostLikeReader {
-    public PostLikeDeleteReader(RedisTemplate<String, Long> redisTemplate) {
+public class PostLikeInsertReader extends PostLikeReader {
+    public PostLikeInsertReader(RedisTemplate<String, Long> redisTemplate) {
         super(redisTemplate);
     }
 
-    private final String REDIS_SCAN_PATTERN = "post:*:liked:users:deleted";
+    private final String REDIS_SCAN_PATTERN = "post:*:liked:users";
 
     @Override
     protected String getRedisScanPattern() {
         return REDIS_SCAN_PATTERN;
     }
-
 }

--- a/module-batch/src/main/java/com/trybe/modulebatch/post/job/reader/PostLikeReader.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/post/job/reader/PostLikeReader.java
@@ -1,6 +1,6 @@
-package com.trybe.modulebatch.job.reader;
+package com.trybe.modulebatch.post.job.reader;
 
-import com.trybe.modulebatch.config.PostLikeJobConfig;
+import com.trybe.modulebatch.post.config.PostLikeJobConfig;
 import com.trybe.modulecore.post.entity.PostLike;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.data.redis.core.Cursor;

--- a/module-batch/src/main/java/com/trybe/modulebatch/post/job/writer/PostLikeDeleteWriter.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/post/job/writer/PostLikeDeleteWriter.java
@@ -1,4 +1,4 @@
-package com.trybe.modulebatch.job.writer;
+package com.trybe.modulebatch.post.job.writer;
 
 import com.trybe.modulecore.post.entity.PostLike;
 import com.trybe.modulecore.post.repository.PostLikeRepository;
@@ -8,27 +8,27 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class PostLikeInsertWriter extends PostLikeWriter {
-    private final String POST_LIKE_KEY = "post:%d:liked:users";
+public class PostLikeDeleteWriter extends PostLikeWriter {
+    private final String POST_LIKE_DELETE_KEY = "post:%d:liked:users:deleted";
     private final PostLikeRepository postLikeRepository;
 
-    public PostLikeInsertWriter(RedisTemplate<String, Long> redisTemplate, PostLikeRepository postLikeRepository) {
+    public PostLikeDeleteWriter(RedisTemplate<String, Long> redisTemplate, PostLikeRepository postLikeRepository) {
         super(redisTemplate);
         this.postLikeRepository = postLikeRepository;
     }
 
     @Override
     protected void dataBaseExecution(List<PostLike> postLikes) {
-        postLikeRepository.bulkInsert(postLikes);
+        postLikeRepository.bulkDelete(postLikes);
     }
 
     @Override
     protected String getPostRedisKey() {
-        return POST_LIKE_KEY;
+        return POST_LIKE_DELETE_KEY;
     }
 
     @Override
     protected boolean shouldDeleteRedisKey() {
-        return false;
+        return true;
     }
 }

--- a/module-batch/src/main/java/com/trybe/modulebatch/post/job/writer/PostLikeInsertWriter.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/post/job/writer/PostLikeInsertWriter.java
@@ -1,4 +1,4 @@
-package com.trybe.modulebatch.job.writer;
+package com.trybe.modulebatch.post.job.writer;
 
 import com.trybe.modulecore.post.entity.PostLike;
 import com.trybe.modulecore.post.repository.PostLikeRepository;
@@ -8,27 +8,27 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class PostLikeDeleteWriter extends PostLikeWriter {
-    private final String POST_LIKE_DELETE_KEY = "post:%d:liked:users:deleted";
+public class PostLikeInsertWriter extends PostLikeWriter {
+    private final String POST_LIKE_KEY = "post:%d:liked:users";
     private final PostLikeRepository postLikeRepository;
 
-    public PostLikeDeleteWriter(RedisTemplate<String, Long> redisTemplate, PostLikeRepository postLikeRepository) {
+    public PostLikeInsertWriter(RedisTemplate<String, Long> redisTemplate, PostLikeRepository postLikeRepository) {
         super(redisTemplate);
         this.postLikeRepository = postLikeRepository;
     }
 
     @Override
     protected void dataBaseExecution(List<PostLike> postLikes) {
-        postLikeRepository.bulkDelete(postLikes);
+        postLikeRepository.bulkInsert(postLikes);
     }
 
     @Override
     protected String getPostRedisKey() {
-        return POST_LIKE_DELETE_KEY;
+        return POST_LIKE_KEY;
     }
 
     @Override
     protected boolean shouldDeleteRedisKey() {
-        return true;
+        return false;
     }
 }

--- a/module-batch/src/main/java/com/trybe/modulebatch/post/job/writer/PostLikeWriter.java
+++ b/module-batch/src/main/java/com/trybe/modulebatch/post/job/writer/PostLikeWriter.java
@@ -1,4 +1,4 @@
-package com.trybe.modulebatch.job.writer;
+package com.trybe.modulebatch.post.job.writer;
 
 import com.trybe.modulecore.post.entity.PostLike;
 import org.springframework.batch.item.Chunk;

--- a/module-batch/src/test/java/com/trybe/modulebatch/challenge/config/ChallengeBookmarkJobConfigTest.java
+++ b/module-batch/src/test/java/com/trybe/modulebatch/challenge/config/ChallengeBookmarkJobConfigTest.java
@@ -1,0 +1,102 @@
+package com.trybe.modulebatch.challenge.config;
+
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRedisCache;
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@SpringBatchTest
+@EnableBatchProcessing
+class ChallengeBookmarkJobConfigTest {
+    @Autowired
+    @Qualifier("syncChallengeBookmarkJob")
+    private Job challengeBookmarkJob;
+    
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @Autowired
+    private ChallengeBookmarkRepository challengeBookmarkRepository;
+
+    private static final Long USER_ID = 999L;
+    private static final Long CHALLENGE_ID = 999L;
+    private static final Long USER_COUNT = 0L;
+    private static final Long CHALLENGE_COUNT = 0L;
+
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils.setJob(challengeBookmarkJob);
+
+        String challengeBookmarkAddedKey = ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_ADDED_KEY;
+        String challengeBookmarkDeletedKey = ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_DELETED_KEY;
+
+        long userId = USER_ID;
+        long challengeId = CHALLENGE_ID;
+
+        for (long i = 0; i < CHALLENGE_COUNT; i++) {
+            for (long j = 0; j < USER_COUNT; j++) {
+                long challengeIdToAdd = challengeId + i;
+                long userIdToAdd = userId + j;
+
+                String addedKey = String.format(challengeBookmarkAddedKey, challengeIdToAdd);
+                String deletedKey = String.format(challengeBookmarkDeletedKey, challengeIdToAdd);
+
+                redisTemplate.opsForSet().add(addedKey, userIdToAdd);
+                redisTemplate.opsForSet().add(deletedKey, userIdToAdd);
+            }
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        for (long i = 0; i < CHALLENGE_COUNT; i++) {
+            for (long j = 0; j < USER_COUNT; j++) {
+                long userIdToDelete = USER_ID + j;
+                long challengeIdToDelete = CHALLENGE_ID + i;
+
+                challengeBookmarkRepository.deleteByChallengeIdAndUserId(challengeIdToDelete, userIdToDelete);
+            }
+        }
+    }
+    
+    @Test
+    @DisplayName("챌린지 북마크 배치 JOB 실행 테스트")
+    void 챌린지_북마크_배치_JOB_실행_테스트 () throws Exception {
+        /* given */
+        /* when */
+        JobExecution execution = jobLauncherTestUtils.launchJob();
+
+        /* then */
+        assertEquals(ExitStatus.COMPLETED, execution.getExitStatus());
+        assertEquals(BatchStatus.COMPLETED, execution.getStatus());
+
+        String addedKey = ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_ADDED_KEY;
+        String deletedKey = ChallengeBookmarkRedisCache.CHALLENGE_BOOKMARK_DELETED_KEY;
+
+        for (long i = 0; i < CHALLENGE_COUNT; i++) {
+            String keyToCheckAdded = String.format(addedKey, CHALLENGE_ID + i);
+            String keyToCheckDeleted = String.format(deletedKey, CHALLENGE_ID + i);
+            assertFalse(redisTemplate.hasKey(keyToCheckAdded));
+            assertFalse(redisTemplate.hasKey(keyToCheckDeleted));
+        }
+    }
+}

--- a/module-batch/src/test/java/com/trybe/modulebatch/post/config/PostLikeBatchJobConfigTest.java
+++ b/module-batch/src/test/java/com/trybe/modulebatch/post/config/PostLikeBatchJobConfigTest.java
@@ -1,4 +1,4 @@
-package com.trybe.modulebatch.config;
+package com.trybe.modulebatch.post.config;
 
 import com.trybe.modulecore.post.repository.PostLikeRepository;
 import org.junit.jupiter.api.Test;

--- a/module-batch/src/test/java/com/trybe/modulebatch/post/config/PostLikeBatchJobConfigTest.java
+++ b/module-batch/src/test/java/com/trybe/modulebatch/post/config/PostLikeBatchJobConfigTest.java
@@ -8,6 +8,7 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -22,9 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @EnableBatchProcessing
 class PostLikeBatchJobConfigTest {
     @Autowired
+    @Qualifier("postLikeBulkUpdateJob")
     private Job postLikeJob;
+
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
+
     @Autowired
     private RedisTemplate<String, Long> redisTemplate;
 

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/entity/ChallengeBookmark.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/entity/ChallengeBookmark.java
@@ -1,31 +1,29 @@
 package com.trybe.modulecore.challenge.entity;
 
 import com.trybe.modulecore.common.entity.BaseEntity;
-import com.trybe.modulecore.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "challenge_bookmarks")
+@Table(name = "challenge_bookmarks",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"challenge_id", "user_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChallengeBookmark extends BaseEntity {
-    public ChallengeBookmark(Challenge challenge, User user) {
-        this.challenge = challenge;
-        this.user = user;
+    public ChallengeBookmark(Long challengeId, Long userId) {
+        this.challengeId = challengeId;
+        this.userId = userId;
     }
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "challenge_id", nullable = false, updatable = false)
-    private Challenge challenge;
+    @Column(name = "challenge_id", nullable = false, updatable = false)
+    private Long challengeId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, updatable = false)
-    private User user;
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkCache.java
@@ -10,5 +10,7 @@ public interface ChallengeBookmarkCache {
     int getUserBookmarkCount(Long userId);
     Set<Long> getBookmarkedChallenges(Long userId, int start, int end);
     Set<Long> getMostBookmarkedChallenges(int count);
+    Set<Long> getBookmarkAddedUsers(Long challengeId);
+    Set<Long> getBookmarkDeletedUsers(Long challengeId);
     void removeBookmarksByChallenge(Long challengeId);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkCustomRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkCustomRepository.java
@@ -1,0 +1,10 @@
+package com.trybe.modulecore.challenge.repository.bookmark;
+
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+
+import java.util.List;
+
+public interface ChallengeBookmarkCustomRepository {
+    void bulkInsert(List<ChallengeBookmark> bookmarks);
+    void bulkDelete(List<ChallengeBookmark> bookmarks);
+}

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkCustomRepositoryImpl.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkCustomRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.trybe.modulecore.challenge.repository.bookmark;
+
+import com.trybe.modulecore.challenge.entity.ChallengeBookmark;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public class ChallengeBookmarkCustomRepositoryImpl implements ChallengeBookmarkCustomRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public ChallengeBookmarkCustomRepositoryImpl(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void bulkInsert(List<ChallengeBookmark> bookmarks) {
+        String sql = "INSERT IGNORE INTO challenge_bookmarks (challenge_id, user_id, created_at) VALUES (?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ChallengeBookmark bookmark = bookmarks.get(i);
+                ps.setLong(1, bookmark.getChallengeId());
+                ps.setLong(2, bookmark.getUserId());
+                ps.setTimestamp(3, Timestamp.valueOf(LocalDateTime.now()));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return bookmarks.size();
+            }
+        });
+    }
+
+    @Override
+    public void bulkDelete(List<ChallengeBookmark> bookmarks) {
+        String sql = "DELETE FROM challenge_bookmarks WHERE challenge_id = ? AND user_id = ?";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ChallengeBookmark bookmark = bookmarks.get(i);
+                ps.setLong(1, bookmark.getChallengeId());
+                ps.setLong(2, bookmark.getUserId());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return bookmarks.size();
+            }
+        });
+    }
+}

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRedisCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRedisCache.java
@@ -1,6 +1,8 @@
 package com.trybe.modulecore.challenge.repository.bookmark;
 
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
@@ -16,15 +18,18 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
         this.redisTemplate = redisTemplate;
     }
 
-    private final String BOOKMARK_SUFFIX = ":bookmarks";
-    private final String USER_SUFFIX = ":users";
+    private static final String BOOKMARK_SUFFIX = ":bookmarks";
+    private static final String USER_SUFFIX = ":users";
     private final String CHALLENGE_SUFFIX = ":challenges";
 
     private final String USER_KEY = "user:%d" + BOOKMARK_SUFFIX + CHALLENGE_SUFFIX;
     private final String CHALLENGE_BOOKMARK_KEY = "challenge:%d" + BOOKMARK_SUFFIX + USER_SUFFIX;
     private final String CHALLENGE_BOOKMARK_COUNT_KEY = "challenge" + BOOKMARK_SUFFIX + ":counts";
-    private final String CHALLENGE_BOOKMARK_ADDED_KEY = "challenge:%d" + BOOKMARK_SUFFIX + ":added" + USER_SUFFIX;
-    private final String CHALLENGE_BOOKMARK_DELETED_KEY = "challenge:%d" + BOOKMARK_SUFFIX + ":deleted" + USER_SUFFIX;
+    public static final String CHALLENGE_BOOKMARK_ADDED_KEY = "challenge:%d" + BOOKMARK_SUFFIX + ":added" + USER_SUFFIX;
+    public static final String CHALLENGE_BOOKMARK_DELETED_KEY = "challenge:%d" + BOOKMARK_SUFFIX + ":deleted" + USER_SUFFIX;
+
+    public static final String CHALLENGE_BOOKMARK_ADDED_PATTERN = "challenge:*" + BOOKMARK_SUFFIX + ":added" + USER_SUFFIX;
+    public static final String CHALLENGE_BOOKMARK_DELETED_PATTERN = "challenge:*" + BOOKMARK_SUFFIX + ":deleted" + USER_SUFFIX;
 
     @Override
     public void addBookmark(Long userId, Long challengeId) {
@@ -81,6 +86,22 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
     }
 
     @Override
+    public Set<Long> getBookmarkAddedUsers(Long challengeId) {
+        String addedKey = getRedisKey(CHALLENGE_BOOKMARK_ADDED_KEY, challengeId);
+
+        return Optional.ofNullable(redisTemplate.opsForSet().members(addedKey))
+                .orElse(Collections.emptySet());
+    }
+
+    @Override
+    public Set<Long> getBookmarkDeletedUsers(Long challengeId) {
+        String deletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
+
+        return Optional.ofNullable(redisTemplate.opsForSet().members(deletedKey))
+                .orElse(Collections.emptySet());
+    }
+
+    @Override
     public void removeBookmarksByChallenge(Long challengeId) {
         String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
         String challengeAddedKey = getRedisKey(CHALLENGE_BOOKMARK_ADDED_KEY, challengeId);
@@ -94,6 +115,19 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
 
         redisTemplate.opsForZSet().remove(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
         redisTemplate.delete(List.of(challengeKey, challengeAddedKey));
+    }
+
+    public Cursor<String> getKeysByPattern(String pattern, int count) {
+        ScanOptions scanOptions = ScanOptions.scanOptions()
+                .match(pattern)
+                .count(count)
+                .build();
+
+        return redisTemplate.scan(scanOptions);
+    }
+
+    public void deleteKeys(List<String> keys) {
+        redisTemplate.delete(keys);
     }
 
     private void addUserChallengeBookmark(Long userId, Long challengeId) {

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRedisCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRedisCache.java
@@ -47,7 +47,7 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
     @Override
     public boolean isBookmarked(Long userId, Long challengeId) {
         String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
-        return redisTemplate.opsForSet().isMember(challengeKey, userId);
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(challengeKey, userId));
     }
 
     @Override

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRedisCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRedisCache.java
@@ -23,12 +23,14 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
     private final String USER_KEY = "user:%d" + BOOKMARK_SUFFIX + CHALLENGE_SUFFIX;
     private final String CHALLENGE_BOOKMARK_KEY = "challenge:%d" + BOOKMARK_SUFFIX + USER_SUFFIX;
     private final String CHALLENGE_BOOKMARK_COUNT_KEY = "challenge" + BOOKMARK_SUFFIX + ":counts";
+    private final String CHALLENGE_BOOKMARK_ADDED_KEY = "challenge:%d" + BOOKMARK_SUFFIX + ":added" + USER_SUFFIX;
     private final String CHALLENGE_BOOKMARK_DELETED_KEY = "challenge:%d" + BOOKMARK_SUFFIX + ":deleted" + USER_SUFFIX;
 
     @Override
     public void addBookmark(Long userId, Long challengeId) {
         addUserChallengeBookmark(userId, challengeId);
         addChallengeUserBookmark(userId, challengeId);
+        addChallengeBookmarkAdded(userId, challengeId);
         removeChallengeBookmarkDeleted(userId, challengeId);
         incrementChallengeBookmarkScore(challengeId);
     }
@@ -37,6 +39,7 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
     public void removeBookmark(Long userId, Long challengeId) {
         removeUserChallengeBookmark(userId, challengeId);
         removeChallengeUserBookmark(userId, challengeId);
+        removeChallengeBookmarkAdded(userId, challengeId);
         addChallengeBookmarkDeleted(userId, challengeId);
         decrementChallengeBookmarkScore(challengeId);
     }
@@ -80,16 +83,17 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
     @Override
     public void removeBookmarksByChallenge(Long challengeId) {
         String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
-        String challengeDeletedKey = getRedisKey(CHALLENGE_BOOKMARK_DELETED_KEY, challengeId);
+        String challengeAddedKey = getRedisKey(CHALLENGE_BOOKMARK_ADDED_KEY, challengeId);
 
         Set<Long> userIds = getBookmarkedUsers(challengeId);
 
         userIds.forEach(userId -> {
             removeUserChallengeBookmark(userId, challengeId);
+            addChallengeBookmarkDeleted(userId, challengeId);
         });
 
         redisTemplate.opsForZSet().remove(CHALLENGE_BOOKMARK_COUNT_KEY, challengeId);
-        redisTemplate.delete(List.of(challengeKey, challengeDeletedKey));
+        redisTemplate.delete(List.of(challengeKey, challengeAddedKey));
     }
 
     private void addUserChallengeBookmark(Long userId, Long challengeId) {
@@ -111,6 +115,16 @@ public class ChallengeBookmarkRedisCache implements ChallengeBookmarkCache {
     private void removeChallengeUserBookmark(Long userId, Long challengeId) {
         String challengeKey = getRedisKey(CHALLENGE_BOOKMARK_KEY, challengeId);
         redisTemplate.opsForSet().remove(challengeKey, userId);
+    }
+
+    private void addChallengeBookmarkAdded(Long userId, Long challengeId) {
+        String challengeAddedKey = getRedisKey(CHALLENGE_BOOKMARK_ADDED_KEY, challengeId);
+        redisTemplate.opsForSet().add(challengeAddedKey, userId);
+    }
+
+    private void removeChallengeBookmarkAdded(Long userId, Long challengeId) {
+        String challengeAddedKey = getRedisKey(CHALLENGE_BOOKMARK_ADDED_KEY, challengeId);
+        redisTemplate.opsForSet().remove(challengeAddedKey, userId);
     }
 
     private void addChallengeBookmarkDeleted(Long userId, Long challengeId) {

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/bookmark/ChallengeBookmarkRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChallengeBookmarkRepository extends JpaRepository<ChallengeBookmark, Long> {
+public interface ChallengeBookmarkRepository extends JpaRepository<ChallengeBookmark, Long>, ChallengeBookmarkCustomRepository {
+    void deleteByChallengeIdAndUserId(Long challengeId, Long userId);
 }


### PR DESCRIPTION
- `ChallengeBookmarkRedisCache`에 북마크를 추가한 유저를 저장하는 `challenge:%d:bookmarks:added:users` 추가
- Redis의 챌린지 북마크 added, deleted 정보를 기반으로 DB에 데이터 추가 및 삭제
  - `ChallengeBookmark` 엔티티의 연관관계 제거 및 기본 키 방식으로 변경
  -   관련 `ItemReader`, `ItemProcessor`, `ItemWriter` 구현
  - `syncChallengeBookmarkJob` 구현
    - `insertChallengeBookmarkStep`, `deleteChallengeBookmarkStep`, `deleteChallengeBookmarkRedisKeyStep` 구현
