### PR TITLE
[#56] 채팅방 알림 기능

### DIFF
--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponse.java
@@ -21,9 +21,10 @@ public class ChallengeResponse {
             int participantCount,
             String proofWay,
             int proofCount,
+            Long chatRoomId,
             Bookmark bookmark
     ) {
-        public static Detail from(Challenge challenge, FileResponse thumbnail, int participantCount, Bookmark bookmark) {
+        public static Detail from(Challenge challenge, FileResponse thumbnail, int participantCount, Long chatRoomId, Bookmark bookmark) {
             return new Detail(
                     challenge.getId(),
                     thumbnail,
@@ -37,6 +38,7 @@ public class ChallengeResponse {
                     participantCount,
                     challenge.getProofWay(),
                     challenge.getProofCount(),
+                    chatRoomId,
                     bookmark
             );
         }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
@@ -21,21 +21,21 @@ public class ChallengeResponseAssembler {
         this.fileManager = fileManager;
     }
 
-    public ChallengeResponse.Detail toInitialDetail(Challenge challenge) {
+    public ChallengeResponse.Detail toInitialDetail(Challenge challenge, Long chatRoomId) {
         FileResponse thumbnail = toFileResponse(challenge.getThumbnail());
         ChallengeResponse.Bookmark bookmark = new ChallengeResponse.Bookmark(0, false);
 
-        return ChallengeResponse.Detail.from(challenge, thumbnail, 0, bookmark);
+        return ChallengeResponse.Detail.from(challenge, thumbnail, 0, chatRoomId, bookmark);
     }
 
-    public ChallengeResponse.Detail toDetail(Challenge challenge, Long userId) {
+    public ChallengeResponse.Detail toDetail(Challenge challenge, Long userId, Long chatRoomId) {
         Long challengeId = challenge.getId();
 
         int participantCount = getParticipantCount(challengeId);
         ChallengeResponse.Bookmark bookmark = toBookmark(challengeId, userId);
         FileResponse thumbnail = toFileResponse(challenge.getThumbnail());
 
-        return ChallengeResponse.Detail.from(challenge, thumbnail, participantCount, bookmark);
+        return ChallengeResponse.Detail.from(challenge, thumbnail, participantCount, chatRoomId, bookmark);
     }
 
     public ChallengeResponse.Preview toPreview(Challenge challenge, Long userId) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/dto/ChallengeResponseAssembler.java
@@ -1,22 +1,27 @@
 package com.trybe.moduleapi.challenge.dto;
 
+import com.trybe.moduleapi.chat.exception.NotFoundChatRoomException;
 import com.trybe.moduleapi.file.dto.FileResponse;
 import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
+import com.trybe.modulecore.chat.entity.ChatRoom;
+import com.trybe.modulecore.chat.repository.ChatRoomRepository;
 import com.trybe.modulecore.file.entity.File;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ChallengeResponseAssembler {
     private final ChallengeParticipationRepository challengeParticipationRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final ChallengeBookmarkCache challengeBookmarkCache;
     private final FileManager fileManager;
 
-    public ChallengeResponseAssembler(ChallengeParticipationRepository challengeParticipationRepository, ChallengeBookmarkCache challengeBookmarkCache, FileManager fileManager) {
+    public ChallengeResponseAssembler(ChallengeParticipationRepository challengeParticipationRepository, ChatRoomRepository chatRoomRepository, ChallengeBookmarkCache challengeBookmarkCache, FileManager fileManager) {
         this.challengeParticipationRepository = challengeParticipationRepository;
+        this.chatRoomRepository = chatRoomRepository;
         this.challengeBookmarkCache = challengeBookmarkCache;
         this.fileManager = fileManager;
     }
@@ -28,8 +33,10 @@ public class ChallengeResponseAssembler {
         return ChallengeResponse.Detail.from(challenge, thumbnail, 0, chatRoomId, bookmark);
     }
 
-    public ChallengeResponse.Detail toDetail(Challenge challenge, Long userId, Long chatRoomId) {
+    public ChallengeResponse.Detail toDetail(Challenge challenge, Long userId) {
         Long challengeId = challenge.getId();
+        ChatRoom chatRoom = getChatRoomByChallengeId(challengeId);
+        Long chatRoomId = chatRoom.getId();
 
         int participantCount = getParticipantCount(challengeId);
         ChallengeResponse.Bookmark bookmark = toBookmark(challengeId, userId);
@@ -64,5 +71,10 @@ public class ChallengeResponseAssembler {
 
     private FileResponse toFileResponse(File file) {
         return file == null ? null : FileResponse.from(file.getOriginalName(), fileManager.getFileUrl(file.getFilePath()));
+    }
+
+    private ChatRoom getChatRoomByChallengeId(Long challengeId) {
+        return chatRoomRepository.findByChallengeId(challengeId)
+                                 .orElseThrow(() -> new NotFoundChatRoomException());
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -88,7 +88,7 @@ public class ChallengeParticipationService {
 
         participation.updateStatus(status);
 
-        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(participation.getChallenge().getId());
+        ChatRoom chatRoom = chatService.getChatRoomByChallengeId(participation.getChallenge().getId());
         chatService.addUserToChatRoom(chatRoom.getId(), participation.getUser());
         return ChallengeParticipationResponse.Detail.from(participation);
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -99,8 +99,9 @@ public class ChallengeParticipationService {
 
         validateRole(participation, ChallengeRole.MEMBER, "리더는 챌린지를 탈퇴할 수 없습니다.");
 
+        ChatRoom chatRoom = chatService.getChatRoomByChallengeId(challengeId);
         participation.updateStatus(ParticipationStatus.DISABLED);
-        chatService.deleteUserFromChatRoom(participation.getChallenge().getId(), user);
+        chatService.deleteUserFromChatRoom(chatRoom.getId(), user);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -100,7 +100,7 @@ public class ChallengeParticipationService {
         validateRole(participation, ChallengeRole.MEMBER, "리더는 챌린지를 탈퇴할 수 없습니다.");
 
         participation.updateStatus(ParticipationStatus.DISABLED);
-        chatService.deleteUserToChatRoom(participation.getChallenge().getId(), user);
+        chatService.deleteUserFromChatRoom(participation.getChallenge().getId(), user);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -89,8 +89,7 @@ public class ChallengeParticipationService {
         participation.updateStatus(status);
 
         ChatRoom chatRoom = chatService.findChatRoomByChallengeId(participation.getChallenge().getId());
-        chatService.addUserToChatRoom(chatRoom.getId(), participation.getUser().getUserId());
-        chatService.broadcastEnterMessage(participation.getUser(), participation.getChallenge().getId());
+        chatService.addUserToChatRoom(chatRoom.getId(), participation.getUser());
         return ChallengeParticipationResponse.Detail.from(participation);
     }
 
@@ -101,8 +100,7 @@ public class ChallengeParticipationService {
         validateRole(participation, ChallengeRole.MEMBER, "리더는 챌린지를 탈퇴할 수 없습니다.");
 
         participation.updateStatus(ParticipationStatus.DISABLED);
-        chatService.deleteUserToChatRoom(participation.getChallenge().getId(), user.getUserId());
-        chatService.broadcastExitMessage(user, challengeId);
+        chatService.deleteUserToChatRoom(participation.getChallenge().getId(), user);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -15,6 +15,7 @@ import com.trybe.modulecore.challenge.enums.ChallengeStatus;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
+import com.trybe.modulecore.chat.entity.ChatRoom;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -86,7 +87,10 @@ public class ChallengeParticipationService {
         validateStatus(participation, status);
 
         participation.updateStatus(status);
-        chatService.enter(participation.getUser(), participation.getChallenge().getId());
+
+        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(participation.getChallenge().getId());
+        chatService.addUserToChatRoom(chatRoom.getId(), participation.getUser().getUserId());
+        chatService.broadcastEnterMessage(participation.getUser(), participation.getChallenge().getId());
         return ChallengeParticipationResponse.Detail.from(participation);
     }
 
@@ -97,7 +101,8 @@ public class ChallengeParticipationService {
         validateRole(participation, ChallengeRole.MEMBER, "리더는 챌린지를 탈퇴할 수 없습니다.");
 
         participation.updateStatus(ParticipationStatus.DISABLED);
-        chatService.exit(user, challengeId);
+        chatService.deleteUserToChatRoom(participation.getChallenge().getId(), user.getUserId());
+        chatService.broadcastExitMessage(user, challengeId);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
@@ -27,7 +27,7 @@ public class ChallengeScheduler {
         List<Challenge> challenges = challengeRepository.findAllByStatusAndStartDate(ChallengeStatus.PENDING, LocalDate.now());
         challenges.forEach(challenge -> {
             challenge.updateStatus(ChallengeStatus.ONGOING);
-            chatService.challengeStartMessage(challenge);
+            chatService.sendChallengeStartMessage(challenge);
         });
     }
 
@@ -37,7 +37,7 @@ public class ChallengeScheduler {
         List<Challenge> challenges = challengeRepository.findAllByStatusAndEndDate(ChallengeStatus.ONGOING, LocalDate.now());
         challenges.forEach(challenge -> {
             challenge.updateStatus(ChallengeStatus.DONE);
-            chatService.challengeClosedMessage(challenge);
+            chatService.sendChallengeClosedMessage(challenge);
         });
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -21,6 +21,7 @@ import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepositor
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
 import com.trybe.modulecore.challenge.repository.view.ChallengeViewCache;
+import com.trybe.modulecore.chat.entity.ChatRoom;
 import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -73,19 +74,21 @@ public class ChallengeService {
         challenge.updateThumbnail(thumbnailFile);
         challengeParticipationRepository.save(participation);
         challengeEventPublisher.publish(new ChallengeEvent(savedChallenge, user.getId(), ChallengeEventType.CREATE));
-        chatService.create(savedChallenge);
+        Long chatRoomId = chatService.create(savedChallenge);
+        chatService.addUserToChatRoom(chatRoomId, user.getUserId());
 
-        return challengeResponseAssembler.toInitialDetail(savedChallenge);
+        return challengeResponseAssembler.toInitialDetail(savedChallenge, chatRoomId);
     }
 
     @Transactional(readOnly = true)
     public ChallengeResponse.Detail find(User user, Long id) {
         Challenge challenge = getChallenge(id);
+        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(id);
         Long userId = user == null ? null : user.getId();
 
         handleView(userId, challenge);
 
-        return challengeResponseAssembler.toDetail(challenge, userId);
+        return challengeResponseAssembler.toDetail(challenge, userId, chatRoom.getId());
     }
 
     @Transactional(readOnly = true)
@@ -139,11 +142,12 @@ public class ChallengeService {
         validateLeader(user.getId(), id, "리더만 챌린지 정보를 수정할 수 있습니다.");
         validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 정보를 수정할 수 있습니다.");
 
+        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(id);
         File thumbnailFile = updateThumbnail(challenge, thumbnail);
         challenge.updateThumbnail(thumbnailFile);
         challenge.updateContent(request.title(), request.description(), request.startDate(), request.endDate(), request.capacity(), request.category());
 
-        return challengeResponseAssembler.toDetail(challenge, user.getId());
+        return challengeResponseAssembler.toDetail(challenge, user.getId(), chatRoom.getId());
     }
 
     @Transactional
@@ -154,8 +158,9 @@ public class ChallengeService {
         validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 인증 정보를 수정할 수 있습니다.");
 
         challenge.updateProof(request.proofWay(), request.proofCount());
+        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(id);
 
-        return challengeResponseAssembler.toDetail(challenge, user.getId());
+        return challengeResponseAssembler.toDetail(challenge, user.getId(), chatRoom.getId());
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -83,12 +83,11 @@ public class ChallengeService {
     @Transactional(readOnly = true)
     public ChallengeResponse.Detail find(User user, Long id) {
         Challenge challenge = getChallenge(id);
-        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(id);
         Long userId = user == null ? null : user.getId();
 
         handleView(userId, challenge);
 
-        return challengeResponseAssembler.toDetail(challenge, userId, chatRoom.getId());
+        return challengeResponseAssembler.toDetail(challenge, userId);
     }
 
     @Transactional(readOnly = true)
@@ -142,12 +141,11 @@ public class ChallengeService {
         validateLeader(user.getId(), id, "리더만 챌린지 정보를 수정할 수 있습니다.");
         validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 정보를 수정할 수 있습니다.");
 
-        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(id);
         File thumbnailFile = updateThumbnail(challenge, thumbnail);
         challenge.updateThumbnail(thumbnailFile);
         challenge.updateContent(request.title(), request.description(), request.startDate(), request.endDate(), request.capacity(), request.category());
 
-        return challengeResponseAssembler.toDetail(challenge, user.getId(), chatRoom.getId());
+        return challengeResponseAssembler.toDetail(challenge, user.getId());
     }
 
     @Transactional
@@ -158,9 +156,8 @@ public class ChallengeService {
         validateChallengeStatus(challenge, true, ChallengeStatus.PENDING, "진행 예정인 챌린지만 인증 정보를 수정할 수 있습니다.");
 
         challenge.updateProof(request.proofWay(), request.proofCount());
-        ChatRoom chatRoom = chatService.findChatRoomByChallengeId(id);
 
-        return challengeResponseAssembler.toDetail(challenge, user.getId(), chatRoom.getId());
+        return challengeResponseAssembler.toDetail(challenge, user.getId());
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -75,7 +75,7 @@ public class ChallengeService {
         challengeParticipationRepository.save(participation);
         challengeEventPublisher.publish(new ChallengeEvent(savedChallenge, user.getId(), ChallengeEventType.CREATE));
         Long chatRoomId = chatService.create(savedChallenge);
-        chatService.addUserToChatRoom(chatRoomId, user.getUserId());
+        chatService.addUserToChatRoom(chatRoomId, user);
 
         return challengeResponseAssembler.toInitialDetail(savedChallenge, chatRoomId);
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/controller/ChatController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/controller/ChatController.java
@@ -20,21 +20,21 @@ public class ChatController {
         this.chatService = chatService;
     }
 
-    @MessageMapping("/chat/{challengeId}/send")
+    @MessageMapping("/chat/{chatRoomId}/send")
     public void send(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @DestinationVariable Long challengeId,
+            @DestinationVariable Long chatRoomId,
             @Payload ChatRequest.Send request) {
-        chatService.sendMessage(challengeId, userDetails.getUser(), request);
+        chatService.sendMessage(chatRoomId, userDetails.getUser(), request);
     }
 
-    @GetMapping("/{challengeId}")
+    @GetMapping("/{chatRoomId}")
     public CursorResponse<ChatResponse.Message> findAll(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable("challengeId") Long challengeId,
+            @PathVariable("chatRoomId") Long chatRoomId,
             @RequestParam(value = "cursor", required = false) Long cursorId
     ){
-        return chatService.findMessages(userDetails.getUser(), challengeId, cursorId);
+        return chatService.findMessages(userDetails.getUser(), chatRoomId, cursorId);
     }
 
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/event/StompEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/event/StompEventListener.java
@@ -1,0 +1,63 @@
+package com.trybe.moduleapi.chat.event;
+
+import com.trybe.moduleapi.chat.exception.WebSocketConnectionException;
+import com.trybe.modulecore.chat.repository.ChatRoomUserCache;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class StompEventListener {
+    private  final ChatRoomUserCache chatRoomUserCache;
+
+    public StompEventListener(ChatRoomUserCache chatRoomUserCache) {
+        this.chatRoomUserCache = chatRoomUserCache;
+    }
+
+    @EventListener
+    public void handleConnectEvent(SessionConnectedEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        String sessionId = accessor.getSessionId();
+        String chatRoomId = getChatRoomId(accessor);
+        String userId = accessor.getUser().getName();
+
+        chatRoomUserCache.online(chatRoomId, userId, sessionId);
+    }
+
+    @EventListener
+    public void handleDisconnectEvent(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        String sessionId = accessor.getSessionId();
+        String userId = accessor.getUser().getName();
+
+        chatRoomUserCache.offline(userId, sessionId);
+    }
+
+    private String getChatRoomId(StompHeaderAccessor accessor){
+        MessageHeaders messageHeaders = accessor.getMessageHeaders();
+        Object simpConnectMessage = messageHeaders.get("simpConnectMessage");
+
+        if (simpConnectMessage instanceof GenericMessage) {
+            GenericMessage<?> genericMessage = (GenericMessage<?>) simpConnectMessage;
+
+            Map<String, List<String>> nativeHeaders = (Map<String, List<String>>) genericMessage.getHeaders().get("nativeHeaders");
+
+            if (nativeHeaders != null && nativeHeaders.containsKey("chatRoomId")) {
+                List<String> chatRoomIds = nativeHeaders.get("chatRoomId");
+                if (!chatRoomIds.isEmpty()) {
+                    return chatRoomIds.get(0);
+                }
+            }
+        }
+        throw new WebSocketConnectionException();
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/event/StompEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/event/StompEventListener.java
@@ -26,7 +26,7 @@ public class StompEventListener {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
 
         String sessionId = accessor.getSessionId();
-        String chatRoomId = getChatRoomId(accessor);
+        Long chatRoomId = getChatRoomId(accessor);
         String userId = accessor.getUser().getName();
 
         chatRoomUserCache.online(chatRoomId, userId, sessionId);
@@ -42,7 +42,7 @@ public class StompEventListener {
         chatRoomUserCache.offline(userId, sessionId);
     }
 
-    private String getChatRoomId(StompHeaderAccessor accessor){
+    private Long getChatRoomId(StompHeaderAccessor accessor){
         MessageHeaders messageHeaders = accessor.getMessageHeaders();
         Object simpConnectMessage = messageHeaders.get("simpConnectMessage");
 
@@ -54,7 +54,7 @@ public class StompEventListener {
             if (nativeHeaders != null && nativeHeaders.containsKey("chatRoomId")) {
                 List<String> chatRoomIds = nativeHeaders.get("chatRoomId");
                 if (!chatRoomIds.isEmpty()) {
-                    return chatRoomIds.get(0);
+                    return Long.valueOf(chatRoomIds.get(0));
                 }
             }
         }

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/exception/NotFoundChatRoomException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/exception/NotFoundChatRoomException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class NotFoundChatRoomException extends BusinessException {
     public NotFoundChatRoomException() {
-        super("해당 챌린지에 대한 채팅방은 존재하지 않습니다.", HttpStatus.NOT_FOUND.value());
+        super("채팅방이 존재하지 않습니다.", HttpStatus.NOT_FOUND.value());
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/exception/WebSocketConnectionException.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/exception/WebSocketConnectionException.java
@@ -1,0 +1,10 @@
+package com.trybe.moduleapi.chat.exception;
+
+import com.trybe.moduleapi.common.api.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class WebSocketConnectionException extends BusinessException {
+    public WebSocketConnectionException() {
+        super("웹소켓 연결 시 헤더 오류", HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -129,14 +129,14 @@ public class ChatService {
         chatRoomUserCache.addUserToChatRoom(chatRoomId, user.getUserId());
     }
 
-    public void deleteUserToChatRoom(Long chatRoomId, User user){
+    public void deleteUserFromChatRoom(Long chatRoomId, User user){
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         String message = createExitMessage(user.getNickname());
 
         ChatMessage chatMessage = createChatMessage(chatRoom, user, message, MessageType.EXIT);
         chatMessageRepository.save(chatMessage);
 
-        chatRoomUserCache.deleteUserToChatRoom(chatRoomId, user.getUserId());
+        chatRoomUserCache.deleteUserFromChatRoom(chatRoomId, user.getUserId());
     }
 
     public ChatRoom findChatRoomByChallengeId(Long challengeId) {

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -113,7 +113,10 @@ public class ChatService {
         return savedChatRoom.getId();
     }
 
-    public void delete(Long chatRoomId) {
+    public void delete(Long challengeId) {
+        ChatRoom chatRoom = getChatRoomByChallengeId(challengeId);
+        Long chatRoomId = chatRoom.getId();
+
         chatRoomUserCache.clear(chatRoomId);
         chatMessageRepository.deleteByChatRoomId(chatRoomId);
         chatRoomRepository.deleteById(chatRoomId);

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -153,7 +153,7 @@ public class ChatService {
                                  .orElseThrow(NotFoundChatRoomException::new);
     }
 
-    public void challengeStartMessage(Challenge challenge) {
+    public void sendChallengeStartMessage(Challenge challenge) {
         String message = String.format(CHALLENGE_START_MESSAGE, challenge.getTitle());
         ChatRoom chatRoom = getChatRoomByChallengeId(challenge.getId());
 
@@ -164,7 +164,7 @@ public class ChatService {
         notifyOfflineUsers(chatRoom, chatRoom.getChallenge(), null);
     }
 
-    public void challengeClosedMessage(Challenge challenge) {
+    public void sendChallengeClosedMessage(Challenge challenge) {
         String message = String.format(CHALLENGE_CLOSED_MESSAGE, challenge.getTitle());
         ChatRoom chatRoom = getChatRoomByChallengeId(challenge.getId());
 

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -139,13 +139,14 @@ public class ChatService {
         chatRoomUserCache.deleteUserFromChatRoom(chatRoomId, user.getUserId());
     }
 
-    public ChatRoom findChatRoomByChallengeId(Long challengeId) {
-        return chatRoomRepository.findByChallengeId(challengeId);
+    public ChatRoom getChatRoomByChallengeId(Long challengeId) {
+        return chatRoomRepository.findByChallengeId(challengeId)
+                                 .orElseThrow(() -> new NotFoundChatRoomException());
     }
 
     public void challengeStartMessage(Challenge challenge) {
         String message = String.format(CHALLENGE_START_MESSAGE, challenge.getTitle());
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challenge.getId());
+        ChatRoom chatRoom = getChatRoomByChallengeId(challenge.getId());
 
         ChatMessage chatMessage = createChatMessage(chatRoom, null, message, MessageType.SYSTEM);
         ChatResponse.Message startMessage = ChatResponse.Message.from(chatMessage);
@@ -156,7 +157,7 @@ public class ChatService {
 
     public void challengeClosedMessage(Challenge challenge) {
         String message = String.format(CHALLENGE_CLOSED_MESSAGE, challenge.getTitle());
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challenge.getId());
+        ChatRoom chatRoom = getChatRoomByChallengeId(challenge.getId());
 
         ChatMessage chatMessage = createChatMessage(chatRoom, null, message, MessageType.SYSTEM);
         ChatResponse.Message closedMessage = ChatResponse.Message.from(chatMessage);

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -81,7 +81,7 @@ public class ChatService {
     @Transactional(readOnly = true)
     public CursorResponse<ChatResponse.Message> findMessages(User user, Long chatRoomId, Long cursorId) {
         validateExistsChatRoom(chatRoomId);
-        validateExistsUserInChatRoom(chatRoomId, user.getId(), "해당 채팅방에 속한 회원만 메시지를 보낼 수 있습니다.");
+        validateExistsUserInChatRoom(chatRoomId, user.getId(), "해당 채팅방에 속한 회원만 메시지를 조회할 수 있습니다.");
 
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         ChatMessage enterMessage = chatMessageRepository.findByChatRoomIdAndUserIdAndMessageType(user.getId(), chatRoom.getId(), MessageType.ENTER);

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -6,7 +6,6 @@ import com.trybe.moduleapi.chat.dto.ChatResponse;
 import com.trybe.moduleapi.chat.exception.NotFoundChatRoomException;
 import com.trybe.moduleapi.common.dto.CursorResponse;
 import com.trybe.moduleapi.notification.service.NotificationProducerService;
-import com.trybe.moduleapi.user.service.UserService;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
@@ -19,6 +18,7 @@ import com.trybe.modulecore.chat.repository.ChatRoomUserCache;
 import com.trybe.modulecore.notification.entity.Notification;
 import com.trybe.modulecore.notification.enums.NotificationType;
 import com.trybe.modulecore.user.entity.User;
+import com.trybe.modulecore.user.repository.UserRepository;
 import org.springframework.data.domain.Limit;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -38,16 +38,16 @@ public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatRoomUserCache chatRoomUserCache;
-    private final UserService userService;
+    private final UserRepository userRepository;
     private final NotificationProducerService notificationProducerService;
 
-    public ChatService(ChallengeParticipationRepository challengeParticipationRepository, ChatRoomRepository chatRoomRepository, ChatMessageRepository chatMessageRepository, SimpMessagingTemplate messagingTemplate, ChatRoomUserCache chatRoomUserCache, UserService userService, NotificationProducerService notificationProducerService) {
+    public ChatService(ChallengeParticipationRepository challengeParticipationRepository, ChatRoomRepository chatRoomRepository, ChatMessageRepository chatMessageRepository, SimpMessagingTemplate messagingTemplate, ChatRoomUserCache chatRoomUserCache, UserRepository userRepository, NotificationProducerService notificationProducerService) {
         this.challengeParticipationRepository = challengeParticipationRepository;
         this.chatRoomRepository = chatRoomRepository;
         this.chatMessageRepository = chatMessageRepository;
         this.messagingTemplate = messagingTemplate;
         this.chatRoomUserCache = chatRoomUserCache;
-        this.userService = userService;
+        this.userRepository = userRepository;
         this.notificationProducerService = notificationProducerService;
     }
 
@@ -180,7 +180,7 @@ public class ChatService {
         String message = createNotifyMessage(challenge.getTitle(), sender);
 
         Set<String> offlineUserUserIds = chatRoomUserCache.findOfflineUserIds(chatRoom.getId());
-        List<User> offlineUsers = userService.findByUserIdIn(offlineUserUserIds);
+        List<User> offlineUsers = userRepository.findByUserIdIn(offlineUserUserIds);
 
         Map<UUID, Notification> notificationMap = offlineUsers.stream()
                 .collect(Collectors.toMap(

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -150,7 +150,7 @@ public class ChatService {
 
     public ChatRoom getChatRoomByChallengeId(Long challengeId) {
         return chatRoomRepository.findByChallengeId(challengeId)
-                                 .orElseThrow(() -> new NotFoundChatRoomException());
+                                 .orElseThrow(NotFoundChatRoomException::new);
     }
 
     public void challengeStartMessage(Challenge challenge) {

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -124,22 +124,28 @@ public class ChatService {
 
     public void addUserToChatRoom(Long chatRoomId, User user){
         ChatRoom chatRoom = getChatRoom(chatRoomId);
+        Long challengeId = chatRoom.getChallenge().getId();
         String message = createEnterMessage(user.getNickname());
 
         ChatMessage chatMessage = createChatMessage(chatRoom, user, message, MessageType.ENTER);
         chatMessageRepository.save(chatMessage);
 
         chatRoomUserCache.addUserToChatRoom(chatRoomId, user.getUserId());
+        ChatResponse.Message enterMessage = ChatResponse.Message.from(chatMessage);
+        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX +  challengeId, enterMessage);
     }
 
     public void deleteUserFromChatRoom(Long chatRoomId, User user){
         ChatRoom chatRoom = getChatRoom(chatRoomId);
+        Long challengeId = chatRoom.getChallenge().getId();
         String message = createExitMessage(user.getNickname());
 
         ChatMessage chatMessage = createChatMessage(chatRoom, user, message, MessageType.EXIT);
         chatMessageRepository.save(chatMessage);
 
         chatRoomUserCache.deleteUserFromChatRoom(chatRoomId, user.getUserId());
+        ChatResponse.Message exitMessage = ChatResponse.Message.from(chatMessage);
+        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX +  challengeId, exitMessage);
     }
 
     public ChatRoom getChatRoomByChallengeId(Long challengeId) {

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -5,6 +5,8 @@ import com.trybe.moduleapi.chat.dto.ChatRequest;
 import com.trybe.moduleapi.chat.dto.ChatResponse;
 import com.trybe.moduleapi.chat.exception.NotFoundChatRoomException;
 import com.trybe.moduleapi.common.dto.CursorResponse;
+import com.trybe.moduleapi.notification.service.NotificationProducerService;
+import com.trybe.moduleapi.user.service.UserService;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
@@ -13,6 +15,9 @@ import com.trybe.modulecore.chat.entity.ChatRoom;
 import com.trybe.modulecore.chat.enums.MessageType;
 import com.trybe.modulecore.chat.repository.ChatMessageRepository;
 import com.trybe.modulecore.chat.repository.ChatRoomRepository;
+import com.trybe.modulecore.chat.repository.ChatRoomUserCache;
+import com.trybe.modulecore.notification.entity.Notification;
+import com.trybe.modulecore.notification.enums.NotificationType;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Limit;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -21,6 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,117 +37,182 @@ public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final SimpMessagingTemplate messagingTemplate;
+    private final ChatRoomUserCache chatRoomUserCache;
+    private final UserService userService;
+    private final NotificationProducerService notificationProducerService;
 
-    public ChatService(ChallengeParticipationRepository challengeParticipationRepository, ChatRoomRepository chatRoomRepository, ChatMessageRepository chatMessageRepository, SimpMessagingTemplate messagingTemplate) {
+    public ChatService(ChallengeParticipationRepository challengeParticipationRepository, ChatRoomRepository chatRoomRepository, ChatMessageRepository chatMessageRepository, SimpMessagingTemplate messagingTemplate, ChatRoomUserCache chatRoomUserCache, UserService userService, NotificationProducerService notificationProducerService) {
         this.challengeParticipationRepository = challengeParticipationRepository;
         this.chatRoomRepository = chatRoomRepository;
         this.chatMessageRepository = chatMessageRepository;
         this.messagingTemplate = messagingTemplate;
+        this.chatRoomUserCache = chatRoomUserCache;
+        this.userService = userService;
+        this.notificationProducerService = notificationProducerService;
     }
 
-    public static final String CHAT_DESTINATION_PREFIX = "/sub/chat/challenges/";
+    public static final String CHAT_DESTINATION_PREFIX = "/sub/chat/chatRoom/";
     public static final String ENTER_MESSAGE = "[ %s ] 님이 입장하였습니다.";
     public static final String EXIT_MESSAGE = "[ %s ] 님이 퇴장하였습니다.";
     public static final String CHALLENGE_INIT_MESSAGE = "[ %s ] 챌린지 단체 채팅방입니다";
     public static final String CHALLENGE_START_MESSAGE = "[ %s ] 챌린지가 시작되었습니다.";
     public static final String CHALLENGE_CLOSED_MESSAGE = "[ %s ] 챌린지가 종료되었습니다.";
 
+    private static final String NOTICE_TITLE = "새로운 매시지가 도착했습니다.";
+    private static final String USER_NOTICE_MESSAGE_FORMAT = "[%s] %s님의 새로운 메시지입니다.";
+    private static final String SYSTEM_NOTICE_MESSAGE_FORMAT = "[%s] 새로운 시스템 메시지가 도착했습니다.";
+
     private static final int MESSAGE_LIMIT_SIZE = 20;
 
     @Transactional
-    public void sendMessage(Long challengeId, User sender, ChatRequest.Send request){
-        validateExistsUserInChatRoom(challengeId, sender, "챌린지에 참여한 회원만 메시지를 보낼 수 있습니다.");
+    public void sendMessage(Long chatRoomId, User sender, ChatRequest.Send request) {
+        validateExistsChatRoom(chatRoomId);
+        validateExistsUserInChatRoom(chatRoomId, sender.getId(), "해당 채팅방에 속한 회원만 메시지를 보낼 수 있습니다.");
 
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challengeId);
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
         ChatMessage chatMessage = request.toEntity(chatRoom, sender);
         chatMessageRepository.save(chatMessage);
         ChatResponse.Message message = ChatResponse.Message.from(chatMessage);
 
-        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX +  challengeId, message);
-
-        /**
-         * TODO
-         * 해당 채팅방 유저들에게 채팅 도착 SSE 알림 전송
-         */
+        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + chatRoomId, message);
+        notifyOfflineUsers(chatRoom, chatRoom.getChallenge(), sender);
     }
 
     @Transactional(readOnly = true)
-    public CursorResponse<ChatResponse.Message> findMessages(User user, Long challengeId, Long cursorId){
-        validateExistsChatRoom(challengeId);
-        validateExistsUserInChatRoom(challengeId, user, "챌린지에 참여한 회원이 아닙니다.");
+    public CursorResponse<ChatResponse.Message> findMessages(User user, Long chatRoomId, Long cursorId) {
+        validateExistsChatRoom(chatRoomId);
+        validateExistsUserInChatRoom(chatRoomId, user.getId(), "해당 채팅방에 속한 회원만 메시지를 보낼 수 있습니다.");
 
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challengeId);
-        ChatMessage enterMessage = chatMessageRepository.findByChatRoomIdAndUserIdAndMessageType(user.getId(),chatRoom.getId(), MessageType.ENTER);
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
+        ChatMessage enterMessage = chatMessageRepository.findByChatRoomIdAndUserIdAndMessageType(user.getId(), chatRoom.getId(), MessageType.ENTER);
 
         Long latestId = chatMessageRepository.findLatestIdByChatRoomId(chatRoom.getId());
         cursorId = (cursorId == null) ? latestId + 1 : cursorId;
         LocalDateTime enterTime = (enterMessage != null) ? enterMessage.getCreatedAt() : LocalDateTime.of(1970, 1, 1, 0, 0);
 
-        List<ChatMessage> messages = chatMessageRepository.findMessagesByCursorId(challengeId, cursorId, enterTime, Limit.of(MESSAGE_LIMIT_SIZE+1));
+        List<ChatMessage> messages = chatMessageRepository.findMessagesByCursorId(chatRoomId, cursorId, enterTime, Limit.of(MESSAGE_LIMIT_SIZE + 1));
 
         boolean hasNext = messages.size() > MESSAGE_LIMIT_SIZE;
         messages = hasNext ? messages.subList(0, MESSAGE_LIMIT_SIZE) : messages;
 
-        Long nextCursor = hasNext ?  messages.get(messages.size() - 1).getId() : null;
+        Long nextCursor = hasNext ? messages.get(messages.size() - 1).getId() : null;
 
         List<ChatResponse.Message> messagesResponse = messages.stream()
-                                                              .map(ChatResponse.Message::from)
-                                                              .collect(Collectors.toList());
+                .map(ChatResponse.Message::from)
+                .collect(Collectors.toList());
         return CursorResponse.of(messagesResponse, nextCursor, messagesResponse.size(), hasNext);
     }
 
-    public void create(Challenge challenge){
+    public Long create(Challenge challenge) {
         ChatRoom chatRoom = new ChatRoom(challenge);
-        chatRoomRepository.save(chatRoom);
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
         String challengeInitMessage = createChallengeInitMessage(challenge.getTitle());
         ChatMessage chatMessage = createChatMessage(chatRoom, null, challengeInitMessage, MessageType.SYSTEM);
         chatMessageRepository.save(chatMessage);
+
+        return savedChatRoom.getId();
     }
 
-    public void enter(User user, Long challengeId){
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challengeId);
+    public void delete(Long chatRoomId) {
+        chatRoomUserCache.clear(chatRoomId);
+        chatMessageRepository.deleteByChatRoomId(chatRoomId);
+        chatRoomRepository.deleteById(chatRoomId);
+    }
+
+    public void addUserToChatRoom(Long chatRoomId, String userName){
+        chatRoomUserCache.addUserToChatRoom(chatRoomId,userName);
+    }
+
+    public void deleteUserToChatRoom(Long chatRoomId, String userName){
+        chatRoomUserCache.deleteUserToChatRoom(chatRoomId,userName);
+    }
+
+    public ChatRoom findChatRoomByChallengeId(Long challengeId) {
+        return chatRoomRepository.findByChallengeId(challengeId);
+    }
+
+    public void broadcastEnterMessage(User user, Long chatRoomId) {
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
         String message = createEnterMessage(user.getNickname());
+
         ChatMessage chatMessage = createChatMessage(chatRoom, user, message, MessageType.ENTER);
         chatMessageRepository.save(chatMessage);
+
         ChatResponse.Message enterMessage = ChatResponse.Message.from(chatMessage);
-        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX +  challengeId, enterMessage);
+        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + chatRoomId, enterMessage);
+
+        notifyOfflineUsers(chatRoom, chatRoom.getChallenge(), null);
     }
 
-    public void exit(User user, Long challengeId){
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challengeId);
+    public void broadcastExitMessage(User user, Long chatRoomId) {
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
         String message = createExitMessage(user.getNickname());
+
         ChatMessage chatMessage = createChatMessage(chatRoom, user, message, MessageType.EXIT);
         chatMessageRepository.save(chatMessage);
+
         ChatResponse.Message exitMessage = ChatResponse.Message.from(chatMessage);
-        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX +  challengeId, exitMessage);
+        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + chatRoomId, exitMessage);
+
+        notifyOfflineUsers(chatRoom, chatRoom.getChallenge(), null);
+    }
+    public void challengeStartMessage(Challenge challenge) {
+        String message = String.format(CHALLENGE_START_MESSAGE, challenge.getTitle());
+        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challenge.getId());
+
+        ChatMessage chatMessage = createChatMessage(chatRoom, null, message, MessageType.SYSTEM);
+        ChatResponse.Message startMessage = ChatResponse.Message.from(chatMessage);
+        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + challenge.getId(), startMessage);
+
+        notifyOfflineUsers(chatRoom, chatRoom.getChallenge(), null);
     }
 
-    public void delete(Long challengeId) {
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challengeId);
-        chatMessageRepository.deleteByChatRoomId(chatRoom.getId());
-        chatRoomRepository.deleteById(chatRoom.getId());
+    public void challengeClosedMessage(Challenge challenge) {
+        String message = String.format(CHALLENGE_CLOSED_MESSAGE, challenge.getTitle());
+        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challenge.getId());
+
+        ChatMessage chatMessage = createChatMessage(chatRoom, null, message, MessageType.SYSTEM);
+        ChatResponse.Message closedMessage = ChatResponse.Message.from(chatMessage);
+        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + challenge.getId(), closedMessage);
+
+        notifyOfflineUsers(chatRoom, challenge, null);
+        chatRoomUserCache.clear(chatRoom.getId());
     }
 
-    private ChatMessage createChatMessage(ChatRoom chatRoom, User user, String message, MessageType messageType){
+    private void notifyOfflineUsers(ChatRoom chatRoom, Challenge challenge, User sender) {
+        String message = createNotifyMessage(challenge.getTitle(), sender);
+
+        Set<String> offlineUserUserIds = chatRoomUserCache.findOfflineUserIds(chatRoom.getId());
+        List<User> offlineUsers = userService.findByUserIdIn(offlineUserUserIds);
+
+        Map<UUID, Notification> notificationMap = offlineUsers.stream()
+                .collect(Collectors.toMap(
+                        User::getUuid,
+                        user -> new Notification(user.getId(), NotificationType.CHAT, chatRoom.getId(), NOTICE_TITLE, message)
+                ));
+
+        notificationProducerService.publishChatNotification(notificationMap);
+    }
+
+    private ChatRoom getChatRoom(Long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(NotFoundChatRoomException::new);
+    }
+
+    private String createNotifyMessage(String challengeTitle, User sender) {
+        if (sender == null) {
+            return String.format(SYSTEM_NOTICE_MESSAGE_FORMAT, challengeTitle);
+        }
+        return String.format(USER_NOTICE_MESSAGE_FORMAT, challengeTitle, sender.getNickname());
+    }
+
+    private ChatMessage createChatMessage(ChatRoom chatRoom, User user, String message, MessageType messageType) {
         return ChatMessage.builder()
-                          .chatRoom(chatRoom)
-                          .user(user)
-                          .message(message)
-                          .messageType(messageType)
-                          .build();
-    }
-
-    private void validateExistsChatRoom(Long challengeId) {
-        if (!chatRoomRepository.existsByChallengeId(challengeId)) {
-            throw new NotFoundChatRoomException();
-        }
-    }
-
-    private void validateExistsUserInChatRoom(Long challengeId, User user, String message){
-        Long userId = user.getId();
-        if (!challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(userId, challengeId, ParticipationStatus.ACCEPTED)) {
-            throw new NotFoundChallengeParticipationException(message);
-        }
+                .chatRoom(chatRoom)
+                .user(user)
+                .message(message)
+                .messageType(messageType)
+                .build();
     }
 
     private String createEnterMessage(String nickname) {
@@ -154,19 +227,17 @@ public class ChatService {
         return String.format(CHALLENGE_INIT_MESSAGE, challengeTitle);
     }
 
-    public void challengeStartMessage(Challenge challenge) {
-        String message = String.format(CHALLENGE_START_MESSAGE, challenge.getTitle());
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challenge.getId());
-        ChatMessage chatMessage = createChatMessage(chatRoom, null, message, MessageType.SYSTEM);
-        ChatResponse.Message startMessage = ChatResponse.Message.from(chatMessage);
-        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX +  challenge.getId(), startMessage);
+    private void validateExistsChatRoom(Long chatRoomId) {
+        if (!chatRoomRepository.existsById(chatRoomId)) {
+            throw new NotFoundChatRoomException();
+        }
     }
 
-    public void challengeClosedMessage(Challenge challenge) {
-        String message = String.format(CHALLENGE_CLOSED_MESSAGE, challenge.getTitle());
-        ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challenge.getId());
-        ChatMessage chatMessage = createChatMessage(chatRoom, null, message, MessageType.SYSTEM);
-        ChatResponse.Message closedMessage = ChatResponse.Message.from(chatMessage);
-        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX +  challenge.getId(), closedMessage);
+    private void validateExistsUserInChatRoom(Long chatRoomId, Long userId, String message) {
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
+        Long challengeId = chatRoom.getChallenge().getId();
+        if (!challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(userId, challengeId, ParticipationStatus.ACCEPTED)) {
+            throw new NotFoundChallengeParticipationException(message);
+        }
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -173,7 +173,6 @@ public class ChatService {
         messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + challenge.getId(), closedMessage);
 
         notifyOfflineUsers(chatRoom, challenge, null);
-        chatRoomUserCache.clear(chatRoom.getId());
     }
 
     private void notifyOfflineUsers(ChatRoom chatRoom, Challenge challenge, User sender) {

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -119,43 +119,30 @@ public class ChatService {
         chatRoomRepository.deleteById(chatRoomId);
     }
 
-    public void addUserToChatRoom(Long chatRoomId, String userName){
-        chatRoomUserCache.addUserToChatRoom(chatRoomId,userName);
-    }
-
-    public void deleteUserToChatRoom(Long chatRoomId, String userName){
-        chatRoomUserCache.deleteUserToChatRoom(chatRoomId,userName);
-    }
-
-    public ChatRoom findChatRoomByChallengeId(Long challengeId) {
-        return chatRoomRepository.findByChallengeId(challengeId);
-    }
-
-    public void broadcastEnterMessage(User user, Long chatRoomId) {
+    public void addUserToChatRoom(Long chatRoomId, User user){
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         String message = createEnterMessage(user.getNickname());
 
         ChatMessage chatMessage = createChatMessage(chatRoom, user, message, MessageType.ENTER);
         chatMessageRepository.save(chatMessage);
 
-        ChatResponse.Message enterMessage = ChatResponse.Message.from(chatMessage);
-        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + chatRoomId, enterMessage);
-
-        notifyOfflineUsers(chatRoom, chatRoom.getChallenge(), null);
+        chatRoomUserCache.addUserToChatRoom(chatRoomId, user.getUserId());
     }
 
-    public void broadcastExitMessage(User user, Long chatRoomId) {
+    public void deleteUserToChatRoom(Long chatRoomId, User user){
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         String message = createExitMessage(user.getNickname());
 
         ChatMessage chatMessage = createChatMessage(chatRoom, user, message, MessageType.EXIT);
         chatMessageRepository.save(chatMessage);
 
-        ChatResponse.Message exitMessage = ChatResponse.Message.from(chatMessage);
-        messagingTemplate.convertAndSend(CHAT_DESTINATION_PREFIX + chatRoomId, exitMessage);
-
-        notifyOfflineUsers(chatRoom, chatRoom.getChallenge(), null);
+        chatRoomUserCache.deleteUserToChatRoom(chatRoomId, user.getUserId());
     }
+
+    public ChatRoom findChatRoomByChallengeId(Long challengeId) {
+        return chatRoomRepository.findByChallengeId(challengeId);
+    }
+
     public void challengeStartMessage(Challenge challenge) {
         String message = String.format(CHALLENGE_START_MESSAGE, challenge.getTitle());
         ChatRoom chatRoom = chatRoomRepository.findByChallengeId(challenge.getId());

--- a/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/chat/service/ChatService.java
@@ -178,8 +178,8 @@ public class ChatService {
     private void notifyOfflineUsers(ChatRoom chatRoom, Challenge challenge, User sender) {
         String message = createNotifyMessage(challenge.getTitle(), sender);
 
-        Set<String> offlineUserUserIds = chatRoomUserCache.findOfflineUserIds(chatRoom.getId());
-        List<User> offlineUsers = userRepository.findByUserIdIn(offlineUserUserIds);
+        Set<String> offlineUserIds = chatRoomUserCache.findOfflineUserIds(chatRoom.getId());
+        List<User> offlineUsers = userRepository.findByUserIdIn(offlineUserIds);
 
         Map<UUID, Notification> notificationMap = offlineUsers.stream()
                 .collect(Collectors.toMap(

--- a/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationProducerService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationProducerService.java
@@ -1,16 +1,41 @@
 package com.trybe.moduleapi.notification.service;
 
 import com.trybe.moduleapi.notification.dto.NotificationMessage;
+import com.trybe.modulecore.notification.entity.Notification;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 public class NotificationProducerService {
     private final KafkaTemplate<String, NotificationMessage> kafkaTemplate;
     private final NotificationService notificationService;
 
+    private static final String CHAT_NOTIFICATION_TOPIC = "Chat_Notification";
+
     public NotificationProducerService(KafkaTemplate<String, NotificationMessage> kafkaTemplate, NotificationService notificationService) {
         this.kafkaTemplate = kafkaTemplate;
         this.notificationService = notificationService;
+    }
+
+    @Transactional
+    public void publishChatNotification(Map<UUID, Notification> notificationMap) {
+        List<Notification> notifications = notificationMap.values().stream().toList();
+        notificationService.saveAll(notifications);
+
+        for (Map.Entry<UUID, Notification> entry  : notificationMap.entrySet()) {
+            UUID uuid = entry.getKey();
+            Notification notification = entry.getValue();
+            NotificationMessage notificationMessage = toNotificationMessage(uuid, notification);
+            kafkaTemplate.send(CHAT_NOTIFICATION_TOPIC, notificationMessage);
+        }
+    }
+
+    private NotificationMessage toNotificationMessage(UUID uuid, Notification notification){
+        return NotificationMessage.from(notification, uuid);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationService.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 public class NotificationService {
     private final NotificationRepository notificationRepository;
@@ -27,6 +29,10 @@ public class NotificationService {
         return notificationRepository.save(notification);
     }
 
+    @Transactional
+    public List<Notification> saveAll(List<Notification> notification) {
+        return notificationRepository.saveAll(notification);
+    }
     @Transactional(readOnly = true)
     public PageResponse<NotificationResponse> getNotifications(User user, Pageable pageable) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Order.desc("createdAt")));

--- a/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationService.java
@@ -30,8 +30,8 @@ public class NotificationService {
     }
 
     @Transactional
-    public List<Notification> saveAll(List<Notification> notification) {
-        return notificationRepository.saveAll(notification);
+    public List<Notification> saveAll(List<Notification> notifications) {
+        return notificationRepository.saveAll(notifications);
     }
     @Transactional(readOnly = true)
     public PageResponse<NotificationResponse> getNotifications(User user, Pageable pageable) {

--- a/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
@@ -16,6 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+import java.util.Set;
+
 @Service
 public class UserService {
     private final UserRepository userRepository;
@@ -48,6 +51,11 @@ public class UserService {
         User user = getUserById(id);
         FileResponse fileResponse = toFileResponse(user.getProfileImage());
         return UserResponse.Detail.from(user, fileResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public List<User> findByUserIdIn(Set<String> userIds){
+        return userRepository.findByUserIdIn(userIds);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/user/service/UserService.java
@@ -16,9 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Set;
-
 @Service
 public class UserService {
     private final UserRepository userRepository;
@@ -51,11 +48,6 @@ public class UserService {
         User user = getUserById(id);
         FileResponse fileResponse = toFileResponse(user.getProfileImage());
         return UserResponse.Detail.from(user, fileResponse);
-    }
-
-    @Transactional(readOnly = true)
-    public List<User> findByUserIdIn(Set<String> userIds){
-        return userRepository.findByUserIdIn(userIds);
     }
 
     @Transactional

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -8,6 +8,7 @@ import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.challenge.service.ChallengeService;
+import com.trybe.moduleapi.chat.fixture.ChatFixtures;
 import com.trybe.moduleapi.common.ControllerTest;
 import com.trybe.moduleapi.file.fixtures.FileFixtures;
 import com.trybe.modulecore.user.entity.User;
@@ -86,7 +87,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.participantCount").value(ChallengeFixtures.초기_참여자_수),
                 jsonPath("$.proofWay").value(request.proofWay()),
                 jsonPath("$.proofCount").value(request.proofCount()),
-                jsonPath("$.chatRoomId").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.chatRoomId()),
+                jsonPath("$.chatRoomId").value(ChatFixtures.채팅방_ID),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.초기_북마크_수),
                 jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_거짓)
@@ -216,7 +217,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.챌린지_상세_응답.proofWay()),
                 jsonPath("$.proofCount").value(ChallengeFixtures.챌린지_상세_응답.proofCount()),
-                jsonPath("$.chatRoomId").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.chatRoomId()),
+                jsonPath("$.chatRoomId").value(ChallengeFixtures.챌린지_상세_응답.chatRoomId()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
                 jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)
@@ -723,7 +724,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofWay()),
                 jsonPath("$.proofCount").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofCount()),
-                jsonPath("$.chatRoomId").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.chatRoomId()),
+                jsonPath("$.chatRoomId").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.chatRoomId()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
                 jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -86,6 +86,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.participantCount").value(ChallengeFixtures.초기_참여자_수),
                 jsonPath("$.proofWay").value(request.proofWay()),
                 jsonPath("$.proofCount").value(request.proofCount()),
+                jsonPath("$.chatRoomId").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.chatRoomId()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.초기_북마크_수),
                 jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_거짓)
@@ -123,6 +124,7 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
                         fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("chatRoomId").description("채팅방 ID"),
                         fieldWithPath("bookmark").description("챌린지 북마크 정보"),
                         fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
                         fieldWithPath("bookmark.bookmarked").description("북마크 여부")
@@ -214,6 +216,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.챌린지_상세_응답.proofWay()),
                 jsonPath("$.proofCount").value(ChallengeFixtures.챌린지_상세_응답.proofCount()),
+                jsonPath("$.chatRoomId").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.chatRoomId()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
                 jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)
@@ -238,6 +241,7 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
                         fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("chatRoomId").description("채팅방 ID"),
                         fieldWithPath("bookmark").description("챌린지 북마크 정보"),
                         fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
                         fieldWithPath("bookmark.bookmarked").description("북마크 여부")
@@ -477,6 +481,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.proofWay()),
                 jsonPath("$.proofCount").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.proofCount()),
+                jsonPath("$.chatRoomId").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.chatRoomId()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
                 jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)
@@ -511,6 +516,7 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
                         fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("chatRoomId").description("채팅방 ID"),
                         fieldWithPath("bookmark").description("챌린지 북마크 정보"),
                         fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
                         fieldWithPath("bookmark.bookmarked").description("북마크 여부")
@@ -717,6 +723,7 @@ class ChallengeControllerTest extends ControllerTest {
                 jsonPath("$.participantCount").value(ChallengeFixtures.참여자_수),
                 jsonPath("$.proofWay").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofWay()),
                 jsonPath("$.proofCount").value(ChallengeFixtures.인증_내용_수정된_챌린지_상세_응답.proofCount()),
+                jsonPath("$.chatRoomId").value(ChallengeFixtures.내용_수정된_챌린지_상세_응답.chatRoomId()),
                 jsonPath("$.bookmark").exists(),
                 jsonPath("$.bookmark.bookmarkCount").value(ChallengeFixtures.북마크_수),
                 jsonPath("$.bookmark.bookmarked").value(ChallengeFixtures.북마크_여부_참)
@@ -743,6 +750,7 @@ class ChallengeControllerTest extends ControllerTest {
                         fieldWithPath("participantCount").description("챌린지 참여자 수"),
                         fieldWithPath("proofWay").description("챌린지 인증 방법"),
                         fieldWithPath("proofCount").description("챌린지 인증 횟수"),
+                        fieldWithPath("chatRoomId").description("채팅방 ID"),
                         fieldWithPath("bookmark").description("챌린지 북마크 정보"),
                         fieldWithPath("bookmark.bookmarkCount").description("챌린지 북마크 수"),
                         fieldWithPath("bookmark.bookmarked").description("북마크 여부")

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/fixtures/ChallengeFixtures.java
@@ -2,6 +2,7 @@ package com.trybe.moduleapi.challenge.fixtures;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
+import com.trybe.moduleapi.chat.fixture.ChatFixtures;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.file.dto.FileResponse;
 import com.trybe.moduleapi.file.fixtures.FileFixtures;
@@ -52,6 +53,8 @@ public class ChallengeFixtures {
     public static final int 챌린지_인증_횟수 = 7;
     public static final int 잘못된_챌린지_인증_횟수 = 0;
     public static final int 수정된_챌린지_인증_횟수 = 14;
+
+    private static final Long 채팅방_ID = ChatFixtures.채팅방_ID;
 
     public static final int 초기_북마크_수 = ChallengeBookmarkFixtures.초기_북마크_수;
     public static final int 초기_참여자_수 = 1;
@@ -193,18 +196,18 @@ public class ChallengeFixtures {
     /* Response DTO */
     private static final FileResponse 파일_응답 = FileFixtures.파일_응답;
 
-    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 초기_참여자_수, 초기_북마크_수, 북마크_여부_거짓);
-    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 참여자_수, 북마크_수, 북마크_여부_참);
-    public static final ChallengeResponse.Detail 챌린지_상세_비로그인_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 참여자_수, 북마크_수, null);
+    public static final ChallengeResponse.Detail 초기_챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 초기_참여자_수, 초기_북마크_수, 채팅방_ID, 북마크_여부_거짓);
+    public static final ChallengeResponse.Detail 챌린지_상세_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 참여자_수, 북마크_수, 채팅방_ID, 북마크_여부_참);
+    public static final ChallengeResponse.Detail 챌린지_상세_비로그인_응답 = 챌린지_상세_응답_생성(챌린지(), 파일_응답, 참여자_수, 북마크_수, 채팅방_ID,null);
 
     public static final ChallengeResponse.Preview 챌린지_미리보기_로그아웃_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, null);
     public static final ChallengeResponse.Preview 챌린지_미리보기_로그인_응답 = 챌린지_미리보기_응답_생성(챌린지(), 참여자_수, 북마크_수, 북마크_여부_참);
 
     public static final ChallengeResponse.Summary 챌린지_요약_응답 = 챌린지_요약_응답_생성(챌린지());
 
-    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, null, 참여자_수, 북마크_수, 북마크_여부_참);
+    public static final ChallengeResponse.Detail 내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(내용_수정된_챌린지, null, 참여자_수, 북마크_수, 채팅방_ID, 북마크_여부_참);
 
-    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, null, 참여자_수, 북마크_수, 북마크_여부_참);
+    public static final ChallengeResponse.Detail 인증_내용_수정된_챌린지_상세_응답 = 챌린지_상세_응답_생성(인증_내용_수정된_챌린지, null, 참여자_수, 북마크_수, 채팅방_ID, 북마크_여부_참);
 
     public static final List<ChallengeResponse.Summary> 챌린지_목록_응답 = 챌린지_목록.stream().map(ChallengeResponse.Summary::from).collect(Collectors.toList());
     public static final List<ChallengeResponse.Preview> 챌린지_미리보기_목록_응답 = 챌린지_목록.stream().map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부_참)).collect(Collectors.toList());
@@ -212,7 +215,7 @@ public class ChallengeFixtures {
     public static final PageResponse<ChallengeResponse.Summary> 챌린지_페이지_응답 = new PageResponse<>(챌린지_페이지.map(ChallengeResponse.Summary::from));
     public static final PageResponse<ChallengeResponse.Preview> 챌린지_미리보기_페이지_응답 = new PageResponse<>(챌린지_페이지.map(challenge -> 챌린지_미리보기_응답_생성(challenge, 참여자_수, 북마크_수, 북마크_여부_참)));
 
-    private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, FileResponse thumbnail, int participantCount, int bookmarkCount, Boolean Bookmarked) {
+    private static ChallengeResponse.Detail 챌린지_상세_응답_생성(Challenge challenge, FileResponse thumbnail, int participantCount, int bookmarkCount, Long chatRoomId, Boolean Bookmarked) {
         return new ChallengeResponse.Detail(
                 챌린지_ID,
                 thumbnail,
@@ -226,6 +229,7 @@ public class ChallengeFixtures {
                 participantCount,
                 challenge.getProofWay(),
                 challenge.getProofCount(),
+                chatRoomId,
                 new ChallengeResponse.Bookmark(bookmarkCount, Bookmarked)
         );
     }

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
@@ -405,7 +405,7 @@ class ChallengeParticipationServiceTest {
         challengeParticipationService.leave(멤버, challengeId);
 
         /* then */
-        verify(chatService, times(1)).deleteUserToChatRoom(any(), any());
+        verify(chatService, times(1)).deleteUserFromChatRoom(any(), any());
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
@@ -278,7 +278,6 @@ class ChallengeParticipationServiceTest {
         /* then */
         verifyChallengeParticipationResponse(챌린지_멤버_참여(), result);
         verify(chatService, times(1)).addUserToChatRoom(any(), any());
-        verify(chatService, times(1)).broadcastEnterMessage(any(), any());
     }
     
     @Test
@@ -407,7 +406,6 @@ class ChallengeParticipationServiceTest {
 
         /* then */
         verify(chatService, times(1)).deleteUserToChatRoom(any(), any());
-        verify(chatService, times(1)).broadcastExitMessage(any(), any());
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
@@ -8,6 +8,7 @@ import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.*;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
+import com.trybe.moduleapi.chat.fixture.ChatFixtures;
 import com.trybe.moduleapi.chat.service.ChatService;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.user.dto.response.UserResponse;
@@ -15,7 +16,7 @@ import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
-import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
+import com.trybe.modulecore.chat.entity.ChatRoom;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,8 @@ import java.util.Optional;
 import static com.trybe.moduleapi.challenge.fixtures.ChallengeParticipationFixtures.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -259,6 +261,7 @@ class ChallengeParticipationServiceTest {
     void 챌린지_참여_처리_시_처리된_챌린지_참여_정보를_반환한다 () {
         /* given */
         Long participationId = 챌린지_참여_ID;
+        ChatRoom chatRoom = ChatFixtures.채팅방();
 
         when(challengeParticipationRepository.findById(participationId))
                 .thenReturn(Optional.of(챌린지_멤버_참여_대기()));
@@ -266,13 +269,16 @@ class ChallengeParticipationServiceTest {
                 .thenReturn(Optional.of(챌린지_리더_참여()));
         when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(챌린지_참여_수락_상태)))
                 .thenReturn(ChallengeFixtures.챌린지().getCapacity() - 1);
+        when(chatService.findChatRoomByChallengeId(any()))
+                .thenReturn(chatRoom);
 
         /* when */
         ChallengeParticipationResponse.Detail result = challengeParticipationService.confirm(리더, participationId, 챌린지_참여_수락_상태);
 
         /* then */
         verifyChallengeParticipationResponse(챌린지_멤버_참여(), result);
-        verify(chatService, times(1)).enter(any(), any());
+        verify(chatService, times(1)).addUserToChatRoom(any(), any());
+        verify(chatService, times(1)).broadcastEnterMessage(any(), any());
     }
     
     @Test
@@ -397,8 +403,11 @@ class ChallengeParticipationServiceTest {
                 .thenReturn(Optional.of(챌린지_멤버_참여()));
 
         /* when */
-        /* then */
         challengeParticipationService.leave(멤버, challengeId);
+
+        /* then */
+        verify(chatService, times(1)).deleteUserToChatRoom(any(), any());
+        verify(chatService, times(1)).broadcastExitMessage(any(), any());
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
@@ -397,10 +397,12 @@ class ChallengeParticipationServiceTest {
     void 챌린지_탈퇴_시_챌린지_참여_정보를_비활성화한다 () {
         /* given */
         Long challengeId = ChallengeFixtures.챌린지_ID;
+        ChatRoom chatRoom = ChatFixtures.채팅방();
 
         when(challengeParticipationRepository.findByUserIdAndChallengeId(any(), any()))
                 .thenReturn(Optional.of(챌린지_멤버_참여()));
-
+        when(chatService.getChatRoomByChallengeId(any()))
+                .thenReturn(chatRoom);
         /* when */
         challengeParticipationService.leave(멤버, challengeId);
 

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
@@ -269,7 +269,7 @@ class ChallengeParticipationServiceTest {
                 .thenReturn(Optional.of(챌린지_리더_참여()));
         when(challengeParticipationRepository.countByChallengeIdAndStatus(any(), eq(챌린지_참여_수락_상태)))
                 .thenReturn(ChallengeFixtures.챌린지().getCapacity() - 1);
-        when(chatService.findChatRoomByChallengeId(any()))
+        when(chatService.getChatRoomByChallengeId(any()))
                 .thenReturn(chatRoom);
 
         /* when */

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -125,9 +125,7 @@ class ChallengeServiceTest {
         when(user.getId()).thenReturn(userId);
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
-        when(chatService.findChatRoomByChallengeId(challengeId))
-                .thenReturn(chatRoom);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
                 .thenReturn(챌린지_상세_응답);
 
         /* when */
@@ -159,9 +157,7 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(challenge));
         when(challengeViewCache.hasViewed(any(), any()))
                 .thenReturn(true);
-        when(chatService.findChatRoomByChallengeId(challengeId))
-                .thenReturn(chatRoom);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
                 .thenReturn(챌린지_상세_응답);
 
         /* when */
@@ -188,9 +184,7 @@ class ChallengeServiceTest {
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
-        when(chatService.findChatRoomByChallengeId(challengeId))
-                .thenReturn(chatRoom);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
                 .thenReturn(챌린지_상세_비로그인_응답);
 
         /* when */
@@ -294,11 +288,9 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(챌린지()));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), eq(challengeId), eq(ChallengeRole.LEADER)))
                 .thenReturn(true);
-        when(chatService.findChatRoomByChallengeId(challengeId))
-                .thenReturn(chatRoom);
         when(fileManager.updateFile(any(File.class), eq(thumbnail), any(String.class)))
                 .thenReturn(thumbnailFile);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
                 .thenReturn(내용_수정된_챌린지_상세_응답);
 
         /* when */
@@ -375,9 +367,7 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(챌린지()));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
                 .thenReturn(true);
-        when(chatService.findChatRoomByChallengeId(challengeId))
-                .thenReturn(chatRoom);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
                 .thenReturn(인증_내용_수정된_챌린지_상세_응답);
 
         /* when */

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -108,7 +108,7 @@ class ChallengeServiceTest {
         assertEquals(초기_북마크_수, response.bookmark().bookmarkCount());
         assertEquals(false, response.bookmark().bookmarked());
 
-        verify(chatService, times(1)).addUserToChatRoom(any(Long.class), any(String.class));
+        verify(chatService, times(1)).addUserToChatRoom(any(Long.class), any(User.class));
         verify(challengeEventPublisher, times(1)).publish(any(ChallengeEvent.class));
     }
 

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -9,6 +9,7 @@ import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeParticipationFixtures;
+import com.trybe.moduleapi.chat.fixture.ChatFixtures;
 import com.trybe.moduleapi.chat.service.ChatService;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.file.dto.FileResponse;
@@ -22,6 +23,7 @@ import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepositor
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
 import com.trybe.modulecore.challenge.repository.bookmark.ChallengeBookmarkCache;
 import com.trybe.modulecore.challenge.repository.view.ChallengeViewCache;
+import com.trybe.modulecore.chat.entity.ChatRoom;
 import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
@@ -81,6 +83,7 @@ class ChallengeServiceTest {
         /* given */
         ChallengeRequest.Create request = 챌린지_생성_요청;
         Challenge challenge = 챌린지();
+        Long chatRoomId = ChatFixtures.채팅방_ID;
 
         MockMultipartFile thumbnail = FileFixtures.파일_요청_생성("thumbnail");
 
@@ -90,7 +93,9 @@ class ChallengeServiceTest {
                 .thenReturn(ChallengeParticipationFixtures.챌린지_리더_참여());
         when(fileManager.uploadFile(eq(thumbnail), any(String.class)))
                 .thenReturn(FileFixtures.파일);
-        when(challengeResponseAssembler.toInitialDetail(challenge))
+        when(chatService.create(any(Challenge.class)))
+                .thenReturn(chatRoomId);
+        when(challengeResponseAssembler.toInitialDetail(challenge, chatRoomId))
                 .thenReturn(초기_챌린지_상세_응답);
 
         /* when */
@@ -98,11 +103,12 @@ class ChallengeServiceTest {
 
         /* then */
         verifyChallengeResponse(challenge, response);
-        verify(chatService, times(1)).create(challenge);
         assertEquals(초기_참여자_수, response.participantCount());
+        assertEquals(chatRoomId, response.chatRoomId());
         assertEquals(초기_북마크_수, response.bookmark().bookmarkCount());
         assertEquals(false, response.bookmark().bookmarked());
 
+        verify(chatService, times(1)).addUserToChatRoom(any(Long.class), any(String.class));
         verify(challengeEventPublisher, times(1)).publish(any(ChallengeEvent.class));
     }
 
@@ -114,11 +120,14 @@ class ChallengeServiceTest {
         Long userId = UserFixtures.회원_PK;
         User user = spy(UserFixtures.회원);
         Challenge challenge = 챌린지();
+        ChatRoom chatRoom = ChatFixtures.채팅방(challenge);
 
         when(user.getId()).thenReturn(userId);
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+        when(chatService.findChatRoomByChallengeId(challengeId))
+                .thenReturn(chatRoom);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
                 .thenReturn(챌린지_상세_응답);
 
         /* when */
@@ -129,6 +138,7 @@ class ChallengeServiceTest {
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
         assertEquals(북마크_여부_참, response.bookmark().bookmarked());
+        assertEquals(ChatFixtures.채팅방_ID, response.chatRoomId());
 
         verify(challengeViewCache, times(1)).recordView(any(), any());
         verify(challengeEventPublisher, times(1)).publish(any(ChallengeEvent.class));
@@ -142,13 +152,16 @@ class ChallengeServiceTest {
         Long userId = UserFixtures.회원_PK;
         User user = spy(UserFixtures.회원);
         Challenge challenge = 챌린지();
+        ChatRoom chatRoom = ChatFixtures.채팅방(challenge);
 
         when(user.getId()).thenReturn(userId);
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
         when(challengeViewCache.hasViewed(any(), any()))
                 .thenReturn(true);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+        when(chatService.findChatRoomByChallengeId(challengeId))
+                .thenReturn(chatRoom);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
                 .thenReturn(챌린지_상세_응답);
 
         /* when */
@@ -159,6 +172,7 @@ class ChallengeServiceTest {
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
         assertEquals(북마크_여부_참, response.bookmark().bookmarked());
+        assertEquals(ChatFixtures.채팅방_ID, response.chatRoomId());
 
         verify(challengeViewCache, never()).recordView(any(), any());
         verify(challengeEventPublisher, never()).publish(any(ChallengeEvent.class));
@@ -170,10 +184,13 @@ class ChallengeServiceTest {
         /* given */
         Long challengeId = 챌린지_ID;
         Challenge challenge = 챌린지();
+        ChatRoom chatRoom = ChatFixtures.채팅방(challenge);
 
         when(challengeRepository.findById(challengeId))
                 .thenReturn(Optional.of(challenge));
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+        when(chatService.findChatRoomByChallengeId(challengeId))
+                .thenReturn(chatRoom);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
                 .thenReturn(챌린지_상세_비로그인_응답);
 
         /* when */
@@ -183,6 +200,8 @@ class ChallengeServiceTest {
         verifyChallengeResponse(challenge, response);
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
+        assertEquals(ChatFixtures.채팅방_ID, response.chatRoomId());
+
         assertNull(response.bookmark().bookmarked());
     }
 
@@ -264,6 +283,7 @@ class ChallengeServiceTest {
         /* given */
         Long challengeId = 챌린지_ID;
         Challenge challenge = 내용_수정된_챌린지;
+        ChatRoom chatRoom = ChatFixtures.채팅방(challenge);
 
         ChallengeRequest.UpdateContent request = 챌린지_내용_수정_요청;
 
@@ -274,9 +294,11 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(챌린지()));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(any(), eq(challengeId), eq(ChallengeRole.LEADER)))
                 .thenReturn(true);
+        when(chatService.findChatRoomByChallengeId(challengeId))
+                .thenReturn(chatRoom);
         when(fileManager.updateFile(any(File.class), eq(thumbnail), any(String.class)))
                 .thenReturn(thumbnailFile);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
                 .thenReturn(내용_수정된_챌린지_상세_응답);
 
         /* when */
@@ -287,6 +309,7 @@ class ChallengeServiceTest {
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
         assertEquals(북마크_여부_참, response.bookmark().bookmarked());
+        assertEquals(ChatFixtures.채팅방_ID, response.chatRoomId());
     }
 
     @Test
@@ -344,6 +367,7 @@ class ChallengeServiceTest {
         /* given */
         Long challengeId = 챌린지_ID;
         Challenge challenge = 인증_내용_수정된_챌린지;
+        ChatRoom chatRoom = ChatFixtures.채팅방(challenge);
 
         ChallengeRequest.UpdateProof request = 챌린지_인증_내용_수정_요청;
 
@@ -351,7 +375,9 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(챌린지()));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndRole(UserFixtures.회원.getId(), challengeId, ChallengeRole.LEADER))
                 .thenReturn(true);
-        when(challengeResponseAssembler.toDetail(any(Challenge.class), any()))
+        when(chatService.findChatRoomByChallengeId(challengeId))
+                .thenReturn(chatRoom);
+        when(challengeResponseAssembler.toDetail(any(Challenge.class), any(), any()))
                 .thenReturn(인증_내용_수정된_챌린지_상세_응답);
 
         /* when */
@@ -362,6 +388,7 @@ class ChallengeServiceTest {
         assertEquals(참여자_수, response.participantCount());
         assertEquals(북마크_수, response.bookmark().bookmarkCount());
         assertEquals(북마크_여부_참, response.bookmark().bookmarked());
+        assertEquals(ChatFixtures.채팅방_ID, response.chatRoomId());
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/controller/ChatControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/controller/ChatControllerTest.java
@@ -1,7 +1,6 @@
 package com.trybe.moduleapi.chat.controller;
 
 import com.trybe.moduleapi.annotation.WithCustomMockUser;
-import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
 import com.trybe.moduleapi.chat.dto.ChatResponse;
 import com.trybe.moduleapi.chat.fixture.ChatFixtures;
 import com.trybe.moduleapi.chat.service.ChatService;
@@ -45,7 +44,7 @@ class ChatControllerTest extends ControllerTest {
         when(chatService.findMessages(any(User.class), any(Long.class), any(Long.class))).thenReturn(응답);
 
         /* when */
-        mockMvc.perform(get("/api/v1/chats/{challengeId}", ChallengeFixtures.챌린지_ID)
+        mockMvc.perform(get("/api/v1/chats/{chatRoomId}", ChatFixtures.채팅방_ID)
                         .param("cursor", String.valueOf(커서_ID))
                         .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8))
                 .andExpect(status().isOk())
@@ -65,7 +64,7 @@ class ChatControllerTest extends ControllerTest {
                 .andDo(document(docsPath,
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        pathParameters(parameterWithName("challengeId").description("챌린지 ID")),
+                        pathParameters(parameterWithName("chatRoomId").description("채팅방 ID")),
                         queryParameters(parameterWithName("cursor").description("커서 ID")),
                         responseFields(
                                 fieldWithPath("content[]").description("채팅 메시지 목록"),

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/fixture/ChatFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/fixture/ChatFixtures.java
@@ -17,6 +17,7 @@ public class ChatFixtures {
     public static final ChatRoom 채팅방(Challenge challenge){
         return new ChatRoom(challenge);
     }
+    public static final Long 채팅방_ID = 1L;
     public static final ChatRoom 채팅방(){
         return new ChatRoom(ChallengeFixtures.챌린지());
     }

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/fixture/ChatFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/fixture/ChatFixtures.java
@@ -12,6 +12,7 @@ import com.trybe.modulecore.chat.enums.MessageType;
 import com.trybe.modulecore.user.entity.User;
 
 import java.util.List;
+import java.util.Set;
 
 public class ChatFixtures {
     public static final ChatRoom 채팅방(Challenge challenge){
@@ -47,6 +48,8 @@ public class ChatFixtures {
                 .message("채팅 메시지")
                 .build();
     }
+
+    public static final Set<String> 오프라인_유저_아이디 = Set.of("test1", "test2", "test3", "test4");
 
     public static final List<ChatMessage> 채팅_메시지_내역 = List.of(채팅_메시지(시스템),채팅_메시지(입장),채팅_메시지(퇴장),채팅_메시지(대화),채팅_메시지(대화), 채팅_메시지(대화));
     public static final CursorResponse<ChatResponse.Message> 채팅_메시지_내역_응답 = CursorResponse.of(채팅_메시지_내역.stream().map(ChatResponse.Message::from).toList(), null, 채팅_메시지_내역.size(), false);

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -285,7 +285,7 @@ class ChatServiceTest {
         List<User> 오프라인_유저 = UserFixtures.채팅_오프라인_유저;
 
         when(chatRoomRepository.findByChallengeId(챌린지.getId()))
-                .thenReturn(채팅방);
+                .thenReturn(Optional.of(채팅방));
         when(chatRoomUserCache.findOfflineUserIds(any()))
                 .thenReturn(오프라인_유저_아이디);
         when(userService.findByUserIdIn(오프라인_유저_아이디))
@@ -313,7 +313,7 @@ class ChatServiceTest {
         List<User> 오프라인_유저 = UserFixtures.채팅_오프라인_유저;
 
         when(chatRoomRepository.findByChallengeId(챌린지.getId()))
-                .thenReturn(채팅방);
+                .thenReturn(Optional.of(채팅방));
         when(chatRoomUserCache.findOfflineUserIds(any()))
                 .thenReturn(오프라인_유저_아이디);
         when(userService.findByUserIdIn(오프라인_유저_아이디))

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -253,7 +253,7 @@ class ChatServiceTest {
                 .thenReturn(Optional.of(채팅방));
 
         /* when */
-        chatService.deleteUserToChatRoom(채팅방_ID, 회원);
+        chatService.deleteUserFromChatRoom(채팅방_ID, 회원);
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -19,18 +19,20 @@ import com.trybe.modulecore.chat.enums.MessageType;
 import com.trybe.modulecore.chat.repository.ChatMessageRepository;
 import com.trybe.modulecore.chat.repository.ChatRoomRepository;
 import com.trybe.modulecore.chat.repository.ChatRoomUserCache;
+import com.trybe.modulecore.notification.entity.Notification;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Limit;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -56,6 +58,9 @@ class ChatServiceTest {
     @InjectMocks
     ChatService chatService;
 
+    @Captor
+    private ArgumentCaptor<Map<UUID, Notification>> notificationMapCaptor;
+
     @Test
     @DisplayName("해당 채팅방에 속한 회원이 메시지를 보내면 성공한다.")
     void 해당_채팅방에_속한_회원이_메시지를_보내면_성공한다 () {
@@ -65,12 +70,19 @@ class ChatServiceTest {
         Long 채팅방_ID = ChatFixtures.채팅방_ID;
         ChatRequest.Send 채팅_메시지_전송_요청 = ChatFixtures.채팅_메시지_전송_요청;
 
+        Set<String> 오프라인_유저_아이디 = ChatFixtures.오프라인_유저_아이디;
+        List<User> 오프라인_유저 = UserFixtures.채팅_오프라인_유저;
+
         when(chatRoomRepository.existsById(채팅방_ID))
                 .thenReturn(true);
         when(chatRoomRepository.findById(채팅방_ID))
                 .thenReturn(Optional.of(채팅방));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), any(ParticipationStatus.class)))
                 .thenReturn(true);
+        when(chatRoomUserCache.findOfflineUserIds(any()))
+                .thenReturn(오프라인_유저_아이디);
+        when(userService.findByUserIdIn(오프라인_유저_아이디))
+                .thenReturn(오프라인_유저);
 
         /* when */
         chatService.sendMessage(채팅방_ID, 회원, 채팅_메시지_전송_요청);
@@ -78,7 +90,9 @@ class ChatServiceTest {
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
         verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
-        // notifyOfflineUsers
+        verify(notificationProducerService, times(1)).publishChatNotification(notificationMapCaptor.capture());
+        Map<UUID, Notification> 캡쳐된_채팅_알림맵 = notificationMapCaptor.getValue();
+        assertEquals(캡쳐된_채팅_알림맵.size() , 오프라인_유저.size());
     }
 
     @Test
@@ -208,11 +222,10 @@ class ChatServiceTest {
     }
 
     @Test
-    @DisplayName("챌린지 참여 수락 시 입장 메시지가 전송된다.")
-    void 챌린지_참여_수락_시_입장_메시지가_전송된다 () {
+    @DisplayName("챌린지 참여 수락 시 채팅방에 입장한다.")
+    void 챌린지_참여_수락_시_채팅방에_입장한다 () {
         /* given */
         User 회원 = UserFixtures.회원;
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
 
         ChatRoom 채팅방 = ChatFixtures.채팅방();
         Long 채팅방_ID = ChatFixtures.채팅방_ID;
@@ -221,19 +234,17 @@ class ChatServiceTest {
                 .thenReturn(Optional.of(채팅방));
 
         /* when */
-        chatService.broadcastEnterMessage(회원, 챌린지_ID);
+        chatService.addUserToChatRoom(채팅방_ID, 회원);
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
-        verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
     }
 
     @Test
-    @DisplayName("챌린지 탈퇴 시 채팅방에 탈퇴 메시지가 전송된다.")
-    void 챌린지_탈퇴_시_채팅방에_탈퇴_메시지가_전송된다 () {
+    @DisplayName("챌린지 탈퇴 시 채팅방에서 나간다.")
+    void 챌린지_탈퇴_시_채팅방에서_나간다 () {
         /* given */
         User 회원 = UserFixtures.회원;
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
 
         ChatRoom 채팅방 = ChatFixtures.채팅방();
         Long 채팅방_ID = ChatFixtures.채팅방_ID;
@@ -242,11 +253,10 @@ class ChatServiceTest {
                 .thenReturn(Optional.of(채팅방));
 
         /* when */
-        chatService.broadcastExitMessage(회원, 챌린지_ID);
+        chatService.deleteUserToChatRoom(채팅방_ID, 회원);
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
-        verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
     }
 
     @Test
@@ -271,13 +281,25 @@ class ChatServiceTest {
         Challenge 챌린지 = ChallengeFixtures.챌린지();
         ChatRoom 채팅방 = ChatFixtures.채팅방();
 
-        when(chatRoomRepository.findByChallengeId(챌린지.getId())).thenReturn(채팅방);
+        Set<String> 오프라인_유저_아이디 = ChatFixtures.오프라인_유저_아이디;
+        List<User> 오프라인_유저 = UserFixtures.채팅_오프라인_유저;
+
+        when(chatRoomRepository.findByChallengeId(챌린지.getId()))
+                .thenReturn(채팅방);
+        when(chatRoomUserCache.findOfflineUserIds(any()))
+                .thenReturn(오프라인_유저_아이디);
+        when(userService.findByUserIdIn(오프라인_유저_아이디))
+                .thenReturn(오프라인_유저);
+
 
         /* when */
         chatService.challengeStartMessage(챌린지);
 
         /* then */
         verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
+        verify(notificationProducerService, times(1)).publishChatNotification(notificationMapCaptor.capture());
+        Map<UUID, Notification> 캡쳐된_채팅_알림맵 = notificationMapCaptor.getValue();
+        assertEquals(캡쳐된_채팅_알림맵.size() , 오프라인_유저.size());
     }
 
     @Test
@@ -287,12 +309,23 @@ class ChatServiceTest {
         Challenge 챌린지 = ChallengeFixtures.챌린지();
         ChatRoom 채팅방 = ChatFixtures.채팅방();
 
-        when(chatRoomRepository.findByChallengeId(챌린지.getId())).thenReturn(채팅방);
+        Set<String> 오프라인_유저_아이디 = ChatFixtures.오프라인_유저_아이디;
+        List<User> 오프라인_유저 = UserFixtures.채팅_오프라인_유저;
+
+        when(chatRoomRepository.findByChallengeId(챌린지.getId()))
+                .thenReturn(채팅방);
+        when(chatRoomUserCache.findOfflineUserIds(any()))
+                .thenReturn(오프라인_유저_아이디);
+        when(userService.findByUserIdIn(오프라인_유저_아이디))
+                .thenReturn(오프라인_유저);
 
         /* when */
         chatService.challengeClosedMessage(챌린지);
 
         /* then */
         verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
+        verify(notificationProducerService, times(1)).publishChatNotification(notificationMapCaptor.capture());
+        Map<UUID, Notification> 캡쳐된_채팅_알림맵 = notificationMapCaptor.getValue();
+        assertEquals(캡쳐된_채팅_알림맵.size() , 오프라인_유저.size());
     }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -9,7 +9,6 @@ import com.trybe.moduleapi.chat.fixture.ChatFixtures;
 import com.trybe.moduleapi.common.dto.CursorResponse;
 import com.trybe.moduleapi.notification.service.NotificationProducerService;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
-import com.trybe.moduleapi.user.service.UserService;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
@@ -21,6 +20,7 @@ import com.trybe.modulecore.chat.repository.ChatRoomRepository;
 import com.trybe.modulecore.chat.repository.ChatRoomUserCache;
 import com.trybe.modulecore.notification.entity.Notification;
 import com.trybe.modulecore.user.entity.User;
+import com.trybe.modulecore.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,7 +51,7 @@ class ChatServiceTest {
     @Mock
     ChatRoomUserCache chatRoomUserCache;
     @Mock
-    UserService userService;
+    UserRepository userRepository;
     @Mock
     NotificationProducerService notificationProducerService;
 
@@ -81,7 +81,7 @@ class ChatServiceTest {
                 .thenReturn(true);
         when(chatRoomUserCache.findOfflineUserIds(any()))
                 .thenReturn(오프라인_유저_아이디);
-        when(userService.findByUserIdIn(오프라인_유저_아이디))
+        when(userRepository.findByUserIdIn(오프라인_유저_아이디))
                 .thenReturn(오프라인_유저);
 
         /* when */
@@ -294,7 +294,7 @@ class ChatServiceTest {
                 .thenReturn(Optional.of(채팅방));
         when(chatRoomUserCache.findOfflineUserIds(any()))
                 .thenReturn(오프라인_유저_아이디);
-        when(userService.findByUserIdIn(오프라인_유저_아이디))
+        when(userRepository.findByUserIdIn(오프라인_유저_아이디))
                 .thenReturn(오프라인_유저);
 
 
@@ -322,7 +322,7 @@ class ChatServiceTest {
                 .thenReturn(Optional.of(채팅방));
         when(chatRoomUserCache.findOfflineUserIds(any()))
                 .thenReturn(오프라인_유저_아이디);
-        when(userService.findByUserIdIn(오프라인_유저_아이디))
+        when(userRepository.findByUserIdIn(오프라인_유저_아이디))
                 .thenReturn(오프라인_유저);
 
         /* when */

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -238,6 +238,7 @@ class ChatServiceTest {
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+        verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
     }
 
     @Test
@@ -257,6 +258,7 @@ class ChatServiceTest {
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+        verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -263,15 +263,19 @@ class ChatServiceTest {
     @DisplayName("챌린지 삭제 시 채팅방은 삭제된다.")
     void 챌린지_삭제_시_채팅방은_삭제된다 () {
         /* given */
-        Long 채팅방_ID = ChatFixtures.채팅방_ID;
+        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
+        ChatRoom 채팅방 = spy(ChatFixtures.채팅방());
+
+        when(chatRoomRepository.findByChallengeId(챌린지_ID))
+                .thenReturn(Optional.of(채팅방));
 
         /* when */
-        chatService.delete(채팅방_ID);
+        chatService.delete(챌린지_ID);
 
         /* then */
-        verify(chatRoomUserCache, times(1)).clear(채팅방_ID);
-        verify(chatMessageRepository, times(1)).deleteByChatRoomId(채팅방_ID);
-        verify(chatRoomRepository, times(1)).deleteById(채팅방_ID);
+        verify(chatRoomUserCache, times(1)).clear(any());
+        verify(chatMessageRepository, times(1)).deleteByChatRoomId(any());
+        verify(chatRoomRepository, times(1)).deleteById(any());
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -299,7 +299,7 @@ class ChatServiceTest {
 
 
         /* when */
-        chatService.challengeStartMessage(챌린지);
+        chatService.sendChallengeStartMessage(챌린지);
 
         /* then */
         verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
@@ -326,7 +326,7 @@ class ChatServiceTest {
                 .thenReturn(오프라인_유저);
 
         /* when */
-        chatService.challengeClosedMessage(챌린지);
+        chatService.sendChallengeClosedMessage(챌린지);
 
         /* then */
         verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));

--- a/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/chat/service/ChatServiceTest.java
@@ -2,13 +2,14 @@ package com.trybe.moduleapi.chat.service;
 
 import com.trybe.moduleapi.challenge.exception.participation.NotFoundChallengeParticipationException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;
-import com.trybe.moduleapi.challenge.fixtures.ChallengeParticipationFixtures;
 import com.trybe.moduleapi.chat.dto.ChatRequest;
 import com.trybe.moduleapi.chat.dto.ChatResponse;
 import com.trybe.moduleapi.chat.exception.NotFoundChatRoomException;
 import com.trybe.moduleapi.chat.fixture.ChatFixtures;
 import com.trybe.moduleapi.common.dto.CursorResponse;
+import com.trybe.moduleapi.notification.service.NotificationProducerService;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
+import com.trybe.moduleapi.user.service.UserService;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
@@ -17,6 +18,7 @@ import com.trybe.modulecore.chat.entity.ChatRoom;
 import com.trybe.modulecore.chat.enums.MessageType;
 import com.trybe.modulecore.chat.repository.ChatMessageRepository;
 import com.trybe.modulecore.chat.repository.ChatRoomRepository;
+import com.trybe.modulecore.chat.repository.ChatRoomUserCache;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import org.springframework.data.domain.Limit;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,48 +46,76 @@ class ChatServiceTest {
     ChatMessageRepository chatMessageRepository;
     @Mock
     SimpMessagingTemplate messagingTemplate;
+    @Mock
+    ChatRoomUserCache chatRoomUserCache;
+    @Mock
+    UserService userService;
+    @Mock
+    NotificationProducerService notificationProducerService;
 
     @InjectMocks
     ChatService chatService;
 
     @Test
-    @DisplayName("해당 챌린지 채팅방에 참여 상태인 회원이 메시지를 보내면 성공한다.")
-    void 해당_챌린지_채팅방에_참여_상태인_회원이_메시지를_보내면_성공한다 () {
+    @DisplayName("해당 채팅방에 속한 회원이 메시지를 보내면 성공한다.")
+    void 해당_채팅방에_속한_회원이_메시지를_보내면_성공한다 () {
         /* given */
-        User 회원 = UserFixtures.회원;
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
+        User 회원 = UserFixtures.회원();
         ChatRoom 채팅방 = ChatFixtures.채팅방();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
         ChatRequest.Send 채팅_메시지_전송_요청 = ChatFixtures.채팅_메시지_전송_요청;
 
-        ParticipationStatus 챌린지_참여_수락_상태 = ChallengeParticipationFixtures.챌린지_참여_수락_상태;
-
-        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(회원.getId(),챌린지_ID,챌린지_참여_수락_상태)).thenReturn(true);
-        when(chatRoomRepository.findByChallengeId(챌린지_ID)).thenReturn(채팅방);
+        when(chatRoomRepository.existsById(채팅방_ID))
+                .thenReturn(true);
+        when(chatRoomRepository.findById(채팅방_ID))
+                .thenReturn(Optional.of(채팅방));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), any(ParticipationStatus.class)))
+                .thenReturn(true);
 
         /* when */
-        chatService.sendMessage(챌린지_ID, 회원, 채팅_메시지_전송_요청);
+        chatService.sendMessage(채팅방_ID, 회원, 채팅_메시지_전송_요청);
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
         verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponse.Message.class));
+        // notifyOfflineUsers
     }
 
     @Test
-    @DisplayName("해당 챌린지 채팅방에 참여 상태가 아닌 회원이 메시지를 보내면 예외를 던진다.")
-    void 해당_챌린지_채팅방에_참여_상태가_아닌_회원이_메시지를_보내면_예외를_던진다 () {
+    @DisplayName("메시지 전송 시 해당 채팅방이 존재하지 않으면 예외를 던진다.")
+    void 메시지_전송_시_해당_채팅방이_존재하지_않으면_예외를_던진다 () {
         /* given */
-        User 회원 = UserFixtures.회원;
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
+        User 회원 = UserFixtures.회원();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
         ChatRequest.Send 채팅_메시지_전송_요청 = ChatFixtures.채팅_메시지_전송_요청;
 
-        ParticipationStatus 챌린지_참여_수락_상태 = ChallengeParticipationFixtures.챌린지_참여_수락_상태;
-
-        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(회원.getId(),챌린지_ID,챌린지_참여_수락_상태)).thenReturn(false);
+        when(chatRoomRepository.existsById(채팅방_ID))
+                .thenReturn(false);
 
         /* when, then */
-        verify(chatMessageRepository, never()).save(any(ChatMessage.class));
-        verify(messagingTemplate, never()).convertAndSend(any(String.class), any(ChatResponse.Message.class));
-        assertThrows(NotFoundChallengeParticipationException.class, () -> chatService.sendMessage(챌린지_ID, 회원, 채팅_메시지_전송_요청), "챌린지에 참여한 회원만 메시지를 보낼 수 있습니다.");
+        assertThrows(NotFoundChatRoomException.class,
+                () -> chatService.sendMessage(채팅방_ID, 회원, 채팅_메시지_전송_요청));
+    }
+
+    @Test
+    @DisplayName("해당 챌린지에 참여 상태가 아닌 회원이 메시지를 보내면 예외를 던진다.")
+    void 해당_챌린지에_참여_상태가_아닌_회원이_메시지를_보내면_예외를_던진다 () {
+        /* given */
+        User 회원 = UserFixtures.회원();
+        ChatRoom 채팅방 = ChatFixtures.채팅방();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
+        ChatRequest.Send 채팅_메시지_전송_요청 = ChatFixtures.채팅_메시지_전송_요청;
+
+        when(chatRoomRepository.existsById(채팅방_ID))
+                .thenReturn(true);
+        when(chatRoomRepository.findById(채팅방_ID))
+                .thenReturn(Optional.of(채팅방));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), any(ParticipationStatus.class)))
+                .thenReturn(false);
+
+        /* when, then */
+        assertThrows(NotFoundChallengeParticipationException.class,
+                () -> chatService.sendMessage(채팅방_ID, 회원, 채팅_메시지_전송_요청));
     }
 
     @Test
@@ -92,25 +123,29 @@ class ChatServiceTest {
     void 정상적인_채팅_메시지_조회_시_메시지_내역을_반환한다 () {
         /* given */
         User 회원 = UserFixtures.회원;
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
         ChatRoom 채팅방 = ChatFixtures.채팅방();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
         Long 커서_ID = ChatFixtures.커서_ID;
 
-        ParticipationStatus 챌린지_참여_수락_상태 = ChallengeParticipationFixtures.챌린지_참여_수락_상태;
         MessageType 입장 = ChatFixtures.입장;
         ChatMessage 입장_메시지 = ChatFixtures.채팅_메시지(채팅방, 회원, "입장 메시지", 입장);
         List<ChatMessage> 채팅_메시지_내역 = ChatFixtures.채팅_메시지_내역;
 
-        when(chatRoomRepository.existsByChallengeId(챌린지_ID)).thenReturn(true);
-        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(회원.getId(), 챌린지_ID, 챌린지_참여_수락_상태)).thenReturn(true);
-        when(chatRoomRepository.findByChallengeId(챌린지_ID)).thenReturn(채팅방);
-        when(chatMessageRepository.findByChatRoomIdAndUserIdAndMessageType(회원.getId(), 채팅방.getId(), 입장)).thenReturn(입장_메시지);
-        when(chatMessageRepository.findLatestIdByChatRoomId(채팅방.getId())).thenReturn(커서_ID);
-        when(chatMessageRepository.findMessagesByCursorId(챌린지_ID, 커서_ID+1, 입장_메시지.getCreatedAt(), Limit.of(ChatFixtures.메시지_조회_제한_개수+1))).thenReturn(채팅_메시지_내역);
-
+        when(chatRoomRepository.existsById(채팅방_ID))
+                .thenReturn(true);
+        when(chatRoomRepository.findById(채팅방_ID))
+                .thenReturn(Optional.of(채팅방));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), any(ParticipationStatus.class)))
+                .thenReturn(true);
+        when(chatMessageRepository.findByChatRoomIdAndUserIdAndMessageType(회원.getId(), 채팅방.getId(), 입장))
+                .thenReturn(입장_메시지);
+        when(chatMessageRepository.findLatestIdByChatRoomId(채팅방.getId()))
+                .thenReturn(커서_ID);
+        when(chatMessageRepository.findMessagesByCursorId(채팅방_ID, 커서_ID+1, 입장_메시지.getCreatedAt(), Limit.of(ChatFixtures.메시지_조회_제한_개수+1)))
+                .thenReturn(채팅_메시지_내역);
 
         /* when */
-        CursorResponse<ChatResponse.Message> response = chatService.findMessages(회원, 챌린지_ID, null);
+        CursorResponse<ChatResponse.Message> response = chatService.findMessages(회원, 채팅방_ID, null);
 
         /* then */
         assertEquals(response.content().size(), 채팅_메시지_내역.size());
@@ -119,48 +154,57 @@ class ChatServiceTest {
     }
 
     @Test
-    @DisplayName("해당 챌린지에 대한 채팅방이 존재하지 않으면 채팅 메시지 조회 시 예외를 던진다.")
-    void 해당_챌린지에_대한_채팅방이_존재하지_않으면_채팅_메시지_조회_시_예외를_던진다 () {
+    @DisplayName("해당 채팅방이 존재하지 않으면 채팅 메시지 조회 시 예외를 던진다.")
+    void 해당_채팅방이_존재하지_않으면_채팅_메시지_조회_시_예외를_던진다 () {
         /* given */
-        User 회원 = UserFixtures.회원;
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
+        User 회원 = UserFixtures.회원();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
 
-        when(chatRoomRepository.existsByChallengeId(챌린지_ID)).thenReturn(false);
+        when(chatRoomRepository.existsById(채팅방_ID))
+                .thenReturn(false);
 
         /* when, then */
-        assertThrows(NotFoundChatRoomException.class, () -> chatService.findMessages(회원, 챌린지_ID, null),
-                "해당 챌린지에 대한 채팅방은 존재하지 않습니다.");
+        assertThrows(NotFoundChatRoomException.class,
+                () -> chatService.findMessages(회원, 채팅방_ID, null));
     }
 
     @Test
-    @DisplayName("해당 챌린지 채팅방에 참여상태가 아닌 회원이 채팅 메시지 조회 시 예외를 던진다.")
-    void 해당_챌린지_채팅방에_참여상태가_아닌_회원이_채팅_메시지_조회_시_예외를_던진다 () {
+    @DisplayName("해당 채팅방에 참여상태가 아닌 회원이 채팅 메시지 조회 시 예외를 던진다.")
+    void 해당_채팅방에_참여상태가_아닌_회원이_채팅_메시지_조회_시_예외를_던진다 () {
         /* given */
         User 회원 = UserFixtures.회원;
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
+        ChatRoom 채팅방 = ChatFixtures.채팅방();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
 
-        ParticipationStatus 챌린지_참여_수락_상태 = ChallengeParticipationFixtures.챌린지_참여_수락_상태;
-
-        when(chatRoomRepository.existsByChallengeId(챌린지_ID)).thenReturn(true);
-        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(회원.getId(),챌린지_ID,챌린지_참여_수락_상태)).thenReturn(false);
+        when(chatRoomRepository.existsById(채팅방_ID))
+                .thenReturn(true);
+        when(chatRoomRepository.findById(채팅방_ID))
+                .thenReturn(Optional.of(채팅방));
+        when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), any(ParticipationStatus.class)))
+                .thenReturn(false);
 
         /* when, then */
-        assertThrows(NotFoundChallengeParticipationException.class, () -> chatService.findMessages(회원, 챌린지_ID, null),
-                "챌린지에 참여한 회원이 아닙니다.");
+        assertThrows(NotFoundChallengeParticipationException.class,
+                () -> chatService.findMessages(회원, 채팅방_ID, null));
     }
 
     @Test
-    @DisplayName("정상적인 챌린지 생성 시 채팅방이 정상적으로 생성된다.")
-    void 정상적인_챌린지_생성_시_채팅방이_정상적으로_생성된다 () {
+    @DisplayName("챌린지 생성 시 해당 챌린지에 대한 채팅방이 생성된다.")
+    void 챌린지_생성_시_해당_챌린지에_대한_채팅방이_생성된다 () {
         /* given */
         Challenge 챌린지 = ChallengeFixtures.챌린지();
+        ChatRoom 채팅방 = ChatFixtures.채팅방(챌린지);
+
+        when(chatRoomRepository.save(any(ChatRoom.class)))
+                .thenReturn(채팅방);
 
         /* when */
-        chatService.create(챌린지);
+        Long chatRoomId = chatService.create(챌린지);
 
         /* then */
         verify(chatRoomRepository, times(1)).save(any(ChatRoom.class));
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
+        assertEquals(채팅방.getId(), chatRoomId);
     }
 
     @Test
@@ -169,12 +213,15 @@ class ChatServiceTest {
         /* given */
         User 회원 = UserFixtures.회원;
         Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
-        ChatRoom 채팅방 = ChatFixtures.채팅방();
 
-        when(chatRoomRepository.findByChallengeId(챌린지_ID)).thenReturn(채팅방);
+        ChatRoom 채팅방 = ChatFixtures.채팅방();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
+
+        when(chatRoomRepository.findById(채팅방_ID))
+                .thenReturn(Optional.of(채팅방));
 
         /* when */
-        chatService.enter(회원, 챌린지_ID);
+        chatService.broadcastEnterMessage(회원, 챌린지_ID);
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
@@ -187,12 +234,15 @@ class ChatServiceTest {
         /* given */
         User 회원 = UserFixtures.회원;
         Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
-        ChatRoom 채팅방 = ChatFixtures.채팅방();
 
-        when(chatRoomRepository.findByChallengeId(챌린지_ID)).thenReturn(채팅방);
+        ChatRoom 채팅방 = ChatFixtures.채팅방();
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
+
+        when(chatRoomRepository.findById(채팅방_ID))
+                .thenReturn(Optional.of(채팅방));
 
         /* when */
-        chatService.exit(회원, 챌린지_ID);
+        chatService.broadcastExitMessage(회원, 챌린지_ID);
 
         /* then */
         verify(chatMessageRepository, times(1)).save(any(ChatMessage.class));
@@ -203,17 +253,15 @@ class ChatServiceTest {
     @DisplayName("챌린지 삭제 시 채팅방은 삭제된다.")
     void 챌린지_삭제_시_채팅방은_삭제된다 () {
         /* given */
-        Long 챌린지_ID = ChallengeFixtures.챌린지_ID;
-        ChatRoom 채팅방 = ChatFixtures.채팅방();
-
-        when(chatRoomRepository.findByChallengeId(챌린지_ID)).thenReturn(채팅방);
+        Long 채팅방_ID = ChatFixtures.채팅방_ID;
 
         /* when */
-        chatService.delete(챌린지_ID);
+        chatService.delete(채팅방_ID);
 
         /* then */
-        verify(chatMessageRepository, times(1)).deleteByChatRoomId(채팅방.getId());
-        verify(chatRoomRepository, times(1)).deleteById(채팅방.getId());
+        verify(chatRoomUserCache, times(1)).clear(채팅방_ID);
+        verify(chatMessageRepository, times(1)).deleteByChatRoomId(채팅방_ID);
+        verify(chatRoomRepository, times(1)).deleteById(채팅방_ID);
     }
 
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/user/fixtures/UserFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/user/fixtures/UserFixtures.java
@@ -10,6 +10,7 @@ import com.trybe.modulecore.user.enums.Role;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class UserFixtures {
     public static final Long 회원_PK = 1L;
@@ -99,4 +100,8 @@ public class UserFixtures {
     public static UserRequest.UpdatePassword 현재_비밀번호_잘못된_비밀번호_변경_요청 = new UserRequest.UpdatePassword(새로운_비밀번호,새로운_비밀번호,확인_비밀번호);
     public static UserRequest.UpdatePassword 새로운_확인용_비밀번호_다른_변경_요청 = new UserRequest.UpdatePassword(현재_비밀번호,새로운_비밀번호,현재_비밀번호);
 
+    public static List<User> 채팅_오프라인_유저 = List.of(회원_생성("test1" , "test1@test.com"),
+                                               회원_생성("test2" , "test2@test.com"),
+                                               회원_생성("test3" , "test3@test.com"),
+                                               회원_생성("test4" , "test4@test.com"));
 }

--- a/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomRepository.java
@@ -4,7 +4,9 @@ import com.trybe.modulecore.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    ChatRoom findByChallengeId(Long challengeId);
+    Optional<ChatRoom> findByChallengeId(Long challengeId);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomRepository.java
@@ -7,5 +7,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     ChatRoom findByChallengeId(Long challengeId);
-    boolean existsByChallengeId(Long challengeId);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
@@ -1,0 +1,75 @@
+package com.trybe.modulecore.chat.repository;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+public class ChatRoomUserCache {
+    private final StringRedisTemplate redisTemplate;
+
+    private final String CHATROOM_SESSION_ID_REDIS_KEY = "chatroom:sessionId:%s"; // sessionId : chatRoomId
+    private final String CHATROOM_OFFLINE_USERS_REDIS_KEY = "chatroom:%s:offline:users";
+
+    public ChatRoomUserCache(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void online(String chatRoomId, String userId, String sessionId) {
+        String sessionIdAndUserMapping = createRedisKey(sessionId);
+        redisTemplate.opsForValue().set(sessionIdAndUserMapping, userId);
+
+        Long longChatRoomId = Long.valueOf(chatRoomId);
+        String offlineUserRedisKey = createRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().remove(offlineUserRedisKey, userId);
+    }
+
+    public void offline(String userId, String sessionId) {
+        String chatRoomId = getChatRoomIdBySessionId(sessionId);
+
+        Long longChatRoomId = Long.valueOf(chatRoomId);
+        String offlineUserRedisKey = createRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().add(offlineUserRedisKey, userId);
+
+        String sessionIdAndUserMapping = createRedisKey(sessionId);
+        redisTemplate.delete(sessionIdAndUserMapping);
+    }
+
+    public void addUserToChatRoom(Long chatRoomId, String userId){
+        Long longChatRoomId = Long.valueOf(chatRoomId);
+        String offlineUserRedisKey = createRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().add(offlineUserRedisKey, userId);
+
+    }
+
+    public void deleteUserToChatRoom(Long chatRoomId, String userName){
+        Long longChatRoomId = Long.valueOf(chatRoomId);
+        String offlineUserRedisKey = createRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().add(offlineUserRedisKey, userName);
+    }
+
+    public void clear(Long chatRoomId){
+        String offlineUserRedisKey = createRedisKey(chatRoomId);
+        redisTemplate.delete(offlineUserRedisKey);
+
+    }
+
+    public Set<String> findOfflineUserIds(Long chatRoomId){
+        String redisKey = createRedisKey(chatRoomId);
+        return redisTemplate.opsForSet().members(redisKey);
+    }
+
+    private String getChatRoomIdBySessionId(String sessionId){
+        String redisKey = createRedisKey(sessionId);
+        return redisTemplate.opsForValue().get(redisKey);
+    }
+
+    private String createRedisKey(Long chatRoomId){
+        return String.format(CHATROOM_OFFLINE_USERS_REDIS_KEY, chatRoomId);
+    }
+
+    private String createRedisKey(String sessionId){
+        return String.format(CHATROOM_SESSION_ID_REDIS_KEY, sessionId);
+    }
+}

--- a/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
@@ -43,10 +43,10 @@ public class ChatRoomUserCache {
 
     }
 
-    public void deleteUserFromChatRoom(Long chatRoomId, String userName){
+    public void deleteUserFromChatRoom(Long chatRoomId, String userId){
         Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserRedisKey = createOfflineUserRedisKey(longChatRoomId);
-        redisTemplate.opsForSet().add(offlineUserRedisKey, userName);
+        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().remove(offlineUserKey, userId);
     }
 
     public void clear(Long chatRoomId){

--- a/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
@@ -17,59 +17,59 @@ public class ChatRoomUserCache {
     }
 
     public void online(String chatRoomId, String userId, String sessionId) {
-        String sessionIdAndUserMapping = createRedisKey(sessionId);
-        redisTemplate.opsForValue().set(sessionIdAndUserMapping, userId);
+        String sessionRoomKey = createSessionRoomKey(sessionId);
+        redisTemplate.opsForValue().set(sessionRoomKey, chatRoomId);
 
         Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserRedisKey = createRedisKey(longChatRoomId);
-        redisTemplate.opsForSet().remove(offlineUserRedisKey, userId);
+        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().remove(offlineUserKey, userId);
     }
 
     public void offline(String userId, String sessionId) {
         String chatRoomId = getChatRoomIdBySessionId(sessionId);
 
         Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserRedisKey = createRedisKey(longChatRoomId);
-        redisTemplate.opsForSet().add(offlineUserRedisKey, userId);
+        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().add(offlineUserKey, userId);
 
-        String sessionIdAndUserMapping = createRedisKey(sessionId);
-        redisTemplate.delete(sessionIdAndUserMapping);
+        String sessionRoomKey = createSessionRoomKey(sessionId);
+        redisTemplate.delete(sessionRoomKey);
     }
 
     public void addUserToChatRoom(Long chatRoomId, String userId){
         Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserRedisKey = createRedisKey(longChatRoomId);
-        redisTemplate.opsForSet().add(offlineUserRedisKey, userId);
+        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        redisTemplate.opsForSet().add(offlineUserKey, userId);
 
     }
 
-    public void deleteUserToChatRoom(Long chatRoomId, String userName){
+    public void deleteUserFromChatRoom(Long chatRoomId, String userName){
         Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserRedisKey = createRedisKey(longChatRoomId);
+        String offlineUserRedisKey = createOfflineUserRedisKey(longChatRoomId);
         redisTemplate.opsForSet().add(offlineUserRedisKey, userName);
     }
 
     public void clear(Long chatRoomId){
-        String offlineUserRedisKey = createRedisKey(chatRoomId);
+        String offlineUserRedisKey = createOfflineUserRedisKey(chatRoomId);
         redisTemplate.delete(offlineUserRedisKey);
 
     }
 
     public Set<String> findOfflineUserIds(Long chatRoomId){
-        String redisKey = createRedisKey(chatRoomId);
+        String redisKey = createOfflineUserRedisKey(chatRoomId);
         return redisTemplate.opsForSet().members(redisKey);
     }
 
     private String getChatRoomIdBySessionId(String sessionId){
-        String redisKey = createRedisKey(sessionId);
+        String redisKey = createSessionRoomKey(sessionId);
         return redisTemplate.opsForValue().get(redisKey);
     }
 
-    private String createRedisKey(Long chatRoomId){
+    private String createOfflineUserRedisKey(Long chatRoomId){
         return String.format(CHATROOM_OFFLINE_USERS_REDIS_KEY, chatRoomId);
     }
 
-    private String createRedisKey(String sessionId){
+    private String createSessionRoomKey(String sessionId){
         return String.format(CHATROOM_SESSION_ID_REDIS_KEY, sessionId);
     }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
@@ -10,26 +10,24 @@ public class ChatRoomUserCache {
     private final StringRedisTemplate redisTemplate;
 
     private final String CHATROOM_SESSION_ID_REDIS_KEY = "chatroom:sessionId:%s"; // sessionId : chatRoomId
-    private final String CHATROOM_OFFLINE_USERS_REDIS_KEY = "chatroom:%s:offline:users";
+    private final String CHATROOM_OFFLINE_USERS_REDIS_KEY = "chatroom:%d:offline:users";
 
     public ChatRoomUserCache(StringRedisTemplate redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 
-    public void online(String chatRoomId, String userId, String sessionId) {
+    public void online(Long chatRoomId, String userId, String sessionId) {
         String sessionRoomKey = createSessionRoomKey(sessionId);
-        redisTemplate.opsForValue().set(sessionRoomKey, chatRoomId);
+        redisTemplate.opsForValue().set(sessionRoomKey, String.valueOf(chatRoomId));
 
-        Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        String offlineUserKey = createOfflineUserRedisKey(chatRoomId);
         redisTemplate.opsForSet().remove(offlineUserKey, userId);
     }
 
     public void offline(String userId, String sessionId) {
-        String chatRoomId = getChatRoomIdBySessionId(sessionId);
+        Long chatRoomId = getChatRoomIdBySessionId(sessionId);
 
-        Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        String offlineUserKey = createOfflineUserRedisKey(chatRoomId);
         redisTemplate.opsForSet().add(offlineUserKey, userId);
 
         String sessionRoomKey = createSessionRoomKey(sessionId);
@@ -37,22 +35,19 @@ public class ChatRoomUserCache {
     }
 
     public void addUserToChatRoom(Long chatRoomId, String userId){
-        Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        String offlineUserKey = createOfflineUserRedisKey(chatRoomId);
         redisTemplate.opsForSet().add(offlineUserKey, userId);
 
     }
 
     public void deleteUserFromChatRoom(Long chatRoomId, String userId){
-        Long longChatRoomId = Long.valueOf(chatRoomId);
-        String offlineUserKey = createOfflineUserRedisKey(longChatRoomId);
+        String offlineUserKey = createOfflineUserRedisKey(chatRoomId);
         redisTemplate.opsForSet().remove(offlineUserKey, userId);
     }
 
     public void clear(Long chatRoomId){
         String offlineUserRedisKey = createOfflineUserRedisKey(chatRoomId);
         redisTemplate.delete(offlineUserRedisKey);
-
     }
 
     public Set<String> findOfflineUserIds(Long chatRoomId){
@@ -60,9 +55,9 @@ public class ChatRoomUserCache {
         return redisTemplate.opsForSet().members(redisKey);
     }
 
-    private String getChatRoomIdBySessionId(String sessionId){
-        String redisKey = createSessionRoomKey(sessionId);
-        return redisTemplate.opsForValue().get(redisKey);
+    private Long getChatRoomIdBySessionId(String sessionId){
+        String sessionRoomKey = createSessionRoomKey(sessionId);
+        return Long.valueOf(redisTemplate.opsForValue().get(sessionRoomKey));
     }
 
     private String createOfflineUserRedisKey(Long chatRoomId){

--- a/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
+++ b/module-core/src/main/java/com/trybe/modulecore/chat/repository/ChatRoomUserCache.java
@@ -46,13 +46,13 @@ public class ChatRoomUserCache {
     }
 
     public void clear(Long chatRoomId){
-        String offlineUserRedisKey = createOfflineUserRedisKey(chatRoomId);
-        redisTemplate.delete(offlineUserRedisKey);
+        String offlineUserKey = createOfflineUserRedisKey(chatRoomId);
+        redisTemplate.delete(offlineUserKey);
     }
 
     public Set<String> findOfflineUserIds(Long chatRoomId){
-        String redisKey = createOfflineUserRedisKey(chatRoomId);
-        return redisTemplate.opsForSet().members(redisKey);
+        String offlineUserKey = createOfflineUserRedisKey(chatRoomId);
+        return redisTemplate.opsForSet().members(offlineUserKey);
     }
 
     private Long getChatRoomIdBySessionId(String sessionId){

--- a/module-core/src/main/java/com/trybe/modulecore/user/repository/UserRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/user/repository/UserRepository.java
@@ -4,7 +4,9 @@ import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -13,5 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUserId(String userId);
     boolean existsByEmail(String email);
+
+    List<User> findByUserIdIn(Set<String> userNicknames);
 
 }

--- a/module-core/src/main/java/com/trybe/modulecore/user/repository/UserRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/user/repository/UserRepository.java
@@ -16,6 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUserId(String userId);
     boolean existsByEmail(String email);
 
-    List<User> findByUserIdIn(Set<String> userNicknames);
+    List<User> findByUserIdIn(Set<String> userIds);
 
 }

--- a/module-notification/src/main/java/com/trybe/modulenotification/service/NotificationConsumerService.java
+++ b/module-notification/src/main/java/com/trybe/modulenotification/service/NotificationConsumerService.java
@@ -9,12 +9,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class NotificationConsumerService {
     private final EmitterService emitterService;
 
+    private static final String CHAT_NOTIFICATION_TOPIC = "Chat_Notification";
+
     public NotificationConsumerService(EmitterService emitterService) {
         this.emitterService = emitterService;
     }
 
     // TODO: topics 내에 사용할 topic 작성
-    @KafkaListener(topics = {}, groupId = "notification-group")
+    @KafkaListener(topics = {CHAT_NOTIFICATION_TOPIC}, groupId = "notification-group")
     public void listen(NotificationMessage message) {
         SseEmitter emitter = emitterService.getEmitter(message.getUserUuid().toString());
         emitterService.sendToClient(message.getUserUuid().toString(), emitter, message);


### PR DESCRIPTION
- `ChatController` challengeId -> chatRoomId로 수정
- `ChatService` 
- `ChatRoomUserCache` 캐시 저장소 추가
    - 채팅방 알림을 위한 오프라인 유저 저장 기능
- `StompListener` 기능 추가
    - 웹소켓 서버와 연결 / 연결 해제 이벤트 처리 기능 추가
- `ChallengeParticipantionService`에 리더가 참여 요청 수락 시 채팅방에 추가하는 로직 추가
- `ChallengeService`에 챌린지 생성, 삭제 시 채팅방 관련 처리 로직 추가
- 코드 변경에 따른 테스트 코드 수정