### PR TITLE
[#80] 챌린지 대표 사진 기능 구현

### DIFF
--- a/module-api/http/challenge.http
+++ b/module-api/http/challenge.http
@@ -1,6 +1,10 @@
 ### 1. 챌린지 생성
 POST http://localhost:8080/api/v1/challenges
 Authorization: {{accessToken}}
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"
 Content-Type: application/json
 
 {
@@ -13,6 +17,12 @@ Content-Type: application/json
   "proofWay": "읽은 내용을 정리해서 공유",
   "proofCount": 17
 }
+--boundary
+Content-Disposition: form-data; name="thumbnail"; filename="thumbnail.jpeg"
+Content-Type: image/jpeg
+
+< ./testImg/test.jpeg
+--boundary
 
 ### 1-1. 챌린지 생성 (유효성 검증 실패)
 POST http://localhost:8080/api/v1/challenges
@@ -53,6 +63,10 @@ Authorization: {{accessToken}}
 ### 6. 챌린지 내용 수정
 PUT http://localhost:8080/api/v1/challenges/1/content
 Authorization: {{accessToken}}
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"
 Content-Type: application/json
 
 {
@@ -63,7 +77,12 @@ Content-Type: application/json
   "capacity": 10,
   "category": "STUDY"
 }
+--boundary
+Content-Disposition: form-data; name="thumbnail"; filename="thumbnail.jpeg"
+Content-Type: image/jpeg
 
+< ./testImg/test.jpeg
+--boundary
 
 ### 6-1. 챌린지 내용 수정 (유효성 검증 실패)
 PUT http://localhost:8080/api/v1/challenges/1/content

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -14,7 +14,6 @@ include::{snippets}/user-controller-test/save/request-fields.adoc[]
 
 - 응답
 include::{snippets}/user-controller-test/save/http-response.adoc[]
-include::{snippets}/user-controller-test/save/response-fields.adoc[]
 
 ==== 비정상 요청 (잘못된 요청)
 요청 필드가 누락되거나 잘못된 형식으로 전달되었을 때:
@@ -195,7 +194,10 @@ include::{snippets}/auth-controller-test/token-reissue/http-response.adoc[]
 
 ==== 정상 요청
 include::{snippets}/challenge-controller-test/create/http-request.adoc[]
-include::{snippets}/challenge-controller-test/create/request-fields.adoc[]
+include::{snippets}/challenge-controller-test/create/request-parts.adoc[]
+
+- JSON fields
+include::{snippets}/challenge-controller-test/create/request-part-request-fields.adoc[]
 
 - 응답
 include::{snippets}/challenge-controller-test/create/http-response.adoc[]
@@ -279,7 +281,10 @@ include::{snippets}/challenge-controller-test/popular/response-fields.adoc[]
 ==== 정상 요청
 include::{snippets}/challenge-controller-test/update-content/http-request.adoc[]
 include::{snippets}/challenge-controller-test/update-content/path-parameters.adoc[]
-include::{snippets}/challenge-controller-test/update-content/request-fields.adoc[]
+include::{snippets}/challenge-controller-test/update-content/request-parts.adoc[]
+
+- JSON fields
+include::{snippets}/challenge-controller-test/update-content/request-part-request-fields.adoc[]
 
 - 응답
 include::{snippets}/challenge-controller-test/update-content/http-response.adoc[]

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/client/ChallengeRecommendationClient.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/client/ChallengeRecommendationClient.java
@@ -1,6 +1,6 @@
 package com.trybe.moduleapi.challenge.client;
 
-import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.modulecore.challenge.entity.Challenge;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +11,7 @@ import java.util.List;
 @FeignClient(name = "challengeRecommendation", url = "${spring.cloud.openfeign.client.challengeRecommendation.url}")
 public interface ChallengeRecommendationClient {
     @GetMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
-    List<ChallengeResponse.Preview> getChallengeRecommendations(
+    List<Challenge> getChallengeRecommendations(
             @RequestParam Long userId
     );
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/controller/ChallengeController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -25,9 +26,10 @@ public class ChallengeController {
     @PostMapping
     public ChallengeResponse.Detail save(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody ChallengeRequest.Create request
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
+            @RequestPart("request") @Valid ChallengeRequest.Create request
     ) {
-        return challengeService.save(userDetails.getUser(), request);
+        return challengeService.save(userDetails.getUser(), thumbnail, request);
     }
 
     @GetMapping("/{id}")
@@ -68,9 +70,10 @@ public class ChallengeController {
     public ChallengeResponse.Detail updateContent(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("id") Long id,
-            @Valid @RequestBody ChallengeRequest.UpdateContent request
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
+            @RequestPart("request") @Valid ChallengeRequest.UpdateContent request
     ) {
-        return challengeService.updateContent(userDetails.getUser(), id, request);
+        return challengeService.updateContent(userDetails.getUser(), id, thumbnail, request);
     }
 
     @PutMapping("/{id}/proof")

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
@@ -1,5 +1,6 @@
 package com.trybe.moduleapi.challenge.dto;
 
+import com.trybe.moduleapi.file.dto.FileResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 public class ChallengeResponse {
     public record Detail(
             Long id,
+            FileResponse thumbnail,
             String title,
             String description,
             LocalDate startDate,
@@ -21,9 +23,10 @@ public class ChallengeResponse {
             int proofCount,
             Bookmark bookmark
     ) {
-        public static Detail from(Challenge challenge, int participantCount, Bookmark bookmark) {
+        public static Detail from(Challenge challenge, FileResponse thumbnail, int participantCount, Bookmark bookmark) {
             return new Detail(
                     challenge.getId(),
+                    thumbnail,
                     challenge.getTitle(),
                     challenge.getDescription(),
                     challenge.getStartDate(),
@@ -41,6 +44,7 @@ public class ChallengeResponse {
 
     public record Preview(
             Long id,
+            FileResponse thumbnail,
             String title,
             String description,
             ChallengeStatus status,
@@ -49,9 +53,10 @@ public class ChallengeResponse {
             int participantCount,
             Bookmark bookmark
     ) {
-        public static Preview from(Challenge challenge, int participantCount, Bookmark bookmark) {
+        public static Preview from(Challenge challenge, FileResponse thumbnail, int participantCount, Bookmark bookmark) {
             return new Preview(
                     challenge.getId(),
+                    thumbnail,
                     challenge.getTitle(),
                     challenge.getDescription(),
                     challenge.getStatus(),

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
@@ -1,19 +1,31 @@
 package com.trybe.moduleapi.challenge.dto;
 
+import com.trybe.moduleapi.file.dto.FileResponse;
+import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
+import com.trybe.modulecore.file.entity.File;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ChallengeResponseAssembler {
     private final ChallengeParticipationRepository challengeParticipationRepository;
     private final ChallengeBookmarkCache challengeBookmarkCache;
+    private final FileManager fileManager;
 
-    public ChallengeResponseAssembler(ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache) {
+    public ChallengeResponseAssembler(ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, FileManager fileManager) {
         this.challengeParticipationRepository = challengeParticipationRepository;
         this.challengeBookmarkCache = challengeBookmarkCache;
+        this.fileManager = fileManager;
+    }
+
+    public ChallengeResponse.Detail toInitialDetail(Challenge challenge) {
+        FileResponse thumbnail = toFileResponse(challenge.getThumbnail());
+        ChallengeResponse.Bookmark bookmark = new ChallengeResponse.Bookmark(0, false);
+
+        return ChallengeResponse.Detail.from(challenge, thumbnail, 0, bookmark);
     }
 
     public ChallengeResponse.Detail toDetail(Challenge challenge, Long userId) {
@@ -21,8 +33,9 @@ public class ChallengeResponseAssembler {
 
         int participantCount = getParticipantCount(challengeId);
         ChallengeResponse.Bookmark bookmark = toBookmark(challengeId, userId);
+        FileResponse thumbnail = toFileResponse(challenge.getThumbnail());
 
-        return ChallengeResponse.Detail.from(challenge, participantCount, bookmark);
+        return ChallengeResponse.Detail.from(challenge, thumbnail, participantCount, bookmark);
     }
 
     public ChallengeResponse.Preview toPreview(Challenge challenge, Long userId) {
@@ -30,8 +43,9 @@ public class ChallengeResponseAssembler {
 
         int participantCount = getParticipantCount(challengeId);
         ChallengeResponse.Bookmark bookmark = toBookmark(challengeId, userId);
+        FileResponse thumbnail = toFileResponse(challenge.getThumbnail());
 
-        return ChallengeResponse.Preview.from(challenge, participantCount, bookmark);
+        return ChallengeResponse.Preview.from(challenge, thumbnail, participantCount, bookmark);
     }
 
     public ChallengeResponse.Summary toSummary(Challenge challenge) {
@@ -46,5 +60,9 @@ public class ChallengeResponseAssembler {
         int bookmarkCount = challengeBookmarkCache.getBookmarkCount(challengeId);
         Boolean bookmarked = userId == null ? null : challengeBookmarkCache.isBookmarked(userId, challengeId);
         return new ChallengeResponse.Bookmark(bookmarkCount, bookmarked);
+    }
+
+    private FileResponse toFileResponse(File file) {
+        return FileResponse.from(file.getOriginalName(), fileManager.getFileUrl(file.getFilePath()));
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
@@ -1,0 +1,50 @@
+package com.trybe.moduleapi.challenge.dto;
+
+import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChallengeResponseAssembler {
+    private final ChallengeParticipationRepository challengeParticipationRepository;
+    private final ChallengeBookmarkCache challengeBookmarkCache;
+
+    public ChallengeResponseAssembler(ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache) {
+        this.challengeParticipationRepository = challengeParticipationRepository;
+        this.challengeBookmarkCache = challengeBookmarkCache;
+    }
+
+    public ChallengeResponse.Detail toDetail(Challenge challenge, Long userId) {
+        Long challengeId = challenge.getId();
+
+        int participantCount = getParticipantCount(challengeId);
+        ChallengeResponse.Bookmark bookmark = toBookmark(challengeId, userId);
+
+        return ChallengeResponse.Detail.from(challenge, participantCount, bookmark);
+    }
+
+    public ChallengeResponse.Preview toPreview(Challenge challenge, Long userId) {
+        Long challengeId = challenge.getId();
+
+        int participantCount = getParticipantCount(challengeId);
+        ChallengeResponse.Bookmark bookmark = toBookmark(challengeId, userId);
+
+        return ChallengeResponse.Preview.from(challenge, participantCount, bookmark);
+    }
+
+    public ChallengeResponse.Summary toSummary(Challenge challenge) {
+        return ChallengeResponse.Summary.from(challenge);
+    }
+
+    private int getParticipantCount(Long challengeId) {
+        return challengeParticipationRepository.countByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED);
+    }
+
+    private ChallengeResponse.Bookmark toBookmark(Long challengeId, Long userId) {
+        int bookmarkCount = challengeBookmarkCache.getBookmarkCount(challengeId);
+        Boolean bookmarked = userId == null ? null : challengeBookmarkCache.isBookmarked(userId, challengeId);
+        return new ChallengeResponse.Bookmark(bookmarkCount, bookmarked);
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
@@ -63,6 +63,6 @@ public class ChallengeResponseAssembler {
     }
 
     private FileResponse toFileResponse(File file) {
-        return FileResponse.from(file.getOriginalName(), fileManager.getFileUrl(file.getFilePath()));
+        return file == null ? null : FileResponse.from(file.getOriginalName(), fileManager.getFileUrl(file.getFilePath()));
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -1,14 +1,13 @@
 package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
 import com.trybe.moduleapi.challenge.event.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
-import com.trybe.modulecore.challenge.enums.ParticipationStatus;
-import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
 import com.trybe.modulecore.user.entity.User;
@@ -24,15 +23,15 @@ import java.util.stream.Collectors;
 @Service
 public class ChallengeBookmarkService {
     private final ChallengeRepository challengeRepository;
-    private final ChallengeParticipationRepository challengeParticipationRepository;
     private final ChallengeBookmarkCache challengeBookmarkCache;
     private final ChallengeEventPublisher challengeEventPublisher;
+    private final ChallengeResponseAssembler challengeResponseAssembler;
 
-    public ChallengeBookmarkService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, ChallengeEventPublisher challengeEventPublisher) {
+    public ChallengeBookmarkService(ChallengeRepository challengeRepository, ChallengeBookmarkCache challengeBookmarkCache, ChallengeEventPublisher challengeEventPublisher, ChallengeResponseAssembler challengeResponseAssembler) {
         this.challengeRepository = challengeRepository;
-        this.challengeParticipationRepository = challengeParticipationRepository;
         this.challengeBookmarkCache = challengeBookmarkCache;
         this.challengeEventPublisher = challengeEventPublisher;
+        this.challengeResponseAssembler = challengeResponseAssembler;
     }
 
     @Transactional
@@ -78,18 +77,12 @@ public class ChallengeBookmarkService {
                 ? Collections.emptyList()
                 : challengeRepository.findAllByIdIn(challengeIds);
 
-        List<ChallengeResponse.Preview> challengeSummaries = sortChallenges(challenges, challengeIds).stream()
-                .map(challenge -> {
-                    int participantCount = challengeParticipationRepository.countByChallengeIdAndStatus(challenge.getId(), ParticipationStatus.ACCEPTED);
-                    int bookmarkCount = challengeBookmarkCache.getBookmarkCount(challenge.getId());
-
-                    ChallengeResponse.Bookmark bookmark = new ChallengeResponse.Bookmark(bookmarkCount, true);
-                    return ChallengeResponse.Preview.from(challenge, participantCount, bookmark);
-                })
-                .collect(Collectors.toList());
+        List<ChallengeResponse.Preview> challengePreviews = sortChallenges(challenges, challengeIds).stream()
+                .map(challenge -> challengeResponseAssembler.toPreview(challenge, user.getId()))
+                .toList();
 
         int totalElements = challengeBookmarkCache.getUserBookmarkCount(user.getId());
-        Page<ChallengeResponse.Preview> challengePage = new PageImpl<>(challengeSummaries, pageable, totalElements);
+        Page<ChallengeResponse.Preview> challengePage = new PageImpl<>(challengePreviews, pageable, totalElements);
 
         return new PageResponse<>(challengePage);
     }
@@ -100,7 +93,7 @@ public class ChallengeBookmarkService {
 
         return challengeIds.stream()
                 .map(challengeMap::get)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Challenge getChallenge(Long challengeId) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeRecommendationClientService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeRecommendationClientService.java
@@ -1,64 +1,30 @@
 package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.client.ChallengeRecommendationClient;
-import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
-import com.trybe.modulecore.challenge.enums.ParticipationStatus;
-import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
-import com.trybe.modulecore.challenge.repository.ChallengeRepository;
-import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 @Service
 public class ChallengeRecommendationClientService {
     private final ChallengeRecommendationClient challengeRecommendationClient;
-    private final ChallengeRepository challengeRepository;
-    private final ChallengeParticipationRepository challengeParticipationRepository;
-    private final ChallengeBookmarkCache challengeBookmarkCache;
     private final PopularChallengeService popularChallengeService;
 
-    public ChallengeRecommendationClientService(ChallengeRecommendationClient challengeRecommendationClient, ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, PopularChallengeService popularChallengeService) {
+    public ChallengeRecommendationClientService(ChallengeRecommendationClient challengeRecommendationClient, PopularChallengeService popularChallengeService) {
         this.challengeRecommendationClient = challengeRecommendationClient;
-        this.challengeRepository = challengeRepository;
-        this.challengeParticipationRepository = challengeParticipationRepository;
-        this.challengeBookmarkCache = challengeBookmarkCache;
         this.popularChallengeService = popularChallengeService;
     }
 
     private static final int MIN_LIMIT = 20;
 
     @CircuitBreaker(name = "challengeRecommendation", fallbackMethod = "fallbackGetChallengeRecommendations")
-    public List<ChallengeResponse.Preview> getChallengeRecommendations(Long userId) {
+    public List<Challenge> getChallengeRecommendations(Long userId) {
         return challengeRecommendationClient.getChallengeRecommendations(userId);
     }
 
-    public List<ChallengeResponse.Preview> fallbackGetChallengeRecommendations(Long userId, Throwable throwable) {
-        List<Challenge> challenges = popularChallengeService.getTopPopularChallenges(MIN_LIMIT);
-
-        Collections.shuffle(challenges);
-        return challenges.stream()
-                .map(challenge -> createPreview(userId, challenge))
-                .toList();
-    }
-
-    private ChallengeResponse.Preview createPreview(Long userId, Challenge challenge) {
-        int participationCount = getParticipationCount(challenge.getId());
-        ChallengeResponse.Bookmark bookmark = createBookmark(userId, challenge.getId());
-        return ChallengeResponse.Preview.from(challenge, participationCount, bookmark);
-    }
-
-    private ChallengeResponse.Bookmark createBookmark(Long userId, Long challengeId) {
-        int bookmarkCount = challengeBookmarkCache.getBookmarkCount(challengeId);
-        Boolean bookmarked = userId == null ? null : challengeBookmarkCache.isBookmarked(userId, challengeId);
-        return new ChallengeResponse.Bookmark(bookmarkCount, bookmarked);
-    }
-
-    private int getParticipationCount(Long challengeId) {
-        return challengeParticipationRepository.countByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED);
+    public List<Challenge> fallbackGetChallengeRecommendations(Long userId, Throwable throwable) {
+        return popularChallengeService.getTopPopularChallenges(MIN_LIMIT);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeRecommendationClientService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeRecommendationClientService.java
@@ -17,14 +17,12 @@ public class ChallengeRecommendationClientService {
         this.popularChallengeService = popularChallengeService;
     }
 
-    private static final int MIN_LIMIT = 20;
-
     @CircuitBreaker(name = "challengeRecommendation", fallbackMethod = "fallbackGetChallengeRecommendations")
-    public List<Challenge> getChallengeRecommendations(Long userId) {
+    public List<Challenge> getChallengeRecommendations(Long userId, int limit) {
         return challengeRecommendationClient.getChallengeRecommendations(userId);
     }
 
-    public List<Challenge> fallbackGetChallengeRecommendations(Long userId, Throwable throwable) {
-        return popularChallengeService.getTopPopularChallenges(MIN_LIMIT);
+    public List<Challenge> fallbackGetChallengeRecommendations(Long userId, int limit, Throwable throwable) {
+        return popularChallengeService.getTopPopularChallenges(limit);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -68,7 +68,7 @@ public class ChallengeService {
         Challenge savedChallenge = challengeRepository.save(challenge);
 
         ChallengeParticipation participation = new ChallengeParticipation(user, savedChallenge, ChallengeRole.LEADER, ParticipationStatus.ACCEPTED);
-        File thumbnailFile = fileManager.uploadFile(thumbnail, String.format(CHALLENGE_THUMBNAIL_BASE_PATH, challenge.getId()));
+        File thumbnailFile = thumbnail == null ? null : fileManager.uploadFile(thumbnail, String.format(CHALLENGE_THUMBNAIL_BASE_PATH, challenge.getId()));
 
         challenge.updateThumbnail(thumbnailFile);
         challengeParticipationRepository.save(participation);

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -11,6 +11,7 @@ import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
 import com.trybe.moduleapi.chat.service.ChatService;
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.enums.ChallengeRole;
@@ -20,11 +21,13 @@ import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepositor
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
 import com.trybe.modulecore.challenge.repository.view.ChallengeViewCache;
+import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 
@@ -39,8 +42,9 @@ public class ChallengeService {
     private final ChallengeRecommendationClientService challengeRecommendationClientService;
     private final ChatService chatService;
     private final ChallengeResponseAssembler challengeResponseAssembler;
+    private final FileManager fileManager;
 
-    public ChallengeService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, ChallengeViewCache challengeViewCache, ChallengeEventPublisher challengeEventPublisher, PopularChallengeService popularChallengeService, ChallengeRecommendationClientService challengeRecommendationClientService, ChatService chatService, ChallengeResponseAssembler challengeResponseAssembler) {
+    public ChallengeService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, ChallengeViewCache challengeViewCache, ChallengeEventPublisher challengeEventPublisher, PopularChallengeService popularChallengeService, ChallengeRecommendationClientService challengeRecommendationClientService, ChatService chatService, ChallengeResponseAssembler challengeResponseAssembler, FileManager fileManager) {
         this.challengeRepository = challengeRepository;
         this.challengeParticipationRepository = challengeParticipationRepository;
         this.challengeBookmarkCache = challengeBookmarkCache;
@@ -50,23 +54,28 @@ public class ChallengeService {
         this.challengeRecommendationClientService = challengeRecommendationClientService;
         this.chatService = chatService;
         this.challengeResponseAssembler = challengeResponseAssembler;
+        this.fileManager = fileManager;
     }
 
     private static final int RECOMMEND_CHALLENGE_COUNT = 20;
     private static final int POPULAR_CHALLENGE_COUNT = 20;
 
+    private static final String CHALLENGE_THUMBNAIL_BASE_PATH = "/challenge/%d/thumbnail/";
+
     @Transactional
-    public ChallengeResponse.Detail save(User user, ChallengeRequest.Create request) {
+    public ChallengeResponse.Detail save(User user, MultipartFile thumbnail, ChallengeRequest.Create request) {
         Challenge challenge = request.toEntity();
         Challenge savedChallenge = challengeRepository.save(challenge);
 
         ChallengeParticipation participation = new ChallengeParticipation(user, savedChallenge, ChallengeRole.LEADER, ParticipationStatus.ACCEPTED);
+        File thumbnailFile = fileManager.uploadFile(thumbnail, String.format(CHALLENGE_THUMBNAIL_BASE_PATH, challenge.getId()));
+
+        challenge.updateThumbnail(thumbnailFile);
         challengeParticipationRepository.save(participation);
         challengeEventPublisher.publish(new ChallengeEvent(savedChallenge, user.getId(), ChallengeEventType.CREATE));
         chatService.create(savedChallenge);
 
-        ChallengeResponse.Bookmark bookmark = new ChallengeResponse.Bookmark(0, false);
-        return ChallengeResponse.Detail.from(savedChallenge, 1, bookmark);
+        return challengeResponseAssembler.toInitialDetail(savedChallenge);
     }
 
     @Transactional(readOnly = true)
@@ -124,12 +133,14 @@ public class ChallengeService {
     }
 
     @Transactional
-    public ChallengeResponse.Detail updateContent(User user, Long id, ChallengeRequest.UpdateContent request) {
+    public ChallengeResponse.Detail updateContent(User user, Long id, MultipartFile thumbnail, ChallengeRequest.UpdateContent request) {
         Challenge challenge = getChallenge(id);
 
         validateLeader(user.getId(), id, "리더만 챌린지 정보를 수정할 수 있습니다.");
         validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 정보를 수정할 수 있습니다.");
 
+        File thumbnailFile = updateThumbnail(challenge, thumbnail);
+        challenge.updateThumbnail(thumbnailFile);
         challenge.updateContent(request.title(), request.description(), request.startDate(), request.endDate(), request.capacity(), request.category());
 
         return challengeResponseAssembler.toDetail(challenge, user.getId());
@@ -154,6 +165,7 @@ public class ChallengeService {
         validateLeader(user.getId(), id, "리더만 챌린지를 삭제할 수 있습니다.");
         validateChallengeStatus(challenge, false, ChallengeStatus.ONGOING, "진행 중인 챌린지는 삭제할 수 없습니다.");
 
+        fileManager.deleteFile(challenge.getThumbnail());
         challengeBookmarkCache.removeBookmarksByChallenge(id);
         challengeParticipationRepository.deleteAllByChallengeId(id);
         chatService.delete(id);
@@ -182,6 +194,24 @@ public class ChallengeService {
         if (userId != null && !challengeViewCache.hasViewed(userId, challengeId)) {
             challengeViewCache.recordView(userId, challengeId);
             challengeEventPublisher.publish(new ChallengeEvent(challenge, userId, ChallengeEventType.VIEW));
+        }
+    }
+
+    private File updateThumbnail(Challenge challenge, MultipartFile newThumbnail) {
+        File oldThumbnail = challenge.getThumbnail();
+        String basePath = String.format(CHALLENGE_THUMBNAIL_BASE_PATH, challenge.getId());
+
+        if (newThumbnail == null) {
+            if (oldThumbnail != null) {
+                fileManager.deleteFile(oldThumbnail);
+            }
+            return null;
+        }
+
+        if (oldThumbnail != null) {
+            return fileManager.updateFile(oldThumbnail, newThumbnail, basePath);
+        } else {
+            return fileManager.uploadFile(newThumbnail, basePath);
         }
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -2,6 +2,7 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
 import com.trybe.moduleapi.challenge.event.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
@@ -25,8 +26,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.*;
 
 @Service
 public class ChallengeService {
@@ -38,8 +38,9 @@ public class ChallengeService {
     private final PopularChallengeService popularChallengeService;
     private final ChallengeRecommendationClientService challengeRecommendationClientService;
     private final ChatService chatService;
+    private final ChallengeResponseAssembler challengeResponseAssembler;
 
-    public ChallengeService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, ChallengeViewCache challengeViewCache, ChallengeEventPublisher challengeEventPublisher, PopularChallengeService popularChallengeService, ChallengeRecommendationClientService challengeRecommendationClientService, ChatService chatService) {
+    public ChallengeService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, ChallengeViewCache challengeViewCache, ChallengeEventPublisher challengeEventPublisher, PopularChallengeService popularChallengeService, ChallengeRecommendationClientService challengeRecommendationClientService, ChatService chatService, ChallengeResponseAssembler challengeResponseAssembler) {
         this.challengeRepository = challengeRepository;
         this.challengeParticipationRepository = challengeParticipationRepository;
         this.challengeBookmarkCache = challengeBookmarkCache;
@@ -48,8 +49,10 @@ public class ChallengeService {
         this.popularChallengeService = popularChallengeService;
         this.challengeRecommendationClientService = challengeRecommendationClientService;
         this.chatService = chatService;
+        this.challengeResponseAssembler = challengeResponseAssembler;
     }
 
+    private static final int RECOMMEND_CHALLENGE_COUNT = 20;
     private static final int POPULAR_CHALLENGE_COUNT = 20;
 
     @Transactional
@@ -69,35 +72,55 @@ public class ChallengeService {
     @Transactional(readOnly = true)
     public ChallengeResponse.Detail find(User user, Long id) {
         Challenge challenge = getChallenge(id);
+        Long userId = user == null ? null : user.getId();
 
-        if (user != null) {
-            handleView(user.getId(), challenge);
-        }
+        handleView(userId, challenge);
 
-        return createDetail(user, challenge);
+        return challengeResponseAssembler.toDetail(challenge, userId);
     }
 
     @Transactional(readOnly = true)
     public PageResponse<ChallengeResponse.Preview> findAll(User user, ChallengeRequest.Read request, Pageable pageable) {
         Page<Challenge> challenges = challengeRepository.getFilteredChallenges(request.keyword(), request.statuses(), request.categories(), pageable);
+        Long userId = user == null ? null : user.getId();
 
-        Page<ChallengeResponse.Preview> challengeSummaries = challenges.map(challenge -> createPreview(user, challenge));
+        Page<ChallengeResponse.Preview> challengePreviews = challenges.map(challenge -> challengeResponseAssembler.toPreview(challenge, userId));
 
-        return new PageResponse<>(challengeSummaries);
+        return new PageResponse<>(challengePreviews);
     }
 
     @Transactional(readOnly = true)
     public List<ChallengeResponse.Preview> getPopular(User user) {
         List<Challenge> challenges = popularChallengeService.getTopPopularChallenges(POPULAR_CHALLENGE_COUNT);
+        Long userId = user == null ? null : user.getId();
 
         return challenges.stream()
-                .map(challenge -> createPreview(user, challenge))
-                .collect(Collectors.toList());
+                .map(challenge -> challengeResponseAssembler.toPreview(challenge, userId))
+                .toList();
     }
 
     @Transactional(readOnly = true)
     public List<ChallengeResponse.Preview> getRecommendations(User user) {
-        return challengeRecommendationClientService.getChallengeRecommendations(user.getId());
+        List<Challenge> challenges = challengeRecommendationClientService.getChallengeRecommendations(user.getId());
+
+        if (challenges.size() < RECOMMEND_CHALLENGE_COUNT) {
+            Set<Challenge> challengeSet = new LinkedHashSet<>(challenges);
+
+            List<Challenge> popularChallenges = popularChallengeService.getTopPopularChallenges(RECOMMEND_CHALLENGE_COUNT);
+            challengeSet.addAll(popularChallenges);
+
+            challenges = new ArrayList<>(challengeSet);
+        }
+
+        if (challenges.size() > RECOMMEND_CHALLENGE_COUNT) {
+            challenges = challenges.subList(0, RECOMMEND_CHALLENGE_COUNT);
+        }
+
+        Collections.shuffle(challenges);
+
+        return challenges.stream()
+                .map(challenge -> challengeResponseAssembler.toPreview(challenge, user.getId()))
+                .toList();
     }
 
     @Transactional
@@ -109,7 +132,7 @@ public class ChallengeService {
 
         challenge.updateContent(request.title(), request.description(), request.startDate(), request.endDate(), request.capacity(), request.category());
 
-        return createDetail(user, challenge);
+        return challengeResponseAssembler.toDetail(challenge, user.getId());
     }
 
     @Transactional
@@ -121,7 +144,7 @@ public class ChallengeService {
 
         challenge.updateProof(request.proofWay(), request.proofCount());
 
-        return createDetail(user, challenge);
+        return challengeResponseAssembler.toDetail(challenge, user.getId());
     }
 
     @Transactional
@@ -137,31 +160,9 @@ public class ChallengeService {
         challengeRepository.delete(challenge);
     }
 
-    private ChallengeResponse.Detail createDetail(User user, Challenge challenge) {
-        int participantCount = getParticipantCount(challenge.getId());
-        ChallengeResponse.Bookmark bookmark = createBookmark(user, challenge.getId());
-        return ChallengeResponse.Detail.from(challenge, participantCount, bookmark);
-    }
-
-    private ChallengeResponse.Preview createPreview(User user, Challenge challenge) {
-        int participantCount = getParticipantCount(challenge.getId());
-        ChallengeResponse.Bookmark bookmark = createBookmark(user, challenge.getId());
-        return ChallengeResponse.Preview.from(challenge, participantCount, bookmark);
-    }
-
-    private ChallengeResponse.Bookmark createBookmark(User user, Long challengeId) {
-        int bookmarkCount = challengeBookmarkCache.getBookmarkCount(challengeId);
-        Boolean bookmarked = user == null ? null : challengeBookmarkCache.isBookmarked(user.getId(), challengeId);
-        return new ChallengeResponse.Bookmark(bookmarkCount, bookmarked);
-    }
-
     private Challenge getChallenge(Long id) {
         return challengeRepository.findById(id)
                 .orElseThrow(NotFoundChallengeException::new);
-    }
-
-    private int getParticipantCount(Long challengeId) {
-        return challengeParticipationRepository.countByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED);
     }
 
     private void validateChallengeStatus(Challenge challenge, boolean shouldBe, ChallengeStatus status, String message) {
@@ -178,7 +179,7 @@ public class ChallengeService {
 
     private void handleView(Long userId, Challenge challenge) {
         Long challengeId = challenge.getId();
-        if (!challengeViewCache.hasViewed(userId, challengeId)) {
+        if (userId != null && !challengeViewCache.hasViewed(userId, challengeId)) {
             challengeViewCache.recordView(userId, challengeId);
             challengeEventPublisher.publish(new ChallengeEvent(challenge, userId, ChallengeEventType.VIEW));
         }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -101,7 +101,7 @@ public class ChallengeService {
 
     @Transactional(readOnly = true)
     public List<ChallengeResponse.Preview> getRecommendations(User user) {
-        List<Challenge> challenges = challengeRecommendationClientService.getChallengeRecommendations(user.getId());
+        List<Challenge> challenges = challengeRecommendationClientService.getChallengeRecommendations(user.getId(), RECOMMEND_CHALLENGE_COUNT);
 
         if (challenges.size() < RECOMMEND_CHALLENGE_COUNT) {
             Set<Challenge> challengeSet = new LinkedHashSet<>(challenges);

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeBookmarkControllerTest.java
@@ -176,6 +176,8 @@ class ChallengeBookmarkControllerTest extends ControllerTest {
                 status().isOk(),
                 jsonPath("$.content").isArray(),
                 jsonPath("$.content[0].id").value(response.content().get(0).id()),
+                jsonPath("$.content[0].thumbnail.originalName").value(response.content().get(0).thumbnail().originalName()),
+                jsonPath("$.content[0].thumbnail.filePath").value(response.content().get(0).thumbnail().filePath()),
                 jsonPath("$.content[0].title").value(response.content().get(0).title()),
                 jsonPath("$.content[0].description").value(response.content().get(0).description()),
                 jsonPath("$.content[0].status").value(response.content().get(0).status().name()),
@@ -196,6 +198,9 @@ class ChallengeBookmarkControllerTest extends ControllerTest {
                 responseFields(
                         fieldWithPath("content").description("챌린지 목록"),
                         fieldWithPath("content[].id").description("챌린지 ID"),
+                        fieldWithPath("content[].thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("content[].thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("content[].thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("content[].title").description("챌린지 제목"),
                         fieldWithPath("content[].description").description("챌린지 설명"),
                         fieldWithPath("content[].status").description("챌린지 상태"),

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -1,5 +1,6 @@
 package com.trybe.moduleapi.challenge.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.trybe.moduleapi.annotation.WithCustomMockUser;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
@@ -8,14 +9,17 @@ import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRol
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
 import com.trybe.moduleapi.common.ControllerTest;
+import com.trybe.moduleapi.file.fixtures.FileFixtures;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.charset.StandardCharsets;
 
@@ -24,6 +28,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ChallengeController.class)
@@ -35,6 +40,15 @@ class ChallengeControllerTest extends ControllerTest {
 
     private String docsPath = "challenge-controller-test/";
 
+    private MockMultipartFile createJsonRequestPart(Object request) throws JsonProcessingException {
+        return new MockMultipartFile(
+                "request",
+                null,
+                "application/json",
+                objectMapper.writeValueAsBytes(request)
+        );
+    }
+
     @Test
     @WithCustomMockUser
     @DisplayName("정상적인 챌린지 생성 요청 시 응답코드 200을 반환한다.")
@@ -42,17 +56,26 @@ class ChallengeControllerTest extends ControllerTest {
         /* given */
         ChallengeRequest.Create request = ChallengeFixtures.챌린지_생성_요청;
 
-        when(challengeService.save(any(User.class), eq(request)))
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+        MockMultipartFile thumbnailPart = FileFixtures.파일_요청_생성("thumbnail");
+
+        when(challengeService.save(any(User.class), eq(thumbnailPart), eq(request)))
                 .thenReturn(ChallengeFixtures.초기_챌린지_상세_응답);
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint)
+                        .file(jsonPart)
+                        .file(thumbnailPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isOk(),
+                jsonPath("$.thumbnail.originalName").value(FileFixtures.파일_원본_이름),
+                jsonPath("$.thumbnail.filePath").value(FileFixtures.파일_전체_경로),
                 jsonPath("$.title").value(request.title()),
                 jsonPath("$.description").value(request.description()),
                 jsonPath("$.startDate").value(request.startDate().toString()),
@@ -71,7 +94,11 @@ class ChallengeControllerTest extends ControllerTest {
         result.andDo(document(docsPath + "create",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
-                requestFields(
+                requestParts(
+                        partWithName("request").description("챌린지 생성 요청 데이터 (JSON)"),
+                        partWithName("thumbnail").description("챌린지 썸네일 이미지 (선택)")
+                ),
+                requestPartFields("request",
                         fieldWithPath("title").description("챌린지 제목 (최대 100자)"),
                         fieldWithPath("description").description("챌린지 설명 (최대 1,000자)"),
                         fieldWithPath("startDate").description("챌린지 시작일 (현재 날짜 이후)"),
@@ -83,6 +110,9 @@ class ChallengeControllerTest extends ControllerTest {
                 ),
                 responseFields(
                         fieldWithPath("id").description("챌린지 ID"),
+                        fieldWithPath("thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),
@@ -106,11 +136,16 @@ class ChallengeControllerTest extends ControllerTest {
         /* given */
         ChallengeRequest.Create request = ChallengeFixtures.잘못된_챌린지_생성_요청;
 
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint)
+                        .file(jsonPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isBadRequest(),
@@ -127,7 +162,7 @@ class ChallengeControllerTest extends ControllerTest {
         result.andDo(document(docsPath + "create/" + invalidBadRequestPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
-                requestFields(
+                requestPartFields("request",
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),
@@ -166,6 +201,9 @@ class ChallengeControllerTest extends ControllerTest {
 
         result.andExpectAll(
                 status().isOk(),
+                jsonPath("$.thumbnail").exists(),
+                jsonPath("$.thumbnail.originalName").value(ChallengeFixtures.챌린지_상세_응답.thumbnail().originalName()),
+                jsonPath("$.thumbnail.filePath").value(ChallengeFixtures.챌린지_상세_응답.thumbnail().filePath()),
                 jsonPath("$.title").value(ChallengeFixtures.챌린지_상세_응답.title()),
                 jsonPath("$.description").value(ChallengeFixtures.챌린지_상세_응답.description()),
                 jsonPath("$.startDate").value(ChallengeFixtures.챌린지_상세_응답.startDate().toString()),
@@ -187,6 +225,9 @@ class ChallengeControllerTest extends ControllerTest {
                 pathParameters(parameterWithName("id").description("조회할 챌린지 ID")),
                 responseFields(
                         fieldWithPath("id").description("챌린지 ID"),
+                        fieldWithPath("thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),
@@ -269,6 +310,9 @@ class ChallengeControllerTest extends ControllerTest {
                 responseFields(
                         fieldWithPath("content").description("챌린지 목록"),
                         fieldWithPath("content[].id").description("챌린지 ID"),
+                        fieldWithPath("content[].thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("content[].thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("content[].thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("content[].title").description("챌린지 제목"),
                         fieldWithPath("content[].description").description("챌린지 설명"),
                         fieldWithPath("content[].status").description("챌린지 상태"),
@@ -341,6 +385,9 @@ class ChallengeControllerTest extends ControllerTest {
                 responseFields(
                         fieldWithPath("[]").description("챌린지 목록"),
                         fieldWithPath("[].id").description("챌린지 ID"),
+                        fieldWithPath("[].thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("[].thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("[].thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("[].title").description("챌린지 제목"),
                         fieldWithPath("[].description").description("챌린지 설명"),
                         fieldWithPath("[].status").description("챌린지 상태"),
@@ -377,6 +424,9 @@ class ChallengeControllerTest extends ControllerTest {
                 responseFields(
                         fieldWithPath("[]").description("챌린지 목록"),
                         fieldWithPath("[].id").description("챌린지 ID"),
+                        fieldWithPath("[].thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("[].thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("[].thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("[].title").description("챌린지 제목"),
                         fieldWithPath("[].description").description("챌린지 설명"),
                         fieldWithPath("[].status").description("챌린지 상태"),
@@ -398,17 +448,27 @@ class ChallengeControllerTest extends ControllerTest {
         Long challengeId = ChallengeFixtures.챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
 
-        when(challengeService.updateContent(any(User.class), eq(challengeId), eq(request)))
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+        MockMultipartFile thumbnailPart = FileFixtures.파일_요청_생성("thumbnail");
+
+        when(challengeService.updateContent(any(User.class), eq(challengeId), eq(thumbnailPart), eq(request)))
                 .thenReturn(ChallengeFixtures.내용_수정된_챌린지_상세_응답);
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/content", challengeId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{id}/content", challengeId)
+                        .file(jsonPart)
+                        .file(thumbnailPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isOk(),
+                jsonPath("$.thumbnail.originalName").value(FileFixtures.파일_원본_이름),
+                jsonPath("$.thumbnail.filePath").value(FileFixtures.파일_전체_경로),
                 jsonPath("$.title").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.title()),
                 jsonPath("$.description").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.description()),
                 jsonPath("$.startDate").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.startDate().toString()),
@@ -428,7 +488,11 @@ class ChallengeControllerTest extends ControllerTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 pathParameters(parameterWithName("id").description("수정할 챌린지 ID")),
-                requestFields(
+                requestParts(
+                        partWithName("request").description("챌린지 수정 요청 데이터 (JSON)"),
+                        partWithName("thumbnail").description("챌린지 썸네일 이미지 (선택)")
+                ),
+                requestPartFields("request",
                         fieldWithPath("title").description("챌린지 제목 (최대 100자)"),
                         fieldWithPath("description").description("챌린지 설명 (최대 1,000자)"),
                         fieldWithPath("startDate").description("챌린지 시작일 (현재 날짜 이후)"),
@@ -438,6 +502,9 @@ class ChallengeControllerTest extends ControllerTest {
                 ),
                 responseFields(
                         fieldWithPath("id").description("챌린지 ID"),
+                        fieldWithPath("thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),
@@ -462,11 +529,17 @@ class ChallengeControllerTest extends ControllerTest {
         Long challengeId = ChallengeFixtures.챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.잘못된_챌린지_내용_수정_요청;
 
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/content", challengeId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{id}/content", challengeId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isBadRequest(),
@@ -482,7 +555,7 @@ class ChallengeControllerTest extends ControllerTest {
         result.andDo(document(docsPath + "update-content/" + invalidBadRequestPath,
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
-                requestFields(
+                requestPartFields("request",
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),
@@ -509,14 +582,20 @@ class ChallengeControllerTest extends ControllerTest {
         Long challengeId = ChallengeFixtures.챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
 
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
         doThrow(new InvalidChallengeRoleActionException("리더만 챌린지 정보를 수정할 수 있습니다."))
-                .when(challengeService).updateContent(any(User.class), eq(challengeId), eq(request));
+                .when(challengeService).updateContent(any(User.class), eq(challengeId), nullable(MultipartFile.class), eq(request));
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/content", challengeId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{id}/content", challengeId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isForbidden(),
@@ -543,14 +622,20 @@ class ChallengeControllerTest extends ControllerTest {
         Long challengeId = ChallengeFixtures.챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
 
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
         doThrow(new InvalidChallengeStatusException("진행 예정인 챌린지만 수정할 수 있습니다."))
-                .when(challengeService).updateContent(any(User.class), eq(challengeId), eq(request));
+                .when(challengeService).updateContent(any(User.class), eq(challengeId), nullable(MultipartFile.class), eq(request));
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/content", challengeId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{id}/content", challengeId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isConflict(),
@@ -577,13 +662,19 @@ class ChallengeControllerTest extends ControllerTest {
         Long challengeId = ChallengeFixtures.잘못된_챌린지_ID;
         ChallengeRequest.UpdateContent request = ChallengeFixtures.챌린지_내용_수정_요청;
 
-        doThrow(new NotFoundChallengeException()).when(challengeService).updateContent(any(User.class), eq(challengeId), eq(request));
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        doThrow(new NotFoundChallengeException()).when(challengeService).updateContent(any(User.class), eq(challengeId), nullable(MultipartFile.class), eq(request));
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{id}/content", challengeId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{id}/content", challengeId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isNotFound(),
@@ -645,6 +736,9 @@ class ChallengeControllerTest extends ControllerTest {
                 ),
                 responseFields(
                         fieldWithPath("id").description("챌린지 ID"),
+                        fieldWithPath("thumbnail").description("챌린지 썸네일 정보"),
+                        fieldWithPath("thumbnail.originalName").description("썸네일 파일 원본 이름"),
+                        fieldWithPath("thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -360,7 +360,7 @@ class ChallengeControllerTest extends ControllerTest {
     void 정상적인_챌린지_추천_목록_조회_요청_시_응답코드_200을_반환한다 () throws Exception {
         /* given */
         when(challengeService.getRecommendations(any(User.class)))
-                .thenReturn(ChallengeFixtures.챌린지_추천_목록_응답);
+                .thenReturn(ChallengeFixtures.챌린지_미리보기_목록_응답);
 
         /* when */
         /* then */
@@ -368,7 +368,7 @@ class ChallengeControllerTest extends ControllerTest {
 
         result.andExpectAll(
                 status().isOk(),
-                jsonPath("$.size()").value(ChallengeFixtures.챌린지_추천_목록_응답.size())
+                jsonPath("$.size()").value(ChallengeFixtures.챌린지_미리보기_목록_응답.size())
         );
 
         result.andDo(document(docsPath + "recommendations",

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -467,8 +467,6 @@ class ChallengeControllerTest extends ControllerTest {
 
         result.andExpectAll(
                 status().isOk(),
-                jsonPath("$.thumbnail.originalName").value(FileFixtures.파일_원본_이름),
-                jsonPath("$.thumbnail.filePath").value(FileFixtures.파일_전체_경로),
                 jsonPath("$.title").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.title()),
                 jsonPath("$.description").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.description()),
                 jsonPath("$.startDate").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.startDate().toString()),
@@ -503,8 +501,6 @@ class ChallengeControllerTest extends ControllerTest {
                 responseFields(
                         fieldWithPath("id").description("챌린지 ID"),
                         fieldWithPath("thumbnail").description("챌린지 썸네일 정보"),
-                        fieldWithPath("thumbnail.originalName").description("썸네일 파일 원본 이름"),
-                        fieldWithPath("thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),
@@ -737,8 +733,6 @@ class ChallengeControllerTest extends ControllerTest {
                 responseFields(
                         fieldWithPath("id").description("챌린지 ID"),
                         fieldWithPath("thumbnail").description("챌린지 썸네일 정보"),
-                        fieldWithPath("thumbnail.originalName").description("썸네일 파일 원본 이름"),
-                        fieldWithPath("thumbnail.filePath").description("썸네일 파일 경로"),
                         fieldWithPath("title").description("챌린지 제목"),
                         fieldWithPath("description").description("챌린지 설명"),
                         fieldWithPath("startDate").description("챌린지 시작일"),

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -3,6 +3,8 @@ package com.trybe.moduleapi.challenge.fixtures;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.dto.FileResponse;
+import com.trybe.moduleapi.file.fixtures.FileFixtures;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
@@ -125,7 +127,7 @@ public class ChallengeFixtures {
 
     /* Entity */
     public static final Challenge 챌린지() {
-        return new Challenge(
+        Challenge challenge = new Challenge(
                 챌린지_제목,
                 챌린지_설명,
                 챌린지_시작_날짜,
@@ -135,6 +137,10 @@ public class ChallengeFixtures {
                 챌린지_인증_방법,
                 챌린지_인증_횟수
         );
+
+        challenge.updateThumbnail(FileFixtures.파일);
+
+        return challenge;
     }
 
     public static final Challenge 내용_수정된_챌린지 = new Challenge(
@@ -147,6 +153,7 @@ public class ChallengeFixtures {
             챌린지_인증_방법,
             챌린지_인증_횟수
     );
+
     public static final Challenge 인증_내용_수정된_챌린지 = new Challenge(
             챌린지_제목,
             챌린지_설명,
@@ -184,18 +191,20 @@ public class ChallengeFixtures {
     public static ChallengeStatus 대기중 = ChallengeStatus.PENDING;
 
     /* Response DTO */
-    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 초기_참여자_수, 초기_북마크_수, 북마크_여부_거짓);
-    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부_참);
-    public static final ChallengeResponse.Detail 챌린지_상세_비로그인_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
+    private static final FileResponse 파일_응답 = FileFixtures.파일_응답;
+
+    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 초기_참여자_수, 초기_북마크_수, 북마크_여부_거짓);
+    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 참여자_수, 북마크_수, 북마크_여부_참);
+    public static final ChallengeResponse.Detail 챌린지_상세_비로그인_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 참여자_수, 북마크_수, null);
 
     public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
     public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부_참);
 
     public static final ChallengeResponse.Summary 챌린지_요약_응답 = 챌린지_요약_응답_생성(챌린지());
 
-    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부_참);
+    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, null, 참여자_수, 북마크_수, 북마크_여부_참);
 
-    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, 참여자_수, 북마크_수, 북마크_여부_참);
+    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, null, 참여자_수, 북마크_수, 북마크_여부_참);
 
     public static final List<ChallengeResponse.Summary> 챌린지_목록_응답 = 챌린지_목록.stream().map(ChallengeResponse.Summary::from).collect(Collectors.toList());
     public static final List<ChallengeResponse.Preview> 챌린지_미리보기_목록_응답 = 챌린지_목록.stream().map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부_참)).collect(Collectors.toList());
@@ -203,9 +212,10 @@ public class ChallengeFixtures {
     public static final PageResponse<ChallengeResponse.Summary> 챌린지_페이지_응답 = new PageResponse<>(챌린지_페이지.map(ChallengeResponse.Summary::from));
     public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부_참)));
 
-    private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, Boolean Bookmarked) {
+    private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, FileResponse thumbnail, int participantCount, int bookmarkCount, Boolean Bookmarked) {
         return new ChallengeResponse.Detail(
                 챌린지_ID,
+                thumbnail,
                 challenge.getTitle(),
                 challenge.getDescription(),
                 challenge.getStartDate(),
@@ -223,6 +233,7 @@ public class ChallengeFixtures {
     public static ChallengeResponse.Preview 챌린지_미리보기_응답_생성(Long challengeId) {
         return new ChallengeResponse.Preview(
                 challengeId,
+                FileFixtures.파일_응답,
                 챌린지_제목,
                 챌린지_설명,
                 대기중,
@@ -236,6 +247,7 @@ public class ChallengeFixtures {
     private static ChallengeResponse.Preview 챌린지_미리보기_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, Boolean bookmarked) {
         return new ChallengeResponse.Preview(
                 챌린지_ID,
+                FileFixtures.파일_응답,
                 challenge.getTitle(),
                 challenge.getDescription(),
                 challenge.getStatus(),

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -173,11 +173,12 @@ public class ChallengeFixtures {
         return challenge;
     }
 
+    public static Challenge 진행예정_챌린지 = createChallenge(ChallengeStatus.PENDING);
     public static Challenge 진행중인_챌린지 = createChallenge(ChallengeStatus.ONGOING);
     public static Challenge 종료된_챌린지 = createChallenge(ChallengeStatus.DONE);
 
     public static Pageable 페이지_요청 = PageRequest.of(0, 10);
-    public static List<Challenge> 챌린지_목록 = List.of(진행중인_챌린지,진행중인_챌린지,진행중인_챌린지);
+    public static List<Challenge> 챌린지_목록 = List.of(진행예정_챌린지, 진행중인_챌린지, 종료된_챌린지);
     public static Page<Challenge> 챌린지_페이지 = new PageImpl<>(챌린지_목록, 페이지_요청, 챌린지_목록.size());
 
     public static ChallengeStatus 대기중 = ChallengeStatus.PENDING;
@@ -185,6 +186,7 @@ public class ChallengeFixtures {
     /* Response DTO */
     public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 초기_참여자_수, 초기_북마크_수, 북마크_여부_거짓);
     public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부_참);
+    public static final ChallengeResponse.Detail 챌린지_상세_비로그인_응답 = 챌린지_상세_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
 
     public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
     public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부_참);
@@ -201,9 +203,7 @@ public class ChallengeFixtures {
     public static final PageResponse<ChallengeResponse.Summary> 챌린지_페이지_응답 = new PageResponse<>(챌린지_페이지.map(ChallengeResponse.Summary::from));
     public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부_참)));
 
-    public static final List<ChallengeResponse.Preview> 챌린지_추천_목록_응답 = List.of(챌린지_미리보기_로그인_응답, 챌린지_미리보기_로그인_응답, 챌린지_미리보기_로그인_응답);
-
-    private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, boolean Bookmarked) {
+    private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, int participantCount, int bookmarkCount, Boolean Bookmarked) {
         return new ChallengeResponse.Detail(
                 챌린지_ID,
                 challenge.getTitle(),
@@ -217,6 +217,19 @@ public class ChallengeFixtures {
                 challenge.getProofWay(),
                 challenge.getProofCount(),
                 new ChallengeResponse.Bookmark(bookmarkCount, Bookmarked)
+        );
+    }
+
+    public static ChallengeResponse.Preview 챌린지_미리보기_응답_생성(Long challengeId) {
+        return new ChallengeResponse.Preview(
+                challengeId,
+                챌린지_제목,
+                챌린지_설명,
+                대기중,
+                챌린지_카테고리,
+                챌린지_인원,
+                참여자_수,
+                new ChallengeResponse.Bookmark(북마크_수, 북마크_여부_참)
         );
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkServiceTest.java
@@ -1,6 +1,7 @@
 package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
 import com.trybe.moduleapi.challenge.event.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
@@ -8,11 +9,8 @@ import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.entity.Challenge;
-import com.trybe.modulecore.challenge.enums.ParticipationStatus;
-import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
-import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,10 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.trybe.moduleapi.challenge.fixtures.ChallengeBookmarkFixtures.*;
@@ -41,13 +36,13 @@ class ChallengeBookmarkServiceTest {
     private ChallengeRepository challengeRepository;
 
     @Mock
-    private ChallengeParticipationRepository challengeParticipationRepository;
-
-    @Mock
     private ChallengeBookmarkCache challengeBookmarkCache;
 
     @Mock
     private ChallengeEventPublisher challengeEventPublisher;
+
+    @Mock
+    private ChallengeResponseAssembler challengeResponseAssembler;
 
     @Test
     @DisplayName("챌린지 북마크 추가 시 북마크 정보를 반환한다.")
@@ -192,6 +187,7 @@ class ChallengeBookmarkServiceTest {
         Long userId = UserFixtures.회원_PK;
         User user = spy(UserFixtures.회원);
         Set<Long> challengeIds = 북마크된_챌린지_ID_목록;
+        Iterator<Long> iterator = challengeIds.iterator();
 
         List<Challenge> challenges = List.of(spy(ChallengeFixtures.챌린지()), spy(ChallengeFixtures.챌린지()), spy(ChallengeFixtures.챌린지()));
 
@@ -204,12 +200,12 @@ class ChallengeBookmarkServiceTest {
                 .thenReturn(challengeIds);
         when(challengeRepository.findAllByIdIn(any(Set.class)))
                 .thenReturn(challenges);
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(Long.class), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(ChallengeFixtures.참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any(Long.class)))
-                .thenReturn(북마크_수);
         when(challengeBookmarkCache.getUserBookmarkCount(any(Long.class)))
                 .thenReturn(challengeIds.size());
+        when(challengeResponseAssembler.toPreview(any(Challenge.class), any(Long.class)))
+                .thenReturn(ChallengeFixtures.챌린지_미리보기_응답_생성(iterator.next()))
+                .thenReturn(ChallengeFixtures.챌린지_미리보기_응답_생성(iterator.next()))
+                .thenReturn(ChallengeFixtures.챌린지_미리보기_응답_생성(iterator.next()));
 
         /* when */
         PageResponse<ChallengeResponse.Preview> result = challengeBookmarkService.getMyBookmarkedChallenges(user, ChallengeFixtures.페이지_요청);
@@ -244,7 +240,7 @@ class ChallengeBookmarkServiceTest {
 
         /* then */
         verify(challengeRepository, never()).findAllByIdIn(any(Set.class));
-        verify(challengeParticipationRepository, never()).countByChallengeIdAndStatus(any(Long.class), eq(ParticipationStatus.ACCEPTED));
+        verify(challengeResponseAssembler, never()).toPreview(any(Challenge.class), any(Long.class));
         verify(challengeBookmarkCache, never()).getBookmarkCount(any(Long.class));
 
         assertEquals(0, result.content().size());

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -2,6 +2,7 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
 import com.trybe.moduleapi.challenge.event.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
@@ -14,11 +15,9 @@ import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.enums.ChallengeRole;
-import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
-import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
 import com.trybe.modulecore.challenge.repository.view.ChallengeViewCache;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -32,8 +31,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -66,6 +64,9 @@ class ChallengeServiceTest {
     @Mock
     private ChatService chatService;
 
+    @Mock
+    private ChallengeResponseAssembler challengeResponseAssembler;
+
     @Test
     @DisplayName("챌린지 생성 시 저장된 챌린지 정보를 반환한다.")
     void 챌린지_생성_시_저장된_챌린지_정보를_반환한다 () {
@@ -96,25 +97,24 @@ class ChallengeServiceTest {
     void 챌린지_단일_조회_시_챌린지_정보를_반환한다 () {
         /* given */
         Long challengeId = 챌린지_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
         Challenge challenge = 챌린지();
 
+        when(user.getId()).thenReturn(userId);
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any()))
-                .thenReturn(북마크_수);
-        when(challengeBookmarkCache.isBookmarked(any(), any()))
-                .thenReturn(false);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+                .thenReturn(챌린지_상세_응답);
 
         /* when */
-        ChallengeResponse.Detail response = challengeService.find(UserFixtures.회원, challengeId);
+        ChallengeResponse.Detail response = challengeService.find(user, challengeId);
 
         /* then */
         verifyChallengeResponse(challenge, response);
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
-        assertEquals(false, response.bookmark().bookmarked());
+        assertEquals(북마크_여부_참, response.bookmark().bookmarked());
 
         verify(challengeViewCache, times(1)).recordView(any(), any());
         verify(challengeEventPublisher, times(1)).publish(any(ChallengeEvent.class));
@@ -125,27 +125,26 @@ class ChallengeServiceTest {
     void 챌린지_단일_조회_시_일정_시간_이내_조회_기록이_존재하는_경우_조회_처리를_하지_않고_챌린지_정보를_반환한다 () {
         /* given */
         Long challengeId = 챌린지_ID;
+        Long userId = UserFixtures.회원_PK;
+        User user = spy(UserFixtures.회원);
         Challenge challenge = 챌린지();
 
+        when(user.getId()).thenReturn(userId);
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any()))
-                .thenReturn(북마크_수);
-        when(challengeBookmarkCache.isBookmarked(any(), any()))
-                .thenReturn(false);
         when(challengeViewCache.hasViewed(any(), any()))
                 .thenReturn(true);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+                .thenReturn(챌린지_상세_응답);
 
         /* when */
-        ChallengeResponse.Detail response = challengeService.find(UserFixtures.회원, challengeId);
+        ChallengeResponse.Detail response = challengeService.find(user, challengeId);
 
         /* then */
         verifyChallengeResponse(challenge, response);
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
-        assertEquals(false, response.bookmark().bookmarked());
+        assertEquals(북마크_여부_참, response.bookmark().bookmarked());
 
         verify(challengeViewCache, never()).recordView(any(), any());
         verify(challengeEventPublisher, never()).publish(any(ChallengeEvent.class));
@@ -160,10 +159,8 @@ class ChallengeServiceTest {
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any()))
-                .thenReturn(북마크_수);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+                .thenReturn(챌린지_상세_비로그인_응답);
 
         /* when */
         ChallengeResponse.Detail response = challengeService.find(null, challengeId);
@@ -172,7 +169,7 @@ class ChallengeServiceTest {
         verifyChallengeResponse(challenge, response);
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
-        assertEquals(null, response.bookmark().bookmarked());
+        assertNull(response.bookmark().bookmarked());
     }
 
     @Test
@@ -197,12 +194,8 @@ class ChallengeServiceTest {
 
         when(challengeRepository.getFilteredChallenges(request.keyword(), request.statuses(), request.categories(), 페이지_요청))
                 .thenReturn(챌린지_페이지);
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any()))
-                .thenReturn(북마크_수);
-        when(challengeBookmarkCache.isBookmarked(any(), any()))
-                .thenReturn(false);
+        when(challengeResponseAssembler.toPreview(any(Challenge.class), any()))
+                .thenReturn(챌린지_미리보기_로그인_응답);
 
         /* when */
         PageResponse<ChallengeResponse.Preview> response = challengeService.findAll(UserFixtures.회원, request, 페이지_요청);
@@ -221,12 +214,8 @@ class ChallengeServiceTest {
         when(user.getId()).thenReturn(userId);
         when(popularChallengeService.getTopPopularChallenges(anyInt()))
                 .thenReturn(챌린지_목록);
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any()))
-                .thenReturn(북마크_수);
-        when(challengeBookmarkCache.isBookmarked(any(), any()))
-                .thenReturn(false);
+        when(challengeResponseAssembler.toPreview(any(Challenge.class), any()))
+                .thenReturn(챌린지_미리보기_로그인_응답);
 
         /* when */
         List<ChallengeResponse.Preview> response = challengeService.getPopular(user);
@@ -243,14 +232,16 @@ class ChallengeServiceTest {
         Long userId = UserFixtures.회원_PK;
 
         when(user.getId()).thenReturn(userId);
-        when(challengeRecommendationClientService.getChallengeRecommendations(any()))
-                .thenReturn(챌린지_추천_목록_응답);
+        when(challengeRecommendationClientService.getChallengeRecommendations(any(), anyInt()))
+                .thenReturn(챌린지_목록);
+        when(challengeResponseAssembler.toPreview(any(Challenge.class), any()))
+                .thenReturn(챌린지_미리보기_로그인_응답);
 
         /* when */
         List<ChallengeResponse.Preview> response = challengeService.getRecommendations(user);
 
         /* then */
-        assertEquals(챌린지_추천_목록_응답.size(), response.size());
+        assertEquals(챌린지_미리보기_목록_응답.size(), response.size());
     }
 
     @Test
@@ -264,12 +255,8 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(챌린지()));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), eq(challengeId), eq(ChallengeRole.LEADER)))
                 .thenReturn(true);
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any()))
-                .thenReturn(북마크_수);
-        when(challengeBookmarkCache.isBookmarked(any(), any()))
-                .thenReturn(false);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+                .thenReturn(내용_수정된_챌린지_상세_응답);
 
         /* when */
         ChallengeResponse.Detail response = challengeService.updateContent(UserFixtures.회원, challengeId, request);
@@ -278,7 +265,7 @@ class ChallengeServiceTest {
         verifyChallengeResponse(내용_수정된_챌린지, response);
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
-        assertEquals(false, response.bookmark().bookmarked());
+        assertEquals(북마크_여부_참, response.bookmark().bookmarked());
     }
 
     @Test
@@ -341,12 +328,8 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(챌린지()));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
                 .thenReturn(true);
-        when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(ParticipationStatus.ACCEPTED)))
-                .thenReturn(참여자_수);
-        when(challengeBookmarkCache.getBookmarkCount(any()))
-                .thenReturn(북마크_수);
-        when(challengeBookmarkCache.isBookmarked(any(), any()))
-                .thenReturn(false);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+                .thenReturn(인증_내용_수정된_챌린지_상세_응답);
 
         /* when */
         ChallengeResponse.Detail response = challengeService.updateProof(UserFixtures.회원, challengeId, request);
@@ -355,7 +338,7 @@ class ChallengeServiceTest {
         verifyChallengeResponse(인증_내용_수정된_챌린지, response);
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
-        assertEquals(false, response.bookmark().bookmarked());
+        assertEquals(북마크_여부_참, response.bookmark().bookmarked());
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -11,6 +11,9 @@ import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRol
 import com.trybe.moduleapi.challenge.fixtures.ChallengeParticipationFixtures;
 import com.trybe.moduleapi.chat.service.ChatService;
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.dto.FileResponse;
+import com.trybe.moduleapi.file.fixtures.FileFixtures;
+import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
@@ -19,6 +22,7 @@ import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepositor
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
 import com.trybe.modulecore.challenge.repository.view.ChallengeViewCache;
+import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -67,6 +72,9 @@ class ChallengeServiceTest {
     @Mock
     private ChallengeResponseAssembler challengeResponseAssembler;
 
+    @Mock
+    private FileManager fileManager;
+
     @Test
     @DisplayName("챌린지 생성 시 저장된 챌린지 정보를 반환한다.")
     void 챌린지_생성_시_저장된_챌린지_정보를_반환한다 () {
@@ -74,13 +82,19 @@ class ChallengeServiceTest {
         ChallengeRequest.Create request = 챌린지_생성_요청;
         Challenge challenge = 챌린지();
 
+        MockMultipartFile thumbnail = FileFixtures.파일_요청_생성("thumbnail");
+
         when(challengeRepository.save(any(Challenge.class)))
                 .thenReturn(challenge);
         when(challengeParticipationRepository.save(any(ChallengeParticipation.class)))
                 .thenReturn(ChallengeParticipationFixtures.챌린지_리더_참여());
+        when(fileManager.uploadFile(eq(thumbnail), any(String.class)))
+                .thenReturn(FileFixtures.파일);
+        when(challengeResponseAssembler.toInitialDetail(challenge))
+                .thenReturn(초기_챌린지_상세_응답);
 
         /* when */
-        ChallengeResponse.Detail response = challengeService.save(UserFixtures.회원, request);
+        ChallengeResponse.Detail response = challengeService.save(UserFixtures.회원, thumbnail, request);
 
         /* then */
         verifyChallengeResponse(challenge, response);
@@ -249,17 +263,24 @@ class ChallengeServiceTest {
     void 챌린지_정보_수정_시_수정된_챌린지_정보를_반환한다 () {
         /* given */
         Long challengeId = 챌린지_ID;
+        Challenge challenge = 내용_수정된_챌린지;
+
         ChallengeRequest.UpdateContent request = 챌린지_내용_수정_요청;
+
+        File thumbnailFile = FileFixtures.파일;
+        MockMultipartFile thumbnail = FileFixtures.파일_요청_생성("thumbnail");
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(챌린지()));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), eq(challengeId), eq(ChallengeRole.LEADER)))
                 .thenReturn(true);
+        when(fileManager.updateFile(any(File.class), eq(thumbnail), any(String.class)))
+                .thenReturn(thumbnailFile);
         when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
                 .thenReturn(내용_수정된_챌린지_상세_응답);
 
         /* when */
-        ChallengeResponse.Detail response = challengeService.updateContent(UserFixtures.회원, challengeId, request);
+        ChallengeResponse.Detail response = challengeService.updateContent(UserFixtures.회원, challengeId, thumbnail, request);
 
         /* then */
         verifyChallengeResponse(내용_수정된_챌린지, response);
@@ -282,7 +303,7 @@ class ChallengeServiceTest {
 
         /* when */
         /* then */
-        assertThrows(InvalidChallengeRoleActionException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, request));
+        assertThrows(InvalidChallengeRoleActionException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, null, request));
     }
 
     @Test
@@ -299,7 +320,7 @@ class ChallengeServiceTest {
 
         /* when */
         /* then */
-        assertThrows(InvalidChallengeStatusException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, request));
+        assertThrows(InvalidChallengeStatusException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, null, request));
     }
 
     @Test
@@ -314,7 +335,7 @@ class ChallengeServiceTest {
 
         /* when */
         /* then */
-        assertThrows(NotFoundChallengeException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, request));
+        assertThrows(NotFoundChallengeException.class, () -> challengeService.updateContent(UserFixtures.회원, challengeId, null, request));
     }
 
     @Test
@@ -322,6 +343,8 @@ class ChallengeServiceTest {
     void 챌린지_인증_정보_수정_시_수정된_챌린지_정보를_반환한다 () {
         /* given */
         Long challengeId = 챌린지_ID;
+        Challenge challenge = 인증_내용_수정된_챌린지;
+
         ChallengeRequest.UpdateProof request = 챌린지_인증_내용_수정_요청;
 
         when(challengeRepository.findById(challengeId))
@@ -463,6 +486,7 @@ class ChallengeServiceTest {
     }
 
     private void verifyChallengeResponse(Challenge challenge, ChallengeResponse.Detail response) {
+        verifyFileResponse(challenge.getThumbnail(), response.thumbnail());
         assertEquals(challenge.getTitle(), response.title());
         assertEquals(challenge.getDescription(), response.description());
         assertEquals(challenge.getStartDate(), response.startDate());
@@ -472,5 +496,15 @@ class ChallengeServiceTest {
         assertEquals(challenge.getCategory(), response.category());
         assertEquals(challenge.getProofWay(), response.proofWay());
         assertEquals(challenge.getProofCount(), response.proofCount());
+    }
+
+    private void verifyFileResponse(File file, FileResponse fileResponse) {
+        if (file == null) {
+            assertNull(fileResponse);
+            return;
+        }
+
+        assertEquals(file.getOriginalName(), fileResponse.originalName());
+        assertEquals(FileFixtures.파일_저장소_경로 + file.getFilePath(), fileResponse.filePath());
     }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
@@ -1,0 +1,41 @@
+package com.trybe.moduleapi.file.fixtures;
+
+import com.trybe.moduleapi.file.dto.FileResponse;
+import com.trybe.modulecore.file.entity.File;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.UUID;
+
+public class FileFixtures {
+    public static final Long 파일_ID = 1L;
+    public static final String 파일_원본_이름 = "originalName.jpeg";
+    public static final String 파일_저장_이름 = UUID.randomUUID().toString() + "-" + 파일_원본_이름;
+    public static final String 파일_경로 = "/filePath/" + 파일_저장_이름;
+    public static final String 파일_타입 = "image/jpeg";
+    public static final Long 파일_사이즈 = 10240L;
+
+    public static final String 파일_저장소_경로 = "http://trybe.test/file";
+    public static final String 파일_전체_경로 = 파일_저장소_경로 + 파일_경로;
+
+    /* Request */
+    public static MockMultipartFile 파일_요청_생성(String parameterName) {
+        return new MockMultipartFile(
+                parameterName,
+                파일_원본_이름,
+                파일_타입,
+                "dummy content".getBytes()
+        );
+    }
+
+    /* Entity */
+    public static final File 파일 = File.builder()
+            .originalName(파일_원본_이름)
+            .savedName(파일_저장_이름)
+            .filePath(파일_경로)
+            .fileType(파일_타입)
+            .fileSize(파일_사이즈)
+            .build();
+
+    /* Response DTO */
+    public static final FileResponse 파일_응답 = new FileResponse(파일_원본_이름, 파일_전체_경로);
+}

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
@@ -3,6 +3,7 @@ package com.trybe.modulecore.challenge.entity;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
 import com.trybe.modulecore.common.entity.BaseEntity;
+import com.trybe.modulecore.file.entity.File;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,6 +35,10 @@ public class Challenge extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "thumbnail_id")
+    private File thumbnail;
 
     @Column(name = "title", nullable = false)
     private String title;
@@ -67,7 +72,8 @@ public class Challenge extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void updateContent(String title, String description, LocalDate startDate, LocalDate endDate, int capacity, ChallengeCategory category) {
+    public void updateContent(File thumbnail, String title, String description, LocalDate startDate, LocalDate endDate, int capacity, ChallengeCategory category) {
+        this.thumbnail = thumbnail;
         this.title = title;
         this.description = description;
         this.startDate = startDate;

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
@@ -15,10 +15,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "challenge")
+@Table(name = "challenges")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE challenge SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE challenges SET deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 public class Challenge extends BaseEntity {
     public Challenge(String title, String description, LocalDate startDate, LocalDate endDate, int capacity, ChallengeCategory category, String proofWay, int proofCount) {

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/entity/Challenge.java
@@ -72,8 +72,11 @@ public class Challenge extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void updateContent(File thumbnail, String title, String description, LocalDate startDate, LocalDate endDate, int capacity, ChallengeCategory category) {
+    public void updateThumbnail(File thumbnail) {
         this.thumbnail = thumbnail;
+    }
+
+    public void updateContent(String title, String description, LocalDate startDate, LocalDate endDate, int capacity, ChallengeCategory category) {
         this.title = title;
         this.description = description;
         this.startDate = startDate;

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -34,18 +34,21 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
                 .and(statusIn(statuses))
                 .and(categoryIn(categories));
 
-        QueryResults<Challenge> challenges = jpaQueryFactory
+        List<Challenge> challenges = jpaQueryFactory
                 .selectFrom(challenge)
                 .where(builder)
                 .orderBy(getSort(pageable, challenge))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetchResults();
+                .fetch();
 
-        List<Challenge> content = challenges.getResults();
-        long total = challenges.getTotal();
+        Long total = jpaQueryFactory
+                .select(challenge.count())
+                .from(challenge)
+                .where(builder)
+                .fetchOne();
 
-        return new PageImpl<>(content, pageable, total);
+        return new PageImpl<>(challenges, pageable, total == null ? 0L : total);
     }
 
     @Override

--- a/module-recommendation/build.gradle
+++ b/module-recommendation/build.gradle
@@ -27,10 +27,6 @@ dependencies {
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
-	implementation(project(':module-api')) {
-		transitive = false
-	}
-
 	implementation project(':module-core')
 }
 

--- a/module-recommendation/src/main/java/com/trybe/modulerecommendation/ModuleRecommendationApplication.java
+++ b/module-recommendation/src/main/java/com/trybe/modulerecommendation/ModuleRecommendationApplication.java
@@ -3,7 +3,7 @@ package com.trybe.modulerecommendation;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackages = {"com.trybe.modulerecommendation", "com.trybe.moduleapi.challenge.dto", "com.trybe.modulecore"})
+@SpringBootApplication(scanBasePackages = {"com.trybe.modulerecommendation", "com.trybe.modulecore"})
 public class ModuleRecommendationApplication {
 
 	public static void main(String[] args) {

--- a/module-recommendation/src/main/java/com/trybe/modulerecommendation/challenge/controller/ChallengeRecommendationController.java
+++ b/module-recommendation/src/main/java/com/trybe/modulerecommendation/challenge/controller/ChallengeRecommendationController.java
@@ -1,6 +1,6 @@
 package com.trybe.modulerecommendation.challenge.controller;
 
-import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulerecommendation.challenge.service.ChallengeRecommendationService;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +16,7 @@ public class ChallengeRecommendationController {
     }
 
     @GetMapping
-    public List<ChallengeResponse.Preview> getChallengeRecommendations(@RequestParam Long userId) {
+    public List<Challenge> getChallengeRecommendations(@RequestParam Long userId) {
         return challengeRecommendationService.getChallengeRecommendations(userId);
     }
 }

--- a/module-recommendation/src/main/java/com/trybe/modulerecommendation/challenge/service/ChallengeRecommendationService.java
+++ b/module-recommendation/src/main/java/com/trybe/modulerecommendation/challenge/service/ChallengeRecommendationService.java
@@ -1,91 +1,35 @@
 package com.trybe.modulerecommendation.challenge.service;
 
-import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeCategory;
-import com.trybe.modulecore.challenge.enums.ParticipationStatus;
-import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
-import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
-import com.trybe.modulecore.challenge.repository.popular.PopularChallengeCache;
 import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
 public class ChallengeRecommendationService {
     private final ChallengeRepository challengeRepository;
-    private final ChallengeParticipationRepository challengeParticipationRepository;
-    private final ChallengeBookmarkCache challengeBookmarkCache;
     private final ChallengePreferenceCache challengePreferenceCache;
-    private final PopularChallengeCache popularChallengeCache;
 
-    public ChallengeRecommendationService(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, ChallengePreferenceCache challengePreferenceCache, PopularChallengeCache popularChallengeCache) {
+    public ChallengeRecommendationService(ChallengeRepository challengeRepository, ChallengePreferenceCache challengePreferenceCache) {
         this.challengeRepository = challengeRepository;
-        this.challengeParticipationRepository = challengeParticipationRepository;
-        this.challengeBookmarkCache = challengeBookmarkCache;
         this.challengePreferenceCache = challengePreferenceCache;
-        this.popularChallengeCache = popularChallengeCache;
     }
 
     private static final int LIMIT = 20;
     private static final int RECOMMENDATION_CATEGORY_COUNT = 3;
     private static final int RECOMMENDATION_KEYWORD_COUNT = 10;
-    public static final int INITIALIZE_HOUR = 4;
 
-    public List<ChallengeResponse.Preview> getChallengeRecommendations(Long userId) {
+    public List<Challenge> getChallengeRecommendations(Long userId) {
         List<ChallengeCategory> categories = challengePreferenceCache.getPreferenceCategories(userId, RECOMMENDATION_CATEGORY_COUNT);
         List<String> keywords = challengePreferenceCache.getPreferenceKeywords(userId, RECOMMENDATION_KEYWORD_COUNT);
 
-        List<Challenge> recommendations = challengeRepository.getByCategoriesOrKeywords(categories, keywords, LIMIT);
+        List<Challenge> recommendations = challengeRepository.getRecommendedChallenges(categories, keywords, LIMIT);
 
-        LinkedHashSet<Challenge> challengeSet = new LinkedHashSet<>(recommendations);
+        Set<Challenge> challengeSet = new LinkedHashSet<>(recommendations);
 
-        if (challengeSet.size() < LIMIT) {
-            challengeSet.addAll(getPopularChallenges(LIMIT));
-        }
-
-        List<Challenge> challenges = new ArrayList<>(challengeSet);
-        if (challenges.size() > LIMIT) {
-            challenges = challenges.subList(0, LIMIT);
-        }
-
-        Collections.shuffle(challenges);
-
-        List<ChallengeResponse.Preview> challengePreviews = challenges.stream()
-                .map(challenge -> createPreview(userId, challenge))
-                .toList();
-
-        return challengePreviews;
-    }
-
-    private List<Challenge> getPopularChallenges(int count) {
-        Set<Long> challengeIds = popularChallengeCache.getTopPopularChallenges(getToday(), count);
-        return challengeRepository.findAllByIdIn(challengeIds);
-    }
-
-    private ChallengeResponse.Preview createPreview(Long userId, Challenge challenge) {
-        int participation = getParticipationCount(challenge.getId());
-        ChallengeResponse.Bookmark bookmark = createBookmark(userId, challenge.getId());
-        return ChallengeResponse.Preview.from(challenge, participation, bookmark);
-    }
-
-    private ChallengeResponse.Bookmark createBookmark(Long userId, Long challengeId) {
-        int bookmarkCount = challengeBookmarkCache.getBookmarkCount(challengeId);
-        Boolean bookmarked = userId == null ? null : challengeBookmarkCache.isBookmarked(userId, challengeId);
-        return new ChallengeResponse.Bookmark(bookmarkCount, bookmarked);
-    }
-
-    private int getParticipationCount(Long challengeId) {
-        return challengeParticipationRepository.countByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED);
-    }
-
-    private LocalDate getToday() {
-        LocalDateTime now = LocalDateTime.now();
-
-        return (now.getHour() < INITIALIZE_HOUR) ? now.toLocalDate().minusDays(1) : now.toLocalDate();
+        return new ArrayList<>(challengeSet);
     }
 }


### PR DESCRIPTION
- 추천 챌린지 조회
  - `ChallengeResponse`의 형태가 아닌 `Challenge`를 반환하도록 수정
  - 챌린지 추천 서버에서 추천 챌린지만을 반환하도록 수정 (부족한 챌린지를 채워넣는 로직을 `ChallengeService`로 위임
- `ChallengeResponse`를 만들어 반환하는 `ChallengeResponseAssembler` 추가
  - `ChallengeService`, `ChallengeBookmarkService`내 응답 생성을 `ChallengeResponseAssembler`에게 위임
  - 변경에 따른 테스트 코드 수정
- `Challenge` 내 thumbnail 필드 추가
  - 챌린지 생성 및 내용 수정 시 MultipartFile 형태의 thumbnail을 받을 수 있도록 수정
  - 변경에 따른 테스트 코드 수정