### PR TITLE
[#66] 게시글 좋아요 Redis 접근 로직 분리 

### DIFF
--- a/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
@@ -29,14 +29,24 @@ public class PostLikeService {
     @Transactional
     public PostResponse.Like addLike(User user, Long postId) {
         validateExistPost(postId);
-        int likeCount = postLikeCache.addLike(user.getId(), postId);
+
+        int likeCount = postLikeCache.getPostLikeCount(postId);
+        if (!postLikeCache.alreadyLike(user.getId(), postId)){
+            postLikeCache.addLike(user.getId(), postId);
+            likeCount++;
+        }
         return PostResponse.Like.from(likeCount, true);
     }
 
     @Transactional
     public PostResponse.Like removeLike(User user, Long postId){
         validateExistPost(postId);
-        int likeCount = postLikeCache.removeLike(user.getId(), postId);
+
+        int likeCount = postLikeCache.getPostLikeCount(postId);
+        if (postLikeCache.alreadyLike(user.getId(), postId)){
+            postLikeCache.removeLike(user.getId(), postId);
+            likeCount--;
+        }
         return PostResponse.Like.from(likeCount,false);
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/post/service/PostLikeService.java
@@ -4,119 +4,65 @@ import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.post.dto.PostResponse;
 import com.trybe.moduleapi.post.exception.NotFoundPostException;
 import com.trybe.modulecore.post.entity.Post;
+import com.trybe.modulecore.post.repository.PostLikeCache;
 import com.trybe.modulecore.post.repository.PostRepository;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
 public class PostLikeService {
-    private final String POST_LIKE_SUFFIX = ":liked";
-    private final String USER_REDIS_KEY = "user:%d" + POST_LIKE_SUFFIX + ":posts";
-    private final String POST_REDIS_KEY = "post:%d" + POST_LIKE_SUFFIX + ":users";
-    private final String POST_LIKE_DELETE_KEY = POST_REDIS_KEY + ":deleted";
-    private final RedisTemplate<String, Long> redisTemplate;
     private final PostRepository postRepository;
+    private final PostLikeCache postLikeCache;
 
-    public PostLikeService(RedisTemplate<String, Long> redisTemplate, PostRepository postRepository) {
-        this.redisTemplate = redisTemplate;
+    public PostLikeService(PostRepository postRepository, PostLikeCache postLikeCache) {
         this.postRepository = postRepository;
+        this.postLikeCache = postLikeCache;
     }
 
     @Transactional
     public PostResponse.Like addLike(User user, Long postId) {
         validateExistPost(postId);
-
-        String userKey = createRedisKey(USER_REDIS_KEY, user.getId());
-        String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
-        String postKey = createRedisKey(POST_REDIS_KEY, postId);
-        int likeCount = count(postId);
-
-        if (!alreadyLike(userKey, postId)) {
-            double score = getCurrentTimeInSeconds();
-            redisTemplate.opsForZSet().add(userKey, postId, score);
-            redisTemplate.opsForSet().add(postKey, user.getId());
-            redisTemplate.opsForSet().remove(deleteKey, user.getId());
-            likeCount++;
-        }
+        int likeCount = postLikeCache.addLike(user.getId(), postId);
         return PostResponse.Like.from(likeCount, true);
     }
 
     @Transactional
     public PostResponse.Like removeLike(User user, Long postId){
         validateExistPost(postId);
-
-        String userKey = createRedisKey(USER_REDIS_KEY, user.getId());
-        String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
-        String postKey = createRedisKey(POST_REDIS_KEY, postId);
-
-        int likeCount = count(postId);
-
-        if (alreadyLike(userKey, postId)) {
-            redisTemplate.opsForZSet().remove(userKey, postId);
-            redisTemplate.opsForSet().remove(postKey, user.getId());
-            redisTemplate.opsForSet().add(deleteKey, user.getId());
-            likeCount--;
-        }
+        int likeCount = postLikeCache.removeLike(user.getId(), postId);
         return PostResponse.Like.from(likeCount,false);
     }
 
-    public void removeLikesByPost(Long postId){
-        String postKey = createRedisKey(POST_REDIS_KEY, postId);
-        Set<Long> userIds = redisTemplate.opsForSet().members(postKey);
-        if (userIds != null) {
-            for (Long userId : userIds) {
-                String userKey = createRedisKey(USER_REDIS_KEY, userId);
-                redisTemplate.opsForZSet().remove(userKey, postId);
-
-                String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
-                redisTemplate.opsForSet().add(deleteKey, userId);
-            }
-            redisTemplate.delete(postKey);
-        }
+    public int getPostLikeCount(Long postId){
+        return postLikeCache.getPostLikeCount(postId);
     }
 
-    public int count(Long postId){
-        String postKey = createRedisKey(POST_REDIS_KEY, postId);
-        Long count = redisTemplate.opsForSet().size(postKey);
-        return count == null ? 0 : count.intValue();
+    public void removeLikesByPost(Long postId){
+        postLikeCache.removeLikesByPost(postId);
     }
 
     @Transactional
     public PageResponse<PostResponse.Summary> getLikePostByUser(User user, Pageable pageable){
-        String userKey = createRedisKey(USER_REDIS_KEY, user.getId());
+        int start = pageable.getPageNumber() * pageable.getPageSize();
+        int end = start + pageable.getPageSize() - 1;
 
-        Set<Long> postIds = redisTemplate.opsForZSet().reverseRange(userKey, 0, -1);
+        Set<Long> postIds = postLikeCache.getLikePostIdsByUser(user.getId(), start, end);
 
-        if (postIds == null || postIds.isEmpty()) {
-            return new PageResponse<>(Page.empty());
-        }
-        List<Post> posts = postRepository.findAllByIdIn(postIds);
-        List<Post> sortedPosts = postIds.stream()
-                                        .map(postId -> posts.stream()
-                                                                  .filter(post -> postId.equals(post.getId()))
-                                                                  .findFirst()
-                                                                  .orElse(null))
-                                        .filter(Objects::nonNull)
-                                        .collect(Collectors.toList());
+        List<Post> posts = postIds.isEmpty() ? Collections.emptyList() : postRepository.findAllByIdIn(postIds);
+        List<Post> sortedPosts = sortPosts(posts, postIds);
 
+        int totalElements = postLikeCache.getUserPostLikeCount(user.getId());
 
-        Page<Post> filterPostsPage = new PageImpl<>(sortedPosts, pageable, sortedPosts.size());
-        Page<PostResponse.Summary> likePostPages = filterPostsPage.map(PostResponse.Summary::from);
+        Page<Post> postPage = new PageImpl<>(sortedPosts, pageable, totalElements);
+        Page<PostResponse.Summary> likePostPages = postPage.map(PostResponse.Summary::from);
         return new PageResponse<>(likePostPages);
-    }
-
-    private String createRedisKey(String key, Long id){
-        return String.format(key, id);
     }
 
     private void validateExistPost(Long postId){
@@ -125,12 +71,12 @@ public class PostLikeService {
         }
     }
 
-    private boolean alreadyLike(String userKey, Long postId) {
-        Double score = redisTemplate.opsForZSet().score(userKey, postId);
-        return score != null;
-    }
+    private List<Post> sortPosts(List<Post> posts, Set<Long> postIds) {
+        Map<Long, Post> postMap = posts.stream()
+                .collect(Collectors.toMap(Post::getId, post -> post));
 
-    private double getCurrentTimeInSeconds() {
-        return System.currentTimeMillis() / 1000.0;
+        return postIds.stream()
+                .map(postMap::get)
+                .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/post/service/PostService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/post/service/PostService.java
@@ -1,6 +1,5 @@
 package com.trybe.moduleapi.post.service;
 
-import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.exception.participation.NotFoundChallengeParticipationException;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.post.dto.PostRequest;
@@ -22,7 +21,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -64,7 +62,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostResponse.Detail find(Long id){
         Post post = getPostById(id);
-        int likes = postLikeService.count(post.getId());
+        int likes = postLikeService.getPostLikeCount(post.getId());
         List<Challenge> challenges = getChallengesByPostId(post.getId());
         return PostResponse.Detail.from(post, challenges, likes);
     }
@@ -79,7 +77,7 @@ public class PostService {
     @Transactional
     public PostResponse.Detail updatePost(User user, Long id, PostRequest.Update request) {
         Post post = getPostById(id);
-        int likes = postLikeService.count(post.getId());
+        int likes = postLikeService.getPostLikeCount(post.getId());
 
         checkLoginUserAndPostUser(user, post);
 

--- a/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/fixtures/PostLikeFixtures.java
@@ -10,7 +10,6 @@ public class PostLikeFixtures {
     public static final PostResponse.Like 좋아요_추가_응답 = PostResponse.Like.from(5, true);
     public static final PostResponse.Like 좋아요_삭제_응답 = PostResponse.Like.from(4, false);
     public static final int 좋아요_개수 = 10;
-    public static final Long 좋아요_개수L = 20L;
 
     private static final String POST_LIKE_SUFFIX = ":liked";
     private static final String USER_REDIS_KEY = "user:%d" + POST_LIKE_SUFFIX + ":posts";

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
@@ -45,14 +45,17 @@ class PostLikeServiceTest {
 
         int 좋아요_개수 = PostLikeFixtures.좋아요_개수;
         when(postRepository.existsById(포스트_ID)).thenReturn(true);
-        when(postLikeCache.addLike(회원.getId(), 포스트_ID)).thenReturn(좋아요_개수);
+        when(postLikeCache.getPostLikeCount(포스트_ID)).thenReturn(좋아요_개수);
+        when(postLikeCache.alreadyLike(회원.getId(), 포스트_ID)).thenReturn(false);
 
         // when
         PostResponse.Like 응답 = postLikeService.addLike(회원, PostFixtures.id);
 
         // then
-        assertEquals(응답.likeCount(), 좋아요_개수);
+        assertEquals(응답.likeCount(), 좋아요_개수+1);
         assertEquals(응답.isLiked(), true);
+        verify(postLikeCache, times(1)).alreadyLike(회원.getId(), 포스트_ID);
+        verify(postLikeCache, times(1)).addLike(회원.getId(), 포스트_ID);
     }
 
     @Test
@@ -76,14 +79,17 @@ class PostLikeServiceTest {
 
         int 좋아요_개수 = PostLikeFixtures.좋아요_개수;
         when(postRepository.existsById(포스트_ID)).thenReturn(true);
-        when(postLikeCache.removeLike(회원.getId(), 포스트_ID)).thenReturn(좋아요_개수);
+        when(postLikeCache.getPostLikeCount(포스트_ID)).thenReturn(좋아요_개수);
+        when(postLikeCache.alreadyLike(회원.getId(), 포스트_ID)).thenReturn(true);
 
         // when
         PostResponse.Like 응답 = postLikeService.removeLike(회원, PostFixtures.id);
 
         // then
-        assertEquals(응답.likeCount(), 좋아요_개수);
+        assertEquals(응답.likeCount(), 좋아요_개수-1);
         assertEquals(응답.isLiked(), false);
+        verify(postLikeCache, times(1)).alreadyLike(회원.getId(), 포스트_ID);
+        verify(postLikeCache, times(1)).removeLike(회원.getId(), 포스트_ID);
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostLikeServiceTest.java
@@ -7,6 +7,7 @@ import com.trybe.moduleapi.post.fixtures.PostFixtures;
 import com.trybe.moduleapi.post.fixtures.PostLikeFixtures;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.post.entity.Post;
+import com.trybe.modulecore.post.repository.PostLikeCache;
 import com.trybe.modulecore.post.repository.PostRepository;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -17,9 +18,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SetOperations;
-import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.List;
 import java.util.Set;
@@ -31,7 +29,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class PostLikeServiceTest {
     @Mock
-    private RedisTemplate<String, Long> redisTemplate;
+    private PostLikeCache postLikeCache;
     @Mock
     private PostRepository postRepository;
 
@@ -42,28 +40,19 @@ class PostLikeServiceTest {
     @DisplayName("게시글에 좋아요를 누르면 Redis에 저장된다")
     void 게시글에_좋아요를_누르면_Redis에_저장된다() {
         // given
-        mockingRedisTemplate();
-
         User 회원 = UserFixtures.회원;
-        String userKey = PostLikeFixtures.createUserKey(회원.getId());
-
         Long 포스트_ID = PostFixtures.id;
-        String postKey = PostLikeFixtures.createPostKey(포스트_ID);
-        String deleteKey = PostLikeFixtures.createDeletedKey(포스트_ID);
 
-        Long 좋아요_개수 = PostLikeFixtures.좋아요_개수L;
-
+        int 좋아요_개수 = PostLikeFixtures.좋아요_개수;
         when(postRepository.existsById(포스트_ID)).thenReturn(true);
-        when(redisTemplate.opsForZSet().score(userKey, 포스트_ID)).thenReturn(null);
-        when(redisTemplate.opsForSet().size(postKey)).thenReturn(좋아요_개수);
+        when(postLikeCache.addLike(회원.getId(), 포스트_ID)).thenReturn(좋아요_개수);
 
         // when
         PostResponse.Like 응답 = postLikeService.addLike(회원, PostFixtures.id);
 
         // then
-        assertEquals(응답.likeCount(), 좋아요_개수+1);
+        assertEquals(응답.likeCount(), 좋아요_개수);
         assertEquals(응답.isLiked(), true);
-        verify(redisTemplate.opsForSet()).remove(eq(deleteKey), eq(회원.getId()));
     }
 
     @Test
@@ -82,30 +71,18 @@ class PostLikeServiceTest {
     @DisplayName("게시글에 대한 좋아요를 삭제하면 Redis에서 삭제된다.")
     void 게시글에_대한_좋아요를_삭제하면_Redis에서_삭제된다() {
         // given
-        mockingRedisTemplate();
-
         User 회원 = UserFixtures.회원;
-        String userKey = PostLikeFixtures.createUserKey(회원.getId());
-
         Long 포스트_ID = PostFixtures.id;
-        String postKey = PostLikeFixtures.createPostKey(포스트_ID);
-        String deleteKey = PostLikeFixtures.createDeletedKey(포스트_ID);
 
-        Long 좋아요_개수 = PostLikeFixtures.좋아요_개수L;
-
+        int 좋아요_개수 = PostLikeFixtures.좋아요_개수;
         when(postRepository.existsById(포스트_ID)).thenReturn(true);
-        when(redisTemplate.opsForZSet().score(userKey, 포스트_ID)).thenReturn(1.000);
-        when(redisTemplate.opsForSet().size(postKey)).thenReturn(좋아요_개수);
-
+        when(postLikeCache.removeLike(회원.getId(), 포스트_ID)).thenReturn(좋아요_개수);
 
         // when
         PostResponse.Like 응답 = postLikeService.removeLike(회원, PostFixtures.id);
 
         // then
-        verify(redisTemplate.opsForZSet()).remove(eq(userKey), eq(PostFixtures.id));
-        verify(redisTemplate.opsForSet()).remove(eq(postKey), eq(회원.getId()));
-        verify(redisTemplate.opsForSet()).add(eq(deleteKey), eq(회원.getId()));
-        assertEquals(응답.likeCount(), 좋아요_개수-1);
+        assertEquals(응답.likeCount(), 좋아요_개수);
         assertEquals(응답.isLiked(), false);
     }
 
@@ -126,60 +103,43 @@ class PostLikeServiceTest {
     @DisplayName("게시글이 삭제되면 해당 게시글에 대한 모든 좋아요는 삭제된다.")
     void 게시글이_삭제되면_해당_게시글에_대한_모든_좋아요는_삭제된다() {
         // given
-        mockingRedisTemplate();
-
         Long 포스트_ID = PostFixtures.id;
-        String postKey = PostLikeFixtures.createPostKey(포스트_ID);
-        Set<Long> userIds = PostLikeFixtures.게시글_좋아요_누른_유저목록;
-        when(redisTemplate.opsForSet().members(postKey)).thenReturn(userIds);
 
         // When
-        postLikeService.removeLikesByPost(PostFixtures.id);
+        postLikeService.removeLikesByPost(포스트_ID);
 
         // Then
-        for (Long userId : userIds) {
-            String userKey = PostLikeFixtures.createUserKey(userId);
-            verify(redisTemplate.opsForZSet(), times(1)).remove(eq(userKey), eq(PostFixtures.id));
-
-            String deleteKey = PostLikeFixtures.createDeletedKey(포스트_ID);
-            verify(redisTemplate.opsForSet()).add(eq(deleteKey), eq(userId));
-        }
-        verify(redisTemplate, times(1)).delete(postKey);
+        verify(postLikeCache, times(1)).removeLikesByPost(포스트_ID);
     }
 
     @Test
     @DisplayName("특정 게시글의 좋아요 수를 조회하면 좋아요 개수가 반환된다.")
     void 특정_게시글의_좋아요_수를_조회하면_좋아요_개수가_반환된다() {
         // given
-        SetOperations<String, Long> setOps = mock(SetOperations.class);
-        when(redisTemplate.opsForSet()).thenReturn(setOps);
-
         Long 포스트_ID = PostFixtures.id;
-        String postKey = PostLikeFixtures.createPostKey(포스트_ID);
-        when(redisTemplate.opsForSet().size(postKey)).thenReturn(5L);
+        int 좋아요_개수 = PostLikeFixtures.좋아요_개수;
+        when(postLikeCache.getPostLikeCount(포스트_ID)).thenReturn(좋아요_개수);
 
         // when
-        int likeCount = postLikeService.count(PostFixtures.id);
+        int likeCount = postLikeService.getPostLikeCount(PostFixtures.id);
 
         // then
-        assertEquals(likeCount, 5);
+        assertEquals(likeCount, 좋아요_개수);
     }
 
     @Test
     @DisplayName("회원이 자신이 좋아요 누른 게시글을 조회하면 좋아요 누른 순으로 반환된다.")
     void 회원이_자신이_좋아요_누른_게시글을_조회하면_좋아요_누른_순으로_반환된다() {
         // given
-        ZSetOperations<String, Long> zSetOps = mock(ZSetOperations.class);
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
-
         Pageable pageable = PageRequest.of(0, 10);
+        int start = pageable.getPageNumber() * pageable.getPageSize();
+        int end = start + pageable.getPageSize() - 1;
 
         User 회원 = UserFixtures.회원;
-        String userKey = PostLikeFixtures.createUserKey(회원.getId());
         Set<Long> postIds = PostFixtures.게시글_아이디_목록;
         List<Post> 게시글_목록 = PostFixtures.ID_존재하는_게시글_목록;
 
-        when(redisTemplate.opsForZSet().reverseRange(userKey, 0, -1)).thenReturn(postIds);
+        when(postLikeCache.getLikePostIdsByUser(회원.getId(), start, end)).thenReturn(postIds);
         when(postRepository.findAllByIdIn(postIds)).thenReturn(게시글_목록);
 
         // When
@@ -187,13 +147,5 @@ class PostLikeServiceTest {
 
         // Then
         assertEquals(응답.content().size(), 게시글_목록.size());
-    }
-
-    private void mockingRedisTemplate(){
-        ZSetOperations<String, Long> zSetOps = mock(ZSetOperations.class);
-        SetOperations<String, Long> setOps = mock(SetOperations.class);
-
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
-        when(redisTemplate.opsForSet()).thenReturn(setOps);
     }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/post/service/PostServiceTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +31,8 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -106,7 +106,7 @@ class PostServiceTest {
 
         when(postRepository.findById(any())).thenReturn(Optional.of(게시글));
         when(postChallengeRepository.findAllByPostId(any())).thenReturn(PostChallengeFixtures.게시글_챌린지_목록);
-        when(postLikeService.count(any())).thenReturn(좋아요_개수);
+        when(postLikeService.getPostLikeCount(any())).thenReturn(좋아요_개수);
 
         /* when */
         PostResponse.Detail postDetail = postService.find(1L);
@@ -161,7 +161,7 @@ class PostServiceTest {
 
         when(postRepository.findById(any())).thenReturn(Optional.of(PostFixtures.게시글));
         when(challengeRepository.findAllByIdIn(PostFixtures.수정_챌린지_Ids)).thenReturn(List.of(ChallengeFixtures.챌린지(),ChallengeFixtures.챌린지()));
-        when(postLikeService.count(any())).thenReturn(좋아요_개수);
+        when(postLikeService.getPostLikeCount(any())).thenReturn(좋아요_개수);
 
 
         /* when */

--- a/module-core/src/main/java/com/trybe/modulecore/post/repository/PostLikeCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/post/repository/PostLikeCache.java
@@ -25,7 +25,7 @@ public class PostLikeCache {
         String userKey = createRedisKey(USER_REDIS_KEY, userId);
         String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
         String postKey = createRedisKey(POST_REDIS_KEY, postId);
-        int likeCount = count(postId);
+        int likeCount = getPostLikeCount(postId);
 
         if (!alreadyLike(userKey, postId)) {
             double score = getCurrentTimeInSeconds();
@@ -42,7 +42,7 @@ public class PostLikeCache {
         String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
         String postKey = createRedisKey(POST_REDIS_KEY, postId);
 
-        int likeCount = count(postId);
+        int likeCount = getPostLikeCount(postId);
 
         if (alreadyLike(userKey, postId)) {
             redisTemplate.opsForZSet().remove(userKey, postId);
@@ -74,7 +74,13 @@ public class PostLikeCache {
                 .orElse(Collections.emptySet());
     }
 
-    public int count(Long postId){
+    public int getUserPostLikeCount(Long userId){
+        String userKey = createRedisKey(USER_REDIS_KEY, userId);
+        Long count = redisTemplate.opsForZSet().size(userKey);
+        return count == null ? 0 : count.intValue();
+    }
+
+    public int getPostLikeCount(Long postId){
         String postKey = createRedisKey(POST_REDIS_KEY, postId);
         Long count = redisTemplate.opsForSet().size(postKey);
         return count == null ? 0 : count.intValue();

--- a/module-core/src/main/java/com/trybe/modulecore/post/repository/PostLikeCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/post/repository/PostLikeCache.java
@@ -1,0 +1,95 @@
+package com.trybe.modulecore.post.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+@Repository
+public class PostLikeCache {
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    private final String POST_LIKE_SUFFIX = ":liked";
+    private final String USER_REDIS_KEY = "user:%d" + POST_LIKE_SUFFIX + ":posts";
+    private final String POST_REDIS_KEY = "post:%d" + POST_LIKE_SUFFIX + ":users";
+    private final String POST_LIKE_DELETE_KEY = POST_REDIS_KEY + ":deleted";
+
+
+    public PostLikeCache(RedisTemplate<String, Long> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public int addLike(Long userId, Long postId){
+        String userKey = createRedisKey(USER_REDIS_KEY, userId);
+        String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
+        String postKey = createRedisKey(POST_REDIS_KEY, postId);
+        int likeCount = count(postId);
+
+        if (!alreadyLike(userKey, postId)) {
+            double score = getCurrentTimeInSeconds();
+            redisTemplate.opsForZSet().add(userKey, postId, score);
+            redisTemplate.opsForSet().add(postKey, userId);
+            redisTemplate.opsForSet().remove(deleteKey, userId);
+            likeCount++;
+        }
+        return likeCount;
+    }
+
+    public int removeLike(Long userId, Long postId){
+        String userKey = createRedisKey(USER_REDIS_KEY, userId);
+        String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
+        String postKey = createRedisKey(POST_REDIS_KEY, postId);
+
+        int likeCount = count(postId);
+
+        if (alreadyLike(userKey, postId)) {
+            redisTemplate.opsForZSet().remove(userKey, postId);
+            redisTemplate.opsForSet().remove(postKey, userId);
+            redisTemplate.opsForSet().add(deleteKey, userId);
+            likeCount--;
+        }
+        return likeCount;
+    }
+
+    public void removeLikesByPost(Long postId){
+        String postKey = createRedisKey(POST_REDIS_KEY, postId);
+        Set<Long> userIds = redisTemplate.opsForSet().members(postKey);
+        if (userIds != null) {
+            for (Long userId : userIds) {
+                String userKey = createRedisKey(USER_REDIS_KEY, userId);
+                redisTemplate.opsForZSet().remove(userKey, postId);
+
+                String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
+                redisTemplate.opsForSet().add(deleteKey, userId);
+            }
+            redisTemplate.delete(postKey);
+        }
+    }
+
+    public Set<Long> getLikePostIdsByUser(Long userId, int start, int end){
+        String userKey = createRedisKey(USER_REDIS_KEY, userId);
+        return Optional.ofNullable(redisTemplate.opsForZSet().reverseRange(userKey, start, end))
+                .orElse(Collections.emptySet());
+    }
+
+    public int count(Long postId){
+        String postKey = createRedisKey(POST_REDIS_KEY, postId);
+        Long count = redisTemplate.opsForSet().size(postKey);
+        return count == null ? 0 : count.intValue();
+    }
+
+    private String createRedisKey(String key, Long id){
+        return String.format(key, id);
+    }
+
+    private boolean alreadyLike(String userKey, Long postId) {
+        Double score = redisTemplate.opsForZSet().score(userKey, postId);
+        return score != null;
+    }
+
+    private double getCurrentTimeInSeconds() {
+        return System.currentTimeMillis() / 1000.0;
+    }
+}

--- a/module-core/src/main/java/com/trybe/modulecore/post/repository/PostLikeCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/post/repository/PostLikeCache.java
@@ -21,36 +21,25 @@ public class PostLikeCache {
         this.redisTemplate = redisTemplate;
     }
 
-    public int addLike(Long userId, Long postId){
+    public void addLike(Long userId, Long postId){
         String userKey = createRedisKey(USER_REDIS_KEY, userId);
         String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
         String postKey = createRedisKey(POST_REDIS_KEY, postId);
-        int likeCount = getPostLikeCount(postId);
 
-        if (!alreadyLike(userKey, postId)) {
-            double score = getCurrentTimeInSeconds();
-            redisTemplate.opsForZSet().add(userKey, postId, score);
-            redisTemplate.opsForSet().add(postKey, userId);
-            redisTemplate.opsForSet().remove(deleteKey, userId);
-            likeCount++;
-        }
-        return likeCount;
+        double score = getCurrentTimeInSeconds();
+        redisTemplate.opsForZSet().add(userKey, postId, score);
+        redisTemplate.opsForSet().add(postKey, userId);
+        redisTemplate.opsForSet().remove(deleteKey, userId);
     }
 
-    public int removeLike(Long userId, Long postId){
+    public void removeLike(Long userId, Long postId){
         String userKey = createRedisKey(USER_REDIS_KEY, userId);
         String deleteKey = createRedisKey(POST_LIKE_DELETE_KEY, postId);
         String postKey = createRedisKey(POST_REDIS_KEY, postId);
 
-        int likeCount = getPostLikeCount(postId);
-
-        if (alreadyLike(userKey, postId)) {
-            redisTemplate.opsForZSet().remove(userKey, postId);
-            redisTemplate.opsForSet().remove(postKey, userId);
-            redisTemplate.opsForSet().add(deleteKey, userId);
-            likeCount--;
-        }
-        return likeCount;
+        redisTemplate.opsForZSet().remove(userKey, postId);
+        redisTemplate.opsForSet().remove(postKey, userId);
+        redisTemplate.opsForSet().add(deleteKey, userId);
     }
 
     public void removeLikesByPost(Long postId){
@@ -66,6 +55,12 @@ public class PostLikeCache {
             }
             redisTemplate.delete(postKey);
         }
+    }
+
+    public boolean alreadyLike(Long userId, Long postId) {
+        String userKey = createRedisKey(USER_REDIS_KEY, userId);
+        Double score = redisTemplate.opsForZSet().score(userKey, postId);
+        return score != null;
     }
 
     public Set<Long> getLikePostIdsByUser(Long userId, int start, int end){
@@ -88,11 +83,6 @@ public class PostLikeCache {
 
     private String createRedisKey(String key, Long id){
         return String.format(key, id);
-    }
-
-    private boolean alreadyLike(String userKey, Long postId) {
-        Double score = redisTemplate.opsForZSet().score(userKey, postId);
-        return score != null;
     }
 
     private double getCurrentTimeInSeconds() {


### PR DESCRIPTION
- PostLikeService내의 Redis 접근 로직 분리
    - `PostLikeCache` 구현
    - User가 좋아요 누른 게시글 개수 조회 메서드 추가
    - 특정 게시글에 대한 좋아요 개수 조회 메서드명 수정
- 변경 사항에 따른 테스트 코드 수정