### PR TITLE
[#72] 유저 프로필 사진 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ jenkins
 redis
 files
 **/application*.yml
+module-api/http/testImg

--- a/module-api/http/user.http
+++ b/module-api/http/user.http
@@ -56,6 +56,18 @@ Authorization: {{accessToken}}
   "birth": null
 }
 
+### 3.2 프로필 이미지 업로드
+PUT http://localhost:8080/api/v1/users/update-profile
+Content-Type: multipart/form-data; boundary=boundary
+Authorization: {{accessToken}}
+
+--boundary
+Content-Disposition: form-data; name="file"; filename="test.jpeg"
+Content-Type: image/jpeg
+
+< ./testImg/test.jpeg
+--boundary--
+
 ### 4. 비밀번호 수정 API
 PUT http://localhost:8080/api/v1/users/change-password
 Content-Type: application/json
@@ -94,11 +106,11 @@ GET http://localhost:8080/api/v1/users/check-email?email=test2@google.com
 GET http://localhost:8080/api/v1/users/check-email?email=test@google.com
 
 ### 7.1 회원탈퇴 API
-DELETE http://localhost:8080/api/v1/users/1
+DELETE http://localhost:8080/api/v1/users
 Authorization: {{accessToken}}
 
 ### 7.1 회원탈퇴 API (인증 실패)
-DELETE http://localhost:8080/api/v1/users/1
+DELETE http://localhost:8080/api/v1/users
 
 
 

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -98,6 +98,16 @@ include::{snippets}/user-controller-test/user-update-password/invalid/bad-reques
 include::{snippets}/user-controller-test/user-update-password/invalid/bad-request/http-response.adoc[]
 include::{snippets}/user-controller-test/user-update-password/invalid/bad-request/response-fields.adoc[]
 
+=== 프로필 이미지 수정 API
+프로필 이미지 수정 시 다음과 같이 응답합니다.
+
+==== 정상 요청
+include::{snippets}/user-controller-test/updateProfile/http-request.adoc[]
+
+- 응답
+include::{snippets}/user-controller-test/updateProfile/http-response.adoc[]
+include::{snippets}/user-controller-test/updateProfile/response-fields.adoc[]
+
 === 회원탈퇴
 회원탈퇴 기능
 

--- a/module-api/src/main/java/com/trybe/moduleapi/file/service/LocalFileService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/file/service/LocalFileService.java
@@ -5,7 +5,6 @@ import com.trybe.moduleapi.file.exception.FileUploadException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
@@ -54,10 +53,8 @@ public class LocalFileService implements FileService {
 
     private String generateFileName(MultipartFile file) {
         String originalName = file.getOriginalFilename();
-        String extension = StringUtils.getFilenameExtension(originalName);
-        return UUID.randomUUID() + "-" + originalName + "." + extension;
+        return UUID.randomUUID() + "-" + originalName;
     }
-
     private void createDirIfNotExists(String dirPath) {
         java.io.File file = new java.io.File(dirPath);
 

--- a/module-api/src/main/java/com/trybe/moduleapi/user/controller/UserController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/controller/UserController.java
@@ -7,11 +7,11 @@ import com.trybe.moduleapi.user.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/users")
 public class UserController {
-
     private final UserService userService;
 
     public UserController(UserService userService) {
@@ -40,6 +40,13 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody UserRequest.UpdatePassword userRequest) {
         userService.updatePassword(userDetails, userRequest);
+    }
+
+    @PutMapping("/update-profile")
+    public UserResponse.Detail update(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart(name = "file") MultipartFile profileImage) {
+        return userService.updateProfileImage(userDetails.getUser(), profileImage);
     }
 
     @DeleteMapping

--- a/module-api/src/main/java/com/trybe/moduleapi/user/controller/UserController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
     }
 
     @PutMapping("/update-profile")
-    public UserResponse.Detail update(
+    public UserResponse.Detail updateProfileImage(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestPart(name = "file") MultipartFile profileImage) {
         return userService.updateProfileImage(userDetails.getUser(), profileImage);

--- a/module-api/src/main/java/com/trybe/moduleapi/user/dto/response/UserResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/dto/response/UserResponse.java
@@ -1,5 +1,6 @@
 package com.trybe.moduleapi.user.dto.response;
 
+import com.trybe.moduleapi.file.dto.FileResponse;
 import com.trybe.modulecore.user.entity.User;
 import com.trybe.modulecore.user.enums.Gender;
 
@@ -14,9 +15,9 @@ public class UserResponse {
             String email,
             Gender gender,
             LocalDate birth,
-            String profileImageUrl
+            FileResponse fileResponse
     ) {
-        public static Detail from(User user, String profileImageUrl) {
+        public static Detail from(User user, FileResponse fileResponse) {
             return new Detail(
                     user.getId(),
                     user.getNickname(),
@@ -24,7 +25,7 @@ public class UserResponse {
                     user.getEmail(),
                     user.getGender(),
                     user.getBirth(),
-                    profileImageUrl
+                    fileResponse
             );
         }
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/user/dto/response/UserResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/dto/response/UserResponse.java
@@ -13,15 +13,19 @@ public class UserResponse {
             String userId,
             String email,
             Gender gender,
-            LocalDate birth
+            LocalDate birth,
+            String profileImageUrl
     ) {
-        public static Detail from(User user) {
-            return new Detail(user.getId(),
-                              user.getNickname(),
-                              user.getUserId(),
-                              user.getEmail(),
-                              user.getGender(),
-                              user.getBirth());
+        public static Detail from(User user, String profileImageUrl) {
+            return new Detail(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getUserId(),
+                    user.getEmail(),
+                    user.getGender(),
+                    user.getBirth(),
+                    profileImageUrl
+            );
         }
     }
 
@@ -31,9 +35,11 @@ public class UserResponse {
             String nickname
     ){
         public static Summary from(User user) {
-            return new Summary(user.getId(),
-                              user.getUserId(),
-                              user.getNickname());
+            return new Summary(
+                    user.getId(),
+                    user.getUserId(),
+                    user.getNickname()
+            );
         }
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
@@ -23,7 +23,6 @@ public class UserService {
     private final FileManager fileManager;
 
     private static final String USER_PROFILE_BASE_PATH = "profile/user";
-    private static final String DEFAULT_PROFILE_BASE_PATH = "profile/default-profile.jpeg";
 
     public UserService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder, FileManager fileManager) {
         this.userRepository = userRepository;
@@ -47,8 +46,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponse.Detail findById(Long id){
         User user = getUserById(id);
-        String profileImageUrl = getUserProfileImageUrl(user);
-        FileResponse fileResponse = FileResponse.from(user.getProfileImage().getOriginalName(), profileImageUrl);
+        FileResponse fileResponse = toFileResponse(user);
         return UserResponse.Detail.from(user, fileResponse);
     }
 
@@ -65,14 +63,13 @@ public class UserService {
     @Transactional
     public UserResponse.Detail updateProfile(CustomUserDetails userDetails,
                                              UserRequest.Update userRequest){
-        User user = userDetails.getUser();
+        User user = getUserById(userDetails.getUser().getId());
         if (user.getEmail() != userRequest.email()) {
             checkDuplicatedEmail(userRequest.email());
         }
         user.updateProfile(userRequest.nickname(), userRequest.email(), userRequest.gender(), userRequest.birth());
-        String profileImageUrl = getUserProfileImageUrl(user);
+        FileResponse fileResponse = toFileResponse(user);
 
-        FileResponse fileResponse = FileResponse.from(user.getProfileImage().getOriginalName(), profileImageUrl);
         return UserResponse.Detail.from(user, fileResponse);
     }
 
@@ -86,8 +83,7 @@ public class UserService {
         user.updateProfileImage(file);
         userRepository.save(user);
 
-        String profileImageUrl = getUserProfileImageUrl(user);
-        FileResponse fileResponse = FileResponse.from(file.getOriginalName(), profileImageUrl);
+        FileResponse fileResponse = toFileResponse(user);
         return UserResponse.Detail.from(user, fileResponse);
     }
 
@@ -136,12 +132,10 @@ public class UserService {
         return userRepository.findById(id).orElseThrow(NotFoundUserException::new);
     }
 
-    private String getUserProfileImageUrl(User user){
-        String filePath = (user.getProfileImage() == null) ?
-                DEFAULT_PROFILE_BASE_PATH :
-                user.getProfileImage().getFilePath();
+    private FileResponse toFileResponse(User user) {
+        if (user.getProfileImage() == null) return null;
 
-        return fileManager.getFileUrl(filePath);
+        String url = fileManager.getFileUrl(user.getProfileImage().getFilePath());
+        return FileResponse.from(user.getProfileImage().getOriginalName(), url);
     }
-
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.trybe.moduleapi.user.service;
 
 import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.moduleapi.file.dto.FileResponse;
 import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.moduleapi.user.dto.request.UserRequest;
 import com.trybe.moduleapi.user.dto.response.UserResponse;
@@ -47,7 +48,8 @@ public class UserService {
     public UserResponse.Detail findById(Long id){
         User user = getUserById(id);
         String profileImageUrl = getUserProfileImageUrl(user);
-        return UserResponse.Detail.from(user, profileImageUrl);
+        FileResponse fileResponse = FileResponse.from(user.getProfileImage().getOriginalName(), profileImageUrl);
+        return UserResponse.Detail.from(user, fileResponse);
     }
 
     @Transactional
@@ -69,7 +71,9 @@ public class UserService {
         }
         user.updateProfile(userRequest.nickname(), userRequest.email(), userRequest.gender(), userRequest.birth());
         String profileImageUrl = getUserProfileImageUrl(user);
-        return UserResponse.Detail.from(user, profileImageUrl);
+
+        FileResponse fileResponse = FileResponse.from(user.getProfileImage().getOriginalName(), profileImageUrl);
+        return UserResponse.Detail.from(user, fileResponse);
     }
 
     @Transactional
@@ -83,7 +87,8 @@ public class UserService {
         userRepository.save(user);
 
         String profileImageUrl = getUserProfileImageUrl(user);
-        return UserResponse.Detail.from(user, profileImageUrl);
+        FileResponse fileResponse = FileResponse.from(file.getOriginalName(), profileImageUrl);
+        return UserResponse.Detail.from(user, fileResponse);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
@@ -46,7 +46,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponse.Detail findById(Long id){
         User user = getUserById(id);
-        FileResponse fileResponse = toFileResponse(user);
+        FileResponse fileResponse = toFileResponse(user.getProfileImage());
         return UserResponse.Detail.from(user, fileResponse);
     }
 
@@ -68,7 +68,7 @@ public class UserService {
             checkDuplicatedEmail(userRequest.email());
         }
         user.updateProfile(userRequest.nickname(), userRequest.email(), userRequest.gender(), userRequest.birth());
-        FileResponse fileResponse = toFileResponse(user);
+        FileResponse fileResponse = toFileResponse(user.getProfileImage());
 
         return UserResponse.Detail.from(user, fileResponse);
     }
@@ -83,7 +83,7 @@ public class UserService {
         user.updateProfileImage(file);
         userRepository.save(user);
 
-        FileResponse fileResponse = toFileResponse(user);
+        FileResponse fileResponse = toFileResponse(file);
         return UserResponse.Detail.from(user, fileResponse);
     }
 
@@ -132,10 +132,7 @@ public class UserService {
         return userRepository.findById(id).orElseThrow(NotFoundUserException::new);
     }
 
-    private FileResponse toFileResponse(User user) {
-        if (user.getProfileImage() == null) return null;
-
-        String url = fileManager.getFileUrl(user.getProfileImage().getFilePath());
-        return FileResponse.from(user.getProfileImage().getOriginalName(), url);
+    private FileResponse toFileResponse(File file) {
+        return file == null ? null : FileResponse.from(file.getOriginalName(), fileManager.getFileUrl(file.getFilePath()));
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
@@ -1,25 +1,33 @@
 package com.trybe.moduleapi.user.service;
 
 import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.moduleapi.user.dto.request.UserRequest;
 import com.trybe.moduleapi.user.dto.response.UserResponse;
 import com.trybe.moduleapi.user.exception.DuplicatedUserException;
 import com.trybe.moduleapi.user.exception.NotFoundUserException;
 import com.trybe.moduleapi.user.exception.UpdatePasswordFailException;
+import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.entity.User;
 import com.trybe.modulecore.user.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public class UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final FileManager fileManager;
 
-    public UserService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder) {
+    private static final String USER_PROFILE_BASE_PATH = "profile/user";
+    private static final String DEFAULT_PROFILE_BASE_PATH = "profile/default-profile.jpeg";
+
+    public UserService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder, FileManager fileManager) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.fileManager = fileManager;
     }
 
     @Transactional
@@ -31,29 +39,51 @@ public class UserService {
 
         String bcryptPassword = passwordEncoder.encode(userRequest.password());
         user.updatePassword(bcryptPassword);
+
         userRepository.save(user);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public UserResponse.Detail findById(Long id){
         User user = getUserById(id);
-        return UserResponse.Detail.from(user);
+        String profileImageUrl = getUserProfileImageUrl(user);
+        return UserResponse.Detail.from(user, profileImageUrl);
     }
 
     @Transactional
     public void delete(CustomUserDetails userDetails){
-        Long id = userDetails.getUser().getId();
-        userRepository.deleteById(id);
+        User user = getUserById(userDetails.getUser().getId());
+
+        File profileImage = user.getProfileImage();
+        fileManager.deleteFile(profileImage);
+
+        userRepository.deleteById(user.getId());
     }
 
     @Transactional
-    public UserResponse.Detail updateProfile(CustomUserDetails userDetails, UserRequest.Update userRequest){
+    public UserResponse.Detail updateProfile(CustomUserDetails userDetails,
+                                             UserRequest.Update userRequest){
         User user = userDetails.getUser();
         if (user.getEmail() != userRequest.email()) {
             checkDuplicatedEmail(userRequest.email());
         }
         user.updateProfile(userRequest.nickname(), userRequest.email(), userRequest.gender(), userRequest.birth());
-        return UserResponse.Detail.from(user);
+        String profileImageUrl = getUserProfileImageUrl(user);
+        return UserResponse.Detail.from(user, profileImageUrl);
+    }
+
+    @Transactional
+    public UserResponse.Detail updateProfileImage(User user, MultipartFile newProfileImage) {
+
+        File file = (user.getProfileImage() != null) ?
+                fileManager.updateFile(user.getProfileImage(), newProfileImage, USER_PROFILE_BASE_PATH) :
+                fileManager.uploadFile(newProfileImage, USER_PROFILE_BASE_PATH);
+
+        user.updateProfileImage(file);
+        userRepository.save(user);
+
+        String profileImageUrl = getUserProfileImageUrl(user);
+        return UserResponse.Detail.from(user, profileImageUrl);
     }
 
     @Transactional
@@ -99,6 +129,14 @@ public class UserService {
 
     private User getUserById(Long id) {
         return userRepository.findById(id).orElseThrow(NotFoundUserException::new);
+    }
+
+    private String getUserProfileImageUrl(User user){
+        String filePath = (user.getProfileImage() == null) ?
+                DEFAULT_PROFILE_BASE_PATH :
+                user.getProfileImage().getFilePath();
+
+        return fileManager.getFileUrl(filePath);
     }
 
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/user/controller/UserControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.trybe.moduleapi.user.controller;
 
+import com.trybe.moduleapi.annotation.WithCustomMockUser;
 import com.trybe.moduleapi.auth.CustomUserDetails;
 import com.trybe.moduleapi.common.ControllerTest;
 import com.trybe.moduleapi.user.dto.request.UserRequest;
@@ -10,13 +11,16 @@ import com.trybe.moduleapi.user.exception.UpdatePasswordFailException;
 import com.trybe.moduleapi.user.fixtures.AuthenticationFixtures;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.moduleapi.user.service.UserService;
+import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.charset.StandardCharsets;
 
@@ -24,11 +28,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -115,6 +116,7 @@ class UserControllerTest  extends ControllerTest {
     @DisplayName("중복 아이디로 회원가입 요청 시 409을 반환한다.")
     void 중복_아이디로_회원가입_요청_시_409을_반환한다() throws Exception {
         UserRequest.Create 중복된_아이디_회원가입_요청 = UserFixtures.회원가입_요청;
+
         doThrow(new DuplicatedUserException("이미 존재하는 아이디입니다.")).when(userService).save(중복된_아이디_회원가입_요청);
         mockMvc.perform(post("/api/v1/users")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -148,6 +150,7 @@ class UserControllerTest  extends ControllerTest {
     @DisplayName("중복 이메일로 회원가입 요청 시 409을 반환한다.")
     void 중복_이메일로_회원가입_요청_시_409을_반환한다() throws Exception {
         UserRequest.Create 중복된_이메일_회원가입_요청 = UserFixtures.회원가입_요청;
+
         doThrow(new DuplicatedUserException("이미 존재하는 이메일입니다.")).when(userService).save(중복된_이메일_회원가입_요청);
         mockMvc.perform(post("/api/v1/users")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -194,7 +197,8 @@ class UserControllerTest  extends ControllerTest {
                        jsonPath("$.email").value(회원_응답.email()),
                        jsonPath("$.userId").value(회원_응답.userId()),
                        jsonPath("$.gender").value(회원_응답.gender().toString()),
-                       jsonPath("$.birth").value(회원_응답.birth().toString())
+                       jsonPath("$.birth").value(회원_응답.birth().toString()),
+                       jsonPath("$.profileImageUrl").value(회원_응답.profileImageUrl())
                )
                .andDo(document(docsPath + "findById",
                                preprocessRequest(prettyPrint()),
@@ -206,7 +210,8 @@ class UserControllerTest  extends ControllerTest {
                                        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                        fieldWithPath("userId").type(JsonFieldType.STRING).description("아이디"),
                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
-                                       fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)")
+                                       fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)"),
+                                       fieldWithPath("profileImageUrl").type(JsonFieldType.STRING).description("이미지 경로")
                                )
                ));
     }
@@ -261,7 +266,8 @@ class UserControllerTest  extends ControllerTest {
                        jsonPath("$.email").value(회원_응답.email()),
                        jsonPath("$.userId").value(회원_응답.userId()),
                        jsonPath("$.gender").value(회원_응답.gender().toString()),
-                       jsonPath("$.birth").value(회원_응답.birth().toString())
+                       jsonPath("$.birth").value(회원_응답.birth().toString()),
+                       jsonPath("$.profileImageUrl").value(회원_응답.profileImageUrl())
                )
                .andDo(document(docsPath + "user-update-profile",
                                preprocessRequest(prettyPrint()),
@@ -278,7 +284,8 @@ class UserControllerTest  extends ControllerTest {
                                        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                        fieldWithPath("userId").type(JsonFieldType.STRING).description("아이디"),
                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
-                                       fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)")
+                                       fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)"),
+                                       fieldWithPath("profileImageUrl").type(JsonFieldType.STRING).description("이미지 경로")
                                )
                ));
     }
@@ -425,6 +432,47 @@ class UserControllerTest  extends ControllerTest {
                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("추가 메시지").optional()
                                )
                ));
+    }
+
+    @Test
+    @DisplayName("정상적인 프로필 이미지 수정 시 200을 반환한다.")
+    @WithCustomMockUser
+    void 정상적인_프로필_이미지_수정_시_200을_반환한다 () throws Exception {
+        MockMultipartFile 프로필_이미지_요청 = UserFixtures.프로필_이미지_요청;
+        UserResponse.Detail 회원_응답 = UserFixtures.회원_응답;
+
+        when(userService.updateProfileImage(any(User.class), any(MultipartFile.class))).thenReturn(회원_응답);
+
+        mockMvc.perform(multipart("/api/v1/users/update-profile")
+                .file(프로필_이미지_요청)
+                .with(request -> {
+                    request.setMethod("PUT");
+                    return request;
+                })
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andExpectAll(
+                        jsonPath("$.id").value(회원_응답.id()),
+                        jsonPath("$.nickname").value(회원_응답.nickname()),
+                        jsonPath("$.email").value(회원_응답.email()),
+                        jsonPath("$.userId").value(회원_응답.userId()),
+                        jsonPath("$.gender").value(회원_응답.gender().toString()),
+                        jsonPath("$.birth").value(회원_응답.birth().toString()),
+                        jsonPath("$.profileImageUrl").value(회원_응답.profileImageUrl())
+                )
+                .andDo(document(docsPath + "updateProfile",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("PK"),
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                fieldWithPath("userId").type(JsonFieldType.STRING).description("아이디"),
+                                fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
+                                fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)"),
+                                fieldWithPath("profileImageUrl").type(JsonFieldType.STRING).description("이미지 경로")
+                        )
+                ));
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/user/controller/UserControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/controller/UserControllerTest.java
@@ -198,8 +198,8 @@ class UserControllerTest  extends ControllerTest {
                        jsonPath("$.userId").value(회원_응답.userId()),
                        jsonPath("$.gender").value(회원_응답.gender().toString()),
                        jsonPath("$.birth").value(회원_응답.birth().toString()),
-                       jsonPath("$.profileImageUrl").value(회원_응답.profileImageUrl())
-               )
+                       jsonPath("$.fileResponse.originalName").value(회원_응답.fileResponse().originalName()),
+                       jsonPath("$.fileResponse.filePath").value(회원_응답.fileResponse().filePath()))
                .andDo(document(docsPath + "findById",
                                preprocessRequest(prettyPrint()),
                                preprocessResponse(prettyPrint()),
@@ -211,7 +211,9 @@ class UserControllerTest  extends ControllerTest {
                                        fieldWithPath("userId").type(JsonFieldType.STRING).description("아이디"),
                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
                                        fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)"),
-                                       fieldWithPath("profileImageUrl").type(JsonFieldType.STRING).description("이미지 경로")
+                                       fieldWithPath("fileResponse").type(JsonFieldType.OBJECT).description("프로필 이미지 정보"),
+                                       fieldWithPath("fileResponse.originalName").type(JsonFieldType.STRING).description("업로드된 파일의 원본 이름"),
+                                       fieldWithPath("fileResponse.filePath").type(JsonFieldType.STRING).description("저장된 파일의 접근 경로 (URL)")
                                )
                ));
     }
@@ -267,8 +269,8 @@ class UserControllerTest  extends ControllerTest {
                        jsonPath("$.userId").value(회원_응답.userId()),
                        jsonPath("$.gender").value(회원_응답.gender().toString()),
                        jsonPath("$.birth").value(회원_응답.birth().toString()),
-                       jsonPath("$.profileImageUrl").value(회원_응답.profileImageUrl())
-               )
+                       jsonPath("$.fileResponse.originalName").value(회원_응답.fileResponse().originalName()),
+                       jsonPath("$.fileResponse.filePath").value(회원_응답.fileResponse().filePath()))
                .andDo(document(docsPath + "user-update-profile",
                                preprocessRequest(prettyPrint()),
                                preprocessResponse(prettyPrint()),
@@ -285,7 +287,9 @@ class UserControllerTest  extends ControllerTest {
                                        fieldWithPath("userId").type(JsonFieldType.STRING).description("아이디"),
                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
                                        fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)"),
-                                       fieldWithPath("profileImageUrl").type(JsonFieldType.STRING).description("이미지 경로")
+                                       fieldWithPath("fileResponse").type(JsonFieldType.OBJECT).description("프로필 이미지 정보"),
+                                       fieldWithPath("fileResponse.originalName").type(JsonFieldType.STRING).description("업로드된 파일의 원본 이름"),
+                                       fieldWithPath("fileResponse.filePath").type(JsonFieldType.STRING).description("저장된 파일의 접근 경로 (URL)")
                                )
                ));
     }
@@ -458,8 +462,8 @@ class UserControllerTest  extends ControllerTest {
                         jsonPath("$.userId").value(회원_응답.userId()),
                         jsonPath("$.gender").value(회원_응답.gender().toString()),
                         jsonPath("$.birth").value(회원_응답.birth().toString()),
-                        jsonPath("$.profileImageUrl").value(회원_응답.profileImageUrl())
-                )
+                        jsonPath("$.fileResponse.originalName").value(회원_응답.fileResponse().originalName()),
+                        jsonPath("$.fileResponse.filePath").value(회원_응답.fileResponse().filePath()))
                 .andDo(document(docsPath + "updateProfile",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
@@ -470,7 +474,9 @@ class UserControllerTest  extends ControllerTest {
                                 fieldWithPath("userId").type(JsonFieldType.STRING).description("아이디"),
                                 fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
                                 fieldWithPath("birth").type(JsonFieldType.STRING).description("생년월일 (형식: YYYY-MM-DD)"),
-                                fieldWithPath("profileImageUrl").type(JsonFieldType.STRING).description("이미지 경로")
+                                fieldWithPath("fileResponse").type(JsonFieldType.OBJECT).description("프로필 이미지 정보"),
+                                fieldWithPath("fileResponse.originalName").type(JsonFieldType.STRING).description("업로드된 파일의 원본 이름"),
+                                fieldWithPath("fileResponse.filePath").type(JsonFieldType.STRING).description("저장된 파일의 접근 경로 (URL)")
                         )
                 ));
     }

--- a/module-api/src/test/java/com/trybe/moduleapi/user/fixtures/UserFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/fixtures/UserFixtures.java
@@ -2,11 +2,11 @@ package com.trybe.moduleapi.user.fixtures;
 
 import com.trybe.moduleapi.user.dto.request.UserRequest;
 import com.trybe.moduleapi.user.dto.response.UserResponse;
+import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.entity.User;
 import com.trybe.modulecore.user.enums.Gender;
 import com.trybe.modulecore.user.enums.Role;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDate;
 
@@ -41,30 +41,59 @@ public class UserFixtures {
 
     public static final String 권한 = Role.ROLE_USER.getDescription();
 
+    public static final String 프로필_기본_경로 = "profile/user";
+    public static final String 프로필_이미지_URL = "https://fake-s3-bucket.s3.amazonaws.com/profile/user/saved-test-image.jpg";
+
+    public static final MockMultipartFile 프로필_이미지_요청 = new MockMultipartFile(
+            "file",
+            "new-image.jpg",
+            "image/jpeg",
+            "test image content".getBytes()
+    );
+
+    public static final File 프로필_이미지_파일 = File.builder()
+            .originalName("default-image.jpg")
+            .savedName("UUID.jpg")
+            .filePath(프로필_기본_경로 + "/default-image.jpg")
+            .fileType("image/jpeg")
+            .fileSize(1024L)
+            .build();
+
+    public static final File 수정된_프로필_이미지_파일 = File.builder()
+            .originalName("new-image.jpg")
+            .savedName("UUID.jpg")
+            .filePath(프로필_기본_경로 + "/update-test-image.jpg")
+            .fileType("image/jpeg")
+            .fileSize(1024L)
+            .build();
+
     public static User 회원 = 회원_생성(회원_아이디, 회원_이메일);
     public static User 회원() {
         return 회원_생성(회원_아이디, 회원_이메일);
     }
 
     public static User 회원_생성(String userId, String email) {
-        return User.builder()
+        User user = User.builder()
                 .userId(userId)
                 .email(email)
                 .nickname(회원_닉네임)
                 .gender(회원_성별)
                 .birth(회원_생년월일)
                 .build();
+        user.updateProfileImage(프로필_이미지_파일);
+        return user;
     }
 
     public static UserRequest.Create 회원가입_요청 = new UserRequest.Create(회원_아이디,회원_이메일,회원_닉네임,회원_비밀번호,회원_성별,회원_생년월일);
     public static UserRequest.Create 잘못된_회원가입_요청 = new UserRequest.Create(잘못된_회원_아이디,잘못된_회원_이메일,잘못된_회원_닉네임,잘못된_회원_비밀번호,잘못된_회원_성별,잘못된_회원_생년월일);
     public static UserRequest.Update 회원정보_수정_요청 = new UserRequest.Update(수정된_회원_닉네임,수정된_회원_이메일,수정된_회원_성별,수정된_회원_생년월일);
     public static UserRequest.Update 잘못된_회원정보_수정_요청 = new UserRequest.Update(잘못된_회원_닉네임,잘못된_회원_이메일,잘못된_회원_성별,잘못된_회원_생년월일);
-    public static UserResponse.Detail 회원_응답 = new UserResponse.Detail(회원_PK,회원_닉네임,회원_아이디,회원_이메일,회원_성별,회원_생년월일);
-    public static UserResponse.Detail 수정된_회원_응답 = new UserResponse.Detail(회원_PK,수정된_회원_닉네임,회원_아이디,수정된_회원_이메일,수정된_회원_성별,수정된_회원_생년월일);
+    public static UserResponse.Detail 회원_응답 = new UserResponse.Detail(회원_PK,회원_닉네임,회원_아이디,회원_이메일,회원_성별,회원_생년월일, 프로필_이미지_URL);
+    public static UserResponse.Detail 수정된_회원_응답 = new UserResponse.Detail(회원_PK,수정된_회원_닉네임,회원_아이디,수정된_회원_이메일,수정된_회원_성별,수정된_회원_생년월일, 프로필_이미지_URL);
     public static UserResponse.Summary 요약_회원_응답 = new UserResponse.Summary(회원_PK,회원_아이디,회원_닉네임);
     public static UserRequest.UpdatePassword 비밀번호_변경_요청 = new UserRequest.UpdatePassword(현재_비밀번호,새로운_비밀번호,확인_비밀번호);
     public static UserRequest.UpdatePassword 현재_새로운_비밀번호_동일한_비밀번호_변경_요청 = new UserRequest.UpdatePassword(현재_비밀번호,현재_비밀번호,확인_비밀번호);
     public static UserRequest.UpdatePassword 현재_비밀번호_잘못된_비밀번호_변경_요청 = new UserRequest.UpdatePassword(새로운_비밀번호,새로운_비밀번호,확인_비밀번호);
     public static UserRequest.UpdatePassword 새로운_확인용_비밀번호_다른_변경_요청 = new UserRequest.UpdatePassword(현재_비밀번호,새로운_비밀번호,현재_비밀번호);
+
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/user/fixtures/UserFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/fixtures/UserFixtures.java
@@ -1,5 +1,6 @@
 package com.trybe.moduleapi.user.fixtures;
 
+import com.trybe.moduleapi.file.dto.FileResponse;
 import com.trybe.moduleapi.user.dto.request.UserRequest;
 import com.trybe.moduleapi.user.dto.response.UserResponse;
 import com.trybe.modulecore.file.entity.File;
@@ -43,6 +44,8 @@ public class UserFixtures {
 
     public static final String 프로필_기본_경로 = "profile/user";
     public static final String 프로필_이미지_URL = "https://fake-s3-bucket.s3.amazonaws.com/profile/user/saved-test-image.jpg";
+
+    public static final FileResponse 파일_응답 = FileResponse.from("originalName.jpg", 프로필_이미지_URL);
 
     public static final MockMultipartFile 프로필_이미지_요청 = new MockMultipartFile(
             "file",
@@ -88,8 +91,8 @@ public class UserFixtures {
     public static UserRequest.Create 잘못된_회원가입_요청 = new UserRequest.Create(잘못된_회원_아이디,잘못된_회원_이메일,잘못된_회원_닉네임,잘못된_회원_비밀번호,잘못된_회원_성별,잘못된_회원_생년월일);
     public static UserRequest.Update 회원정보_수정_요청 = new UserRequest.Update(수정된_회원_닉네임,수정된_회원_이메일,수정된_회원_성별,수정된_회원_생년월일);
     public static UserRequest.Update 잘못된_회원정보_수정_요청 = new UserRequest.Update(잘못된_회원_닉네임,잘못된_회원_이메일,잘못된_회원_성별,잘못된_회원_생년월일);
-    public static UserResponse.Detail 회원_응답 = new UserResponse.Detail(회원_PK,회원_닉네임,회원_아이디,회원_이메일,회원_성별,회원_생년월일, 프로필_이미지_URL);
-    public static UserResponse.Detail 수정된_회원_응답 = new UserResponse.Detail(회원_PK,수정된_회원_닉네임,회원_아이디,수정된_회원_이메일,수정된_회원_성별,수정된_회원_생년월일, 프로필_이미지_URL);
+    public static UserResponse.Detail 회원_응답 = new UserResponse.Detail(회원_PK,회원_닉네임,회원_아이디,회원_이메일,회원_성별,회원_생년월일, 파일_응답);
+    public static UserResponse.Detail 수정된_회원_응답 = new UserResponse.Detail(회원_PK,수정된_회원_닉네임,회원_아이디,수정된_회원_이메일,수정된_회원_성별,수정된_회원_생년월일, 파일_응답);
     public static UserResponse.Summary 요약_회원_응답 = new UserResponse.Summary(회원_PK,회원_아이디,회원_닉네임);
     public static UserRequest.UpdatePassword 비밀번호_변경_요청 = new UserRequest.UpdatePassword(현재_비밀번호,새로운_비밀번호,확인_비밀번호);
     public static UserRequest.UpdatePassword 현재_새로운_비밀번호_동일한_비밀번호_변경_요청 = new UserRequest.UpdatePassword(현재_비밀번호,현재_비밀번호,확인_비밀번호);

--- a/module-api/src/test/java/com/trybe/moduleapi/user/service/UserServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/service/UserServiceTest.java
@@ -106,7 +106,8 @@ class UserServiceTest {
         assertEquals(response.email(), UserFixtures.회원_이메일);
         assertEquals(response.gender(), UserFixtures.회원_성별);
         assertEquals(response.birth(), UserFixtures.회원_생년월일);
-        assertEquals(response.profileImageUrl(), UserFixtures.프로필_이미지_URL);
+        assertEquals(response.fileResponse().filePath(), UserFixtures.프로필_이미지_URL);
+        assertEquals(response.fileResponse().originalName(), UserFixtures.프로필_이미지_파일.getOriginalName());
     }
 
     @Test
@@ -180,7 +181,8 @@ class UserServiceTest {
         assertEquals(response.email(), user.getEmail());
         assertEquals(response.gender(), user.getGender());
         assertEquals(response.birth(), user.getBirth());
-        assertEquals(response.profileImageUrl(), UserFixtures.프로필_이미지_URL);
+        assertEquals(response.fileResponse().filePath(), UserFixtures.프로필_이미지_URL);
+        assertEquals(response.fileResponse().originalName(), 수정된_프로필_이미지_파일.getOriginalName());
 
         verify(userRepository, times(1)).save(user);
     }

--- a/module-api/src/test/java/com/trybe/moduleapi/user/service/UserServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/service/UserServiceTest.java
@@ -1,12 +1,14 @@
 package com.trybe.moduleapi.user.service;
 
 import com.trybe.moduleapi.auth.CustomUserDetails;
+import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.moduleapi.user.dto.request.UserRequest;
 import com.trybe.moduleapi.user.dto.response.UserResponse;
 import com.trybe.moduleapi.user.exception.DuplicatedUserException;
 import com.trybe.moduleapi.user.exception.NotFoundUserException;
 import com.trybe.moduleapi.user.exception.UpdatePasswordFailException;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.entity.User;
 import com.trybe.modulecore.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -16,14 +18,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -35,6 +38,9 @@ class UserServiceTest {
 
     @Mock
     private CustomUserDetails customUserDetails;
+
+    @Mock
+    private FileManager fileManager;
 
     @InjectMocks
     private UserService userService;
@@ -61,6 +67,7 @@ class UserServiceTest {
     void 회원가입_중복_아이디_가입_시_에러를_반환한다() {
         /* given */
         UserRequest.Create request = UserFixtures.회원가입_요청;
+
         Mockito.when(userRepository.existsByUserId(any(String.class))).thenReturn(true);
 
         /* when, then */
@@ -74,6 +81,7 @@ class UserServiceTest {
     void 회원가입_중복_이메일_가입_시_에러를_반환한다() {
         /* given */
         UserRequest.Create request = UserFixtures.회원가입_요청;
+
         Mockito.when(userRepository.existsByUserId(any(String.class))).thenReturn(true);
 
         /* when, then */
@@ -86,7 +94,8 @@ class UserServiceTest {
     @DisplayName("회원조회 시 유저를 반환한다.")
     void 회원조회_시_유저를_반환한다() {
         /* given */
-        Mockito.when(userRepository.findById(UserFixtures.회원_PK)).thenReturn(Optional.of(UserFixtures.회원));
+        when(userRepository.findById(UserFixtures.회원_PK)).thenReturn(Optional.of(UserFixtures.회원));
+        when(fileManager.getFileUrl(UserFixtures.프로필_이미지_파일.getFilePath())).thenReturn(UserFixtures.프로필_이미지_URL);
 
         /* when */
         UserResponse.Detail response = userService.findById(UserFixtures.회원_PK);
@@ -97,6 +106,7 @@ class UserServiceTest {
         assertEquals(response.email(), UserFixtures.회원_이메일);
         assertEquals(response.gender(), UserFixtures.회원_성별);
         assertEquals(response.birth(), UserFixtures.회원_생년월일);
+        assertEquals(response.profileImageUrl(), UserFixtures.프로필_이미지_URL);
     }
 
     @Test
@@ -145,10 +155,39 @@ class UserServiceTest {
             userService.updateProfile(customUserDetails, request);
         }, "이미 존재하는 이메일입니다.");
     }
+
+    @Test
+    @DisplayName("프로필 이미지 수정 시 수정된 프로필 정보를 반환한다.")
+    void 프로필_이미지_수정_시_수정된_프로필_정보를_반환한다 () {
+        /* given */
+        User user = UserFixtures.회원();
+        MockMultipartFile 프로필_이미지_업로드_요청 = UserFixtures.프로필_이미지_요청;
+        File 프로필_이미지_파일 = UserFixtures.프로필_이미지_파일;
+        File 수정된_프로필_이미지_파일 = UserFixtures.수정된_프로필_이미지_파일;
+        String 프로필_기본_경로 = UserFixtures.프로필_기본_경로;
+        String 프로필_이미지_Url = UserFixtures.프로필_이미지_URL;
+
+        when(fileManager.updateFile(프로필_이미지_파일,프로필_이미지_업로드_요청,프로필_기본_경로)).thenReturn(수정된_프로필_이미지_파일);
+        when(fileManager.getFileUrl(수정된_프로필_이미지_파일.getFilePath())).thenReturn(프로필_이미지_Url);
+
+        /* when */
+        UserResponse.Detail response = userService.updateProfileImage(user, 프로필_이미지_업로드_요청);
+
+        /* then */
+        assertEquals(response.id(), user.getId());
+        assertEquals(response.userId(), user.getUserId());
+        assertEquals(response.nickname(), user.getNickname());
+        assertEquals(response.email(), user.getEmail());
+        assertEquals(response.gender(), user.getGender());
+        assertEquals(response.birth(), user.getBirth());
+        assertEquals(response.profileImageUrl(), UserFixtures.프로필_이미지_URL);
+
+        verify(userRepository, times(1)).save(user);
+    }
     
     @Test
-    @DisplayName("정상적인 비밀번호 변경")
-    void 정상적인_비밀번호_변경() {
+    @DisplayName("정상적인 비밀번호 변경 시 비밀번호는 변경된다.")
+    void 정상적인_비밀번호_변경_시_비밀번호는_변경된다() {
         /* given */
         Mockito.when(customUserDetails.getUser()).thenReturn(UserFixtures.회원);
         UserFixtures.회원.updatePassword(UserFixtures.회원_암호화된_비밀번호);
@@ -200,16 +239,20 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("회원탈퇴 성공시 DB에서 유저를 삭제한다.")
+    @DisplayName("회원탈퇴 성공 시 DB에서 유저를 삭제한다.")
     void 회원탈퇴_성공_시_DB에서_유저를_삭제한다() {
         /* given */
-        Mockito.when(customUserDetails.getUser()).thenReturn(UserFixtures.회원);
+        User 회원 = UserFixtures.회원;
+        File 프로필_이미지_파일 = UserFixtures.프로필_이미지_파일;
+
+        when(customUserDetails.getUser()).thenReturn(회원);
+        when(userRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
 
         /* when */
         userService.delete(customUserDetails);
 
         /* then */
-        Mockito.verify(userRepository, times(1)).deleteById(any());
-
+        verify(userRepository, times(1)).deleteById(any());
+        verify(fileManager, times(1)).deleteFile(프로필_이미지_파일);
     }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/user/service/UserServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/service/UserServiceTest.java
@@ -127,7 +127,11 @@ class UserServiceTest {
     void 회원정보_수정_시_성공하면_수정된_회원_정보를_반환한다() {
         /* given */
         UserRequest.Update request = UserFixtures.회원정보_수정_요청;
-        Mockito.when(customUserDetails.getUser()).thenReturn(UserFixtures.회원());
+        User 회원 = UserFixtures.회원();
+
+        when(customUserDetails.getUser()).thenReturn(회원);
+        when(userRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
+        when(fileManager.getFileUrl(UserFixtures.프로필_이미지_파일.getFilePath())).thenReturn(UserFixtures.프로필_이미지_URL);
 
         /* when */
         UserResponse.Detail response = userService.updateProfile(customUserDetails, request);
@@ -137,6 +141,8 @@ class UserServiceTest {
         assertEquals(response.email(), UserFixtures.수정된_회원_이메일);
         assertEquals(response.gender(), UserFixtures.수정된_회원_성별);
         assertEquals(response.birth(), UserFixtures.수정된_회원_생년월일);
+        assertEquals(response.fileResponse().filePath(), UserFixtures.프로필_이미지_URL);
+        assertEquals(response.fileResponse().originalName(), UserFixtures.프로필_이미지_파일.getOriginalName());
     }
 
     @Test
@@ -144,12 +150,11 @@ class UserServiceTest {
     void 회원정보_수정_시_이메일이_중복이면_에러를_반환한다() {
         /* given */
         UserRequest.Update request = UserFixtures.회원정보_수정_요청;
-        Mockito.when(customUserDetails.getUser()).thenReturn(UserFixtures.회원);
-        Mockito.when(userRepository.existsByEmail(any(String.class))).thenReturn(true);
-        UserFixtures.회원.updateProfile(UserFixtures.수정된_회원_닉네임,
-                                      UserFixtures.회원_이메일,
-                                      UserFixtures.수정된_회원_성별,
-                                      UserFixtures.수정된_회원_생년월일);
+        User 회원 = UserFixtures.회원();
+
+        when(customUserDetails.getUser()).thenReturn(회원);
+        when(userRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
+        when(userRepository.existsByEmail(request.email())).thenReturn(true);
 
         /* when , then */
         assertThrows(DuplicatedUserException.class, () -> {

--- a/module-core/src/main/java/com/trybe/modulecore/user/entity/User.java
+++ b/module-core/src/main/java/com/trybe/modulecore/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.trybe.modulecore.user.entity;
 
 import com.trybe.modulecore.common.entity.BaseEntity;
+import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.enums.Gender;
 import com.trybe.modulecore.user.enums.Role;
 import jakarta.persistence.*;
@@ -10,8 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.annotations.SoftDelete;
-import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,6 +27,10 @@ public class User extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "profile_image_id")
+    private File profileImage;
 
     @Column(name = "uuid", nullable = false, updatable = false, unique = true)
     private UUID uuid = UUID.randomUUID();
@@ -76,5 +79,8 @@ public class User extends BaseEntity {
 
     public void updatePassword(String newEncodedPassword){
         this.encodedPassword = newEncodedPassword;
+    }
+    public void updateProfileImage(File newProfileImage){
+        this.profileImage = newProfileImage;
     }
 }


### PR DESCRIPTION
- `User`와 `File`엔티티 연관관계 매핑
- `UserController`에 프로필 이미지 수정 API 추가
- `UserResponse.Detail`에 이미지 URL 경로 추가
- `UserService`에 프로필 이미지 수정/삭제 테스트 코드 및 DTO에 프로필 URL 추가
- `UserServiceTest`에 이미지 수정/삭제 테스트 코드 및 DTO에 프로필 URL 코드 추가
- `UserControllerTest`에 이미지 수정 API 테스트 코드 및 DTO에 프로필 URL 코드 추가
-  `adoc` 에 프로필 수정 API 문서화
- `user.http`파일에 이미지 수정 API 추가