### PR TITLE
[#81] 인증 히스토리에 사진 기능 추가

### DIFF
--- a/module-api/http/proof-history.http
+++ b/module-api/http/proof-history.http
@@ -1,33 +1,69 @@
 ### 1. 인증 기록 생성
 POST http://localhost:8080/api/v1/proofs/histories/1
 Authorization: {{accessToken}}
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"
 Content-Type: application/json
 
 {
   "content": "인증 기록 생성 테스트"
 }
+--boundary
+Content-Disposition: form-data; name="files"; filename="image1.png"
+Content-Type: image/png
+
+< ./testImg/image1.png
+--boundary
+Content-Disposition: form-data; name="files"; filename="image2.png"
+Content-Type: image/png
+
+< ./testImg/image2.png
+--boundary--
 
 ### 1-1. 인증 기록 생성 (유효성 검증 실패)
 POST http://localhost:8080/api/v1/proofs/histories/1
 Authorization: {{accessToken}}
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"
 Content-Type: application/json
 
 {
   "content": ""
 }
+--boundary--
 
 ### 2. 인증 기록 목록 조회
-GET http://localhost:8080/api/v1/proofs/histories/1?size=10&page=0
+GET http://localhost:8080/api/v1/proofs/histories/all/1?size=10&page=0
 Authorization: {{accessToken}}
 
 ### 3. 인증 기록 수정
 PUT http://localhost:8080/api/v1/proofs/histories/1
 Authorization: {{accessToken}}
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="request"
 Content-Type: application/json
 
 {
-  "content": "인증 기록 수정 테스트"
+  "content": "인증 기록 수정 테스트",
+  "fileOrder": [null, 1, null]
 }
+--boundary
+Content-Disposition: form-data; name="files"; filename="image3.png"
+Content-Type: image/png
+
+< ./testImg/image3.png
+--boundary
+Content-Disposition: form-data; name="files"; filename="image4.png"
+Content-Type: image/png
+
+< ./testImg/image4.png
+--boundary--
 
 ### 3-1. 인증 기록 수정 (유효성 검증 실패)
 PUT http://localhost:8080/api/v1/proofs/histories/1

--- a/module-api/src/docs/asciidoc/index.adoc
+++ b/module-api/src/docs/asciidoc/index.adoc
@@ -765,7 +765,10 @@ include::{snippets}/proof-controller-test/delete/invalid/bad-request/response-fi
 ==== 정상 요청
 include::{snippets}/proof-history-controller-test/save/http-request.adoc[]
 include::{snippets}/proof-history-controller-test/save/path-parameters.adoc[]
-include::{snippets}/proof-history-controller-test/save/request-fields.adoc[]
+include::{snippets}/proof-history-controller-test/save/request-parts.adoc[]
+
+- JSON fields
+include::{snippets}/proof-history-controller-test/save/request-part-request-fields.adoc[]
 
 - 응답
 include::{snippets}/proof-history-controller-test/save/http-response.adoc[]
@@ -833,7 +836,10 @@ include::{snippets}/proof-history-controller-test/findAll/invalid/forbidden/resp
 ==== 정상 요청
 include::{snippets}/proof-history-controller-test/update/http-request.adoc[]
 include::{snippets}/proof-history-controller-test/update/path-parameters.adoc[]
-include::{snippets}/proof-history-controller-test/update/request-fields.adoc[]
+include::{snippets}/proof-history-controller-test/update/request-parts.adoc[]
+
+- JSON fields
+include::{snippets}/proof-history-controller-test/update/request-part-request-fields.adoc[]
 
 - 응답
 include::{snippets}/proof-history-controller-test/update/http-response.adoc[]

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -60,7 +60,7 @@ public class ChallengeService {
     private static final int RECOMMEND_CHALLENGE_COUNT = 20;
     private static final int POPULAR_CHALLENGE_COUNT = 20;
 
-    private static final String CHALLENGE_THUMBNAIL_BASE_PATH = "/challenge/%d/thumbnail/";
+    private static final String CHALLENGE_THUMBNAIL_BASE_PATH = "/challenge/%d/thumbnail";
 
     @Transactional
     public ChallengeResponse.Detail save(User user, MultipartFile thumbnail, ChallengeRequest.Create request) {

--- a/module-api/src/main/java/com/trybe/moduleapi/file/dto/FileWithIdResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/file/dto/FileWithIdResponse.java
@@ -7,7 +7,7 @@ public record FileWithIdResponse (
         String originalName,
         String filePath
 ) {
-    public static FileWithIdResponse from(File file, String path) {
-        return new FileWithIdResponse(file.getId(), file.getOriginalName(), path);
+    public static FileWithIdResponse from(Long id, File file, String path) {
+        return new FileWithIdResponse(id, file.getOriginalName(), path);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/file/dto/FileWithIdResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/file/dto/FileWithIdResponse.java
@@ -1,0 +1,13 @@
+package com.trybe.moduleapi.file.dto;
+
+import com.trybe.modulecore.file.entity.File;
+
+public record FileWithIdResponse (
+        Long id,
+        String originalName,
+        String filePath
+) {
+    public static FileWithIdResponse from(File file, String path) {
+        return new FileWithIdResponse(file.getId(), file.getOriginalName(), path);
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
@@ -26,7 +26,7 @@ public class ProofHistoryController {
     public ProofHistoryResponse.Summary save(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("proofId") Long proofId,
-            @RequestPart("files") List<MultipartFile> files,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files,
             @RequestPart("request") @Valid ProofHistoryRequest.Create request
     ) {
         return proofHistoryService.save(userDetails.getUser(),proofId, files, request);
@@ -45,7 +45,7 @@ public class ProofHistoryController {
     public ProofHistoryResponse.Summary update(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("proofHistoryId") Long proofHistoryId,
-            @RequestPart("files") List<MultipartFile> files,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files,
             @RequestPart("request") @Valid ProofHistoryRequest.Update request
     ) {
         return proofHistoryService.update(userDetails.getUser(), proofHistoryId, files, request);

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/controller/ProofHistoryController.java
@@ -9,6 +9,9 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/proofs/histories")
@@ -23,9 +26,10 @@ public class ProofHistoryController {
     public ProofHistoryResponse.Summary save(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("proofId") Long proofId,
-            @Valid @RequestBody ProofHistoryRequest.Create request
+            @RequestPart("files") List<MultipartFile> files,
+            @RequestPart("request") @Valid ProofHistoryRequest.Create request
     ) {
-        return proofHistoryService.save(userDetails.getUser(),proofId, request);
+        return proofHistoryService.save(userDetails.getUser(),proofId, files, request);
     }
 
     @GetMapping("/all/{proofId}")
@@ -41,9 +45,10 @@ public class ProofHistoryController {
     public ProofHistoryResponse.Summary update(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("proofHistoryId") Long proofHistoryId,
-            @Valid @RequestBody ProofHistoryRequest.Update request
+            @RequestPart("files") List<MultipartFile> files,
+            @RequestPart("request") @Valid ProofHistoryRequest.Update request
     ) {
-        return proofHistoryService.update(userDetails.getUser(), proofHistoryId, request);
+        return proofHistoryService.update(userDetails.getUser(), proofHistoryId, files, request);
     }
 
     @DeleteMapping("/{proofHistoryId}")

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
@@ -6,6 +6,8 @@ import com.trybe.modulecore.user.entity.User;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public class ProofHistoryRequest {
     private static final String CONTENT_NOT_BLANK_MESSAGE = "인증 내용을 입력해주세요.";
     private static final String CONTENT_MAX_LENGTH_MESSAGE = "인증 내용은 최대 1,000자까지 입력 가능합니다.";
@@ -13,7 +15,8 @@ public class ProofHistoryRequest {
     public record Create(
             @NotBlank(message = CONTENT_NOT_BLANK_MESSAGE)
             @Size(max = 1000, message = CONTENT_MAX_LENGTH_MESSAGE)
-            String content
+            String content,
+            List<Integer> fileOrder
     ) {
         public ProofHistory toEntity(Proof proof, User user, String content) {
             return new ProofHistory(proof, user, content);
@@ -23,6 +26,7 @@ public class ProofHistoryRequest {
     public record Update(
             @NotBlank(message = CONTENT_NOT_BLANK_MESSAGE)
             @Size(max = 1000, message = CONTENT_MAX_LENGTH_MESSAGE)
-            String content
+            String content,
+            List<Integer> fileOrder
     ) {}
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
@@ -15,8 +15,7 @@ public class ProofHistoryRequest {
     public record Create(
             @NotBlank(message = CONTENT_NOT_BLANK_MESSAGE)
             @Size(max = 1000, message = CONTENT_MAX_LENGTH_MESSAGE)
-            String content,
-            List<Integer> fileOrder
+            String content
     ) {
         public ProofHistory toEntity(Proof proof, User user, String content) {
             return new ProofHistory(proof, user, content);

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/request/ProofHistoryRequest.java
@@ -26,6 +26,6 @@ public class ProofHistoryRequest {
             @NotBlank(message = CONTENT_NOT_BLANK_MESSAGE)
             @Size(max = 1000, message = CONTENT_MAX_LENGTH_MESSAGE)
             String content,
-            List<Integer> fileOrder
+            List<Long> fileOrder
     ) {}
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryResponse.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/dto/response/ProofHistoryResponse.java
@@ -1,21 +1,28 @@
 package com.trybe.moduleapi.proof.dto.response;
 
+import com.trybe.moduleapi.file.dto.FileWithIdResponse;
+import com.trybe.moduleapi.user.dto.response.UserResponse;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ProofHistoryResponse {
     public record Summary(
             Long id,
+            UserResponse.Summary writer,
             String content,
+            List<FileWithIdResponse> files,
             ProofHistoryStatus status,
             LocalDateTime createdAt
     ) {
-        public static Summary from(ProofHistory proofHistory) {
+        public static Summary from(ProofHistory proofHistory, List<FileWithIdResponse> files) {
             return new Summary(
                     proofHistory.getId(),
+                    UserResponse.Summary.from(proofHistory.getUser()),
                     proofHistory.getContent(),
+                    files,
                     proofHistory.getStatus(),
                     proofHistory.getCreatedAt()
             );
@@ -25,15 +32,19 @@ public class ProofHistoryResponse {
     public record Detail(
             ProofResponse.Summary proof,
             Long id,
+            UserResponse.Summary writer,
             String content,
+            List<FileWithIdResponse> files,
             ProofHistoryStatus status,
             LocalDateTime createdAt
     ) {
-        public static Detail from(ProofHistory proofHistory) {
+        public static Detail from(ProofHistory proofHistory, List<FileWithIdResponse> files) {
             return new Detail(
                     ProofResponse.Summary.from(proofHistory.getProof()),
                     proofHistory.getId(),
+                    UserResponse.Summary.from(proofHistory.getUser()),
                     proofHistory.getContent(),
+                    files,
                     proofHistory.getStatus(),
                     proofHistory.getCreatedAt()
             );

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -18,6 +18,7 @@ import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import com.trybe.modulecore.proof.entity.ProofHistoryFile;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
+import com.trybe.modulecore.proof.repository.ProofHistoryFileRepository;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
 import com.trybe.modulecore.proof.repository.ProofRepository;
 import com.trybe.modulecore.user.entity.User;
@@ -34,18 +35,20 @@ import java.util.stream.Collectors;
 @Service
 public class ProofHistoryService {
     private final ProofHistoryRepository proofHistoryRepository;
+    private final ProofHistoryFileRepository proofHistoryFileRepository;
     private final ProofRepository proofRepository;
     private final ChallengeParticipationRepository challengeParticipationRepository;
     private final FileManager fileManager;
 
-    public ProofHistoryService(ProofHistoryRepository proofHistoryRepository, ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository, FileManager fileManager) {
+    public ProofHistoryService(ProofHistoryRepository proofHistoryRepository, ProofHistoryFileRepository proofHistoryFileRepository, ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository, FileManager fileManager) {
         this.proofHistoryRepository = proofHistoryRepository;
+        this.proofHistoryFileRepository = proofHistoryFileRepository;
         this.proofRepository = proofRepository;
         this.challengeParticipationRepository = challengeParticipationRepository;
         this.fileManager = fileManager;
     }
 
-    private static final String FILE_BASE_PATH_FORMAT = "/challenge/%d/proofhistory/%d/";
+    private static final String FILE_BASE_PATH_FORMAT = "/challenge/%d/proofhistory/%d";
 
     @Transactional
     public ProofHistoryResponse.Summary save(User user, Long proofId, List<MultipartFile> files, ProofHistoryRequest.Create request) {
@@ -57,10 +60,9 @@ public class ProofHistoryService {
         validateDuplicateProofHistory(proof.getId(), user.getId());
 
         ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
+        List<ProofHistoryFile> savedFiles = saveFiles(savedProofHistory, files);
 
-        List<ProofHistoryFile> proofHistoryFiles = saveFiles(savedProofHistory, files);
-
-        return ProofHistoryResponse.Summary.from(savedProofHistory, toFileResponses(proofHistoryFiles));
+        return ProofHistoryResponse.Summary.from(savedProofHistory, toFileResponses(savedFiles));
     }
 
     @Transactional(readOnly = true)
@@ -72,7 +74,7 @@ public class ProofHistoryService {
         Page<ProofHistory> proofHistories = proofHistoryRepository.findAllByProofId(proofId, pageable);
 
         Page<ProofHistoryResponse.Summary> responses = proofHistories.map(proofHistory -> {
-            List<ProofHistoryFile> files = proofHistory.getFiles();
+            List<ProofHistoryFile> files = getFiles(proofHistory.getId());
             List<FileWithIdResponse> fileResponses = toFileResponses(files);
             return ProofHistoryResponse.Summary.from(proofHistory, fileResponses);
         });
@@ -88,10 +90,9 @@ public class ProofHistoryService {
         validateProofHistoryStatus(proofHistory, ProofHistoryStatus.PENDING, "이미 처리된 인증 기록은 수정할 수 없습니다.");
 
         proofHistory.updateContent(request.content());
+        List<ProofHistoryFile> savedFiles = updateFiles(proofHistory, request.fileOrder(), files);
 
-        updateFiles(proofHistory, request.fileOrder(), files);
-
-        return ProofHistoryResponse.Summary.from(proofHistory, toFileResponses(proofHistory.getFiles()));
+        return ProofHistoryResponse.Summary.from(proofHistory, toFileResponses(savedFiles));
     }
 
     @Transactional
@@ -118,6 +119,10 @@ public class ProofHistoryService {
         Long proofHistoryId = proofHistory.getId();
 
         return String.format(FILE_BASE_PATH_FORMAT, challengeId, proofHistoryId);
+    }
+
+    private List<ProofHistoryFile> getFiles(Long proofHistoryId) {
+        return proofHistoryFileRepository.findAllByProofHistoryIdOrderByFileOrder(proofHistoryId);
     }
 
     private void validateMemberParticipation(Long userId, Long challengeId, String message) {
@@ -152,36 +157,38 @@ public class ProofHistoryService {
 
     private List<ProofHistoryFile> saveFiles(ProofHistory proofHistory, List<MultipartFile> files) {
         List<File> uploadedFiles = fileManager.uploadFiles(files, getBasePath(proofHistory));
+        List<ProofHistoryFile> fileEntities = new ArrayList<>();
 
-        List<ProofHistoryFile> proofHistoryFiles = new ArrayList<>();
         int order = 1;
 
         for (File file : uploadedFiles) {
-            ProofHistoryFile proofHistoryFile = new ProofHistoryFile(proofHistory, file, order++);
-            proofHistory.addFile(proofHistoryFile);
-            proofHistoryFiles.add(proofHistoryFile);
+            fileEntities.add(new ProofHistoryFile(proofHistory, file, order++));
         }
 
-        return proofHistoryFiles;
+        return proofHistoryFileRepository.saveAll(fileEntities);
     }
 
-    private void updateFiles(ProofHistory proofHistory, List<Long> fileOrder, List<MultipartFile> newFiles) {
-        Map<Long, ProofHistoryFile> existingFile = proofHistory.getFiles().stream()
+    private List<ProofHistoryFile> updateFiles(ProofHistory proofHistory, List<Long> fileOrder, List<MultipartFile> newFiles) {
+        List<ProofHistoryFile> files = getFiles(proofHistory.getId());
+        Map<Long, ProofHistoryFile> existingFile = files.stream()
                 .collect(Collectors.toMap(ProofHistoryFile::getId, file -> file));
 
         Set<Long> remainingIds = fileOrder.stream()
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        for (ProofHistoryFile file : new ArrayList<>(proofHistory.getFiles())) {
-            if (!remainingIds.contains(file.getId())) {
-                proofHistory.removeFile(file);
+        for (ProofHistoryFile proofHistoryFile: new ArrayList<>(files)) {
+            if (!remainingIds.contains(proofHistoryFile.getId())) {
+                File file = proofHistoryFile.getFile();
+                proofHistoryFileRepository.delete(proofHistoryFile);
+                fileManager.deleteFile(file);
             }
         }
 
         List<File> uploadedFiles = fileManager.uploadFiles(newFiles, getBasePath(proofHistory));
         Iterator<File> iterator = uploadedFiles.iterator();
 
+        List<ProofHistoryFile> fileEntities = new ArrayList<>();
         int order = 1;
 
         for (Long fileId : fileOrder) {
@@ -190,20 +197,24 @@ public class ProofHistoryService {
                 if (file != null && file.getFileOrder() != order) {
                     file.updateFileOrder(order++);
                 }
+                fileEntities.add(file);
             } else {
                 if (iterator.hasNext()) {
                     File file = iterator.next();
-                    proofHistory.addFile(new ProofHistoryFile(proofHistory, file, order++));
+                    ProofHistoryFile proofHistoryFile =proofHistoryFileRepository.save(new ProofHistoryFile(proofHistory, file, order++));
+                    fileEntities.add(proofHistoryFile);
                 }
             }
         }
+
+        return fileEntities;
     }
 
     private List<FileWithIdResponse> toFileResponses(List<ProofHistoryFile> files) {
         return files.stream()
                 .map(proofHistoryFile -> {
                     File file = proofHistoryFile.getFile();
-                    return FileWithIdResponse.from(file, fileManager.getFileUrl(file.getFilePath()));
+                    return FileWithIdResponse.from(proofHistoryFile.getId(), file, fileManager.getFileUrl(file.getFilePath()));
                 })
                 .toList();
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -101,6 +101,7 @@ public class ProofHistoryService {
 
         validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 삭제할 수 있습니다.");
 
+        deleteFiles(getFiles(proofHistory.getId()));
         proofHistoryRepository.delete(proofHistory);
     }
 
@@ -212,6 +213,12 @@ public class ProofHistoryService {
         File file = proofHistoryFile.getFile();
         proofHistoryFileRepository.delete(proofHistoryFile);
         fileManager.deleteFile(file);
+    }
+
+    private void deleteFiles(List<ProofHistoryFile> files) {
+        for (ProofHistoryFile proofHistoryFile : files) {
+            deleteFile(proofHistoryFile);
+        }
     }
 
     private List<FileWithIdResponse> toFileResponses(List<ProofHistoryFile> files) {

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -179,9 +179,7 @@ public class ProofHistoryService {
 
         for (ProofHistoryFile proofHistoryFile: new ArrayList<>(files)) {
             if (!remainingIds.contains(proofHistoryFile.getId())) {
-                File file = proofHistoryFile.getFile();
-                proofHistoryFileRepository.delete(proofHistoryFile);
-                fileManager.deleteFile(file);
+                deleteFile(proofHistoryFile);
             }
         }
 
@@ -208,6 +206,12 @@ public class ProofHistoryService {
         }
 
         return fileEntities;
+    }
+
+    private void deleteFile(ProofHistoryFile proofHistoryFile) {
+        File file = proofHistoryFile.getFile();
+        proofHistoryFileRepository.delete(proofHistoryFile);
+        fileManager.deleteFile(file);
     }
 
     private List<FileWithIdResponse> toFileResponses(List<ProofHistoryFile> files) {

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -201,7 +201,7 @@ public class ProofHistoryService {
             } else {
                 if (iterator.hasNext()) {
                     File file = iterator.next();
-                    ProofHistoryFile proofHistoryFile =proofHistoryFileRepository.save(new ProofHistoryFile(proofHistory, file, order++));
+                    ProofHistoryFile proofHistoryFile = proofHistoryFileRepository.save(new ProofHistoryFile(proofHistory, file, order++));
                     fileEntities.add(proofHistoryFile);
                 }
             }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -2,6 +2,8 @@ package com.trybe.moduleapi.proof.service;
 
 import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.dto.FileWithIdResponse;
+import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
 import com.trybe.moduleapi.proof.exception.*;
@@ -11,8 +13,10 @@ import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusExce
 import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.file.entity.File;
 import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.entity.ProofHistoryFile;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
 import com.trybe.modulecore.proof.repository.ProofRepository;
@@ -21,31 +25,42 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class ProofHistoryService {
     private final ProofHistoryRepository proofHistoryRepository;
     private final ProofRepository proofRepository;
     private final ChallengeParticipationRepository challengeParticipationRepository;
+    private final FileManager fileManager;
 
-    public ProofHistoryService(ProofHistoryRepository proofHistoryRepository, ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository) {
+    public ProofHistoryService(ProofHistoryRepository proofHistoryRepository, ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository, FileManager fileManager) {
         this.proofHistoryRepository = proofHistoryRepository;
         this.proofRepository = proofRepository;
         this.challengeParticipationRepository = challengeParticipationRepository;
+        this.fileManager = fileManager;
     }
 
-    @Transactional
-    public ProofHistoryResponse.Summary save(User user, Long proofId, ProofHistoryRequest.Create request) {
-        Proof proof = getProof(proofId);
+    private static final String FILE_BASE_PATH_FORMAT = "/challenge/%d/proofhistory/%d/";
 
-        validateMemberParticipation(user.getId(), proof.getChallenge().getId(), "멤버만 인증 기록을 등록할 수 있습니다.");
+    @Transactional
+    public ProofHistoryResponse.Summary save(User user, Long proofId, List<MultipartFile> files, ProofHistoryRequest.Create request) {
+        Proof proof = getProof(proofId);
+        Long challengeId = proof.getChallenge().getId();
+
+        validateMemberParticipation(user.getId(), challengeId, "멤버만 인증 기록을 등록할 수 있습니다.");
         validateDate(proof);
         validateDuplicateProofHistory(proof.getId(), user.getId());
 
         ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
-        return ProofHistoryResponse.Summary.from(savedProofHistory);
+
+        List<ProofHistoryFile> proofHistoryFiles = saveFiles(savedProofHistory, files);
+
+        return ProofHistoryResponse.Summary.from(savedProofHistory, toFileResponses(proofHistoryFiles));
     }
 
     @Transactional(readOnly = true)
@@ -55,11 +70,18 @@ public class ProofHistoryService {
         validateMemberParticipation(user.getId(), proof.getChallenge().getId(), "멤버만 인증 기록을 조회할 수 있습니다.");
 
         Page<ProofHistory> proofHistories = proofHistoryRepository.findAllByProofId(proofId, pageable);
-        return new PageResponse<>(proofHistories.map(ProofHistoryResponse.Summary::from));
+
+        Page<ProofHistoryResponse.Summary> responses = proofHistories.map(proofHistory -> {
+            List<ProofHistoryFile> files = proofHistory.getFiles();
+            List<FileWithIdResponse> fileResponses = toFileResponses(files);
+            return ProofHistoryResponse.Summary.from(proofHistory, fileResponses);
+        });
+
+        return new PageResponse<>(responses);
     }
 
     @Transactional
-    public ProofHistoryResponse.Summary update(User user, Long proofHistoryId, ProofHistoryRequest.Update request) {
+    public ProofHistoryResponse.Summary update(User user, Long proofHistoryId, List<MultipartFile> files, ProofHistoryRequest.Update request) {
         ProofHistory proofHistory = getProofHistory(proofHistoryId);
 
         validateProofHistoryOwner(user, true, proofHistory, "인증 기록의 작성자만 수정할 수 있습니다.");
@@ -67,7 +89,9 @@ public class ProofHistoryService {
 
         proofHistory.updateContent(request.content());
 
-        return ProofHistoryResponse.Summary.from(proofHistory);
+        updateFiles(proofHistory, request.fileOrder(), files);
+
+        return ProofHistoryResponse.Summary.from(proofHistory, toFileResponses(proofHistory.getFiles()));
     }
 
     @Transactional
@@ -87,6 +111,13 @@ public class ProofHistoryService {
     private ProofHistory getProofHistory(Long proofHistoryId) {
         return proofHistoryRepository.findById(proofHistoryId)
                 .orElseThrow(NotFoundProofHistoryException::new);
+    }
+
+    private String getBasePath(ProofHistory proofHistory) {
+        Long challengeId = proofHistory.getProof().getChallenge().getId();
+        Long proofHistoryId = proofHistory.getId();
+
+        return String.format(FILE_BASE_PATH_FORMAT, challengeId, proofHistoryId);
     }
 
     private void validateMemberParticipation(Long userId, Long challengeId, String message) {
@@ -117,5 +148,63 @@ public class ProofHistoryService {
         if (proofHistoryRepository.existsByProofIdAndUserId(proofId, userId)) {
             throw new DuplicatedProofHistoryException();
         }
+    }
+
+    private List<ProofHistoryFile> saveFiles(ProofHistory proofHistory, List<MultipartFile> files) {
+        List<File> uploadedFiles = fileManager.uploadFiles(files, getBasePath(proofHistory));
+
+        List<ProofHistoryFile> proofHistoryFiles = new ArrayList<>();
+        int order = 1;
+
+        for (File file : uploadedFiles) {
+            ProofHistoryFile proofHistoryFile = new ProofHistoryFile(proofHistory, file, order++);
+            proofHistory.addFile(proofHistoryFile);
+            proofHistoryFiles.add(proofHistoryFile);
+        }
+
+        return proofHistoryFiles;
+    }
+
+    private void updateFiles(ProofHistory proofHistory, List<Long> fileOrder, List<MultipartFile> newFiles) {
+        Map<Long, ProofHistoryFile> existingFile = proofHistory.getFiles().stream()
+                .collect(Collectors.toMap(ProofHistoryFile::getId, file -> file));
+
+        Set<Long> remainingIds = fileOrder.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        for (ProofHistoryFile file : new ArrayList<>(proofHistory.getFiles())) {
+            if (!remainingIds.contains(file.getId())) {
+                proofHistory.removeFile(file);
+            }
+        }
+
+        List<File> uploadedFiles = fileManager.uploadFiles(newFiles, getBasePath(proofHistory));
+        Iterator<File> iterator = uploadedFiles.iterator();
+
+        int order = 1;
+
+        for (Long fileId : fileOrder) {
+            if (fileId != null) {
+                ProofHistoryFile file = existingFile.get(fileId);
+                if (file != null && file.getFileOrder() != order) {
+                    file.updateFileOrder(order++);
+                }
+            } else {
+                if (iterator.hasNext()) {
+                    File file = iterator.next();
+                    proofHistory.addFile(new ProofHistoryFile(proofHistory, file, order++));
+                }
+            }
+        }
+    }
+
+    private List<FileWithIdResponse> toFileResponses(List<ProofHistoryFile> files) {
+        return files.stream()
+                .map(proofHistoryFile -> {
+                    File file = proofHistoryFile.getFile();
+                    return FileWithIdResponse.from(file, fileManager.getFileUrl(file.getFilePath()));
+                })
+                .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -170,7 +170,7 @@ public class ProofHistoryService {
 
     private List<ProofHistoryFile> updateFiles(ProofHistory proofHistory, List<Long> fileOrder, List<MultipartFile> newFiles) {
         List<ProofHistoryFile> files = getFiles(proofHistory.getId());
-        Map<Long, ProofHistoryFile> existingFile = files.stream()
+        Map<Long, ProofHistoryFile> existingFiles = files.stream()
                 .collect(Collectors.toMap(ProofHistoryFile::getId, file -> file));
 
         Set<Long> remainingIds = fileOrder.stream()
@@ -193,7 +193,7 @@ public class ProofHistoryService {
 
         for (Long fileId : fileOrder) {
             if (fileId != null) {
-                ProofHistoryFile file = existingFile.get(fileId);
+                ProofHistoryFile file = existingFiles.get(fileId);
                 if (file != null && file.getFileOrder() != order) {
                     file.updateFileOrder(order++);
                 }

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/controller/ChallengeControllerTest.java
@@ -1,6 +1,5 @@
 package com.trybe.moduleapi.challenge.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.trybe.moduleapi.annotation.WithCustomMockUser;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
@@ -39,15 +38,6 @@ class ChallengeControllerTest extends ControllerTest {
     private String endpoint = "/api/v1/challenges";
 
     private String docsPath = "challenge-controller-test/";
-
-    private MockMultipartFile createJsonRequestPart(Object request) throws JsonProcessingException {
-        return new MockMultipartFile(
-                "request",
-                null,
-                "application/json",
-                objectMapper.writeValueAsBytes(request)
-        );
-    }
 
     @Test
     @WithCustomMockUser

--- a/module-api/src/test/java/com/trybe/moduleapi/common/ControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/common/ControllerTest.java
@@ -1,5 +1,6 @@
 package com.trybe.moduleapi.common;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trybe.moduleapi.auth.CustomUserDetailsService;
 import com.trybe.moduleapi.auth.jwt.JwtUtils;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -39,4 +41,13 @@ public abstract class ControllerTest {
     protected final String invalidNotFoundPath = "/invalid/not-found/";
     protected final String invalidForbiddenPath = "/invalid/forbidden/";
     protected final String invalidConflictPath = "/invalid/conflict/";
+
+    protected MockMultipartFile createJsonRequestPart(Object request) throws JsonProcessingException {
+        return new MockMultipartFile(
+                "request",
+                null,
+                "application/json",
+                objectMapper.writeValueAsBytes(request)
+        );
+    }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
@@ -20,6 +20,8 @@ public class FileFixtures {
     public static final String 파일_저장소_경로 = "http://trybe.test/file";
     public static final String 파일_전체_경로 = 파일_저장소_경로 + 파일_경로;
 
+    public static final int 파일_순서 = 1;
+
     /* Request */
     public static MockMultipartFile 파일_요청_생성(String parameterName) {
         return new MockMultipartFile(

--- a/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
@@ -1,9 +1,12 @@
 package com.trybe.moduleapi.file.fixtures;
 
 import com.trybe.moduleapi.file.dto.FileResponse;
+import com.trybe.moduleapi.file.dto.FileWithIdResponse;
+import com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures;
 import com.trybe.modulecore.file.entity.File;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 public class FileFixtures {
@@ -38,4 +41,6 @@ public class FileFixtures {
 
     /* Response DTO */
     public static final FileResponse 파일_응답 = new FileResponse(파일_원본_이름, 파일_전체_경로);
+    public static final FileWithIdResponse 아이디_포함_파일_응답 = FileWithIdResponse.from(ProofHistoryFixtures.인증_기록_ID, 파일, 파일_전체_경로);
+    public static final List<FileWithIdResponse> 아이디_포함_파일_목록_응답 = List.of(아이디_포함_파일_응답);
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/file/fixtures/FileFixtures.java
@@ -2,7 +2,6 @@ package com.trybe.moduleapi.file.fixtures;
 
 import com.trybe.moduleapi.file.dto.FileResponse;
 import com.trybe.moduleapi.file.dto.FileWithIdResponse;
-import com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures;
 import com.trybe.modulecore.file.entity.File;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -11,6 +10,7 @@ import java.util.UUID;
 
 public class FileFixtures {
     public static final Long 파일_ID = 1L;
+    public static final Long 연관_파일_ID = 1L;
     public static final String 파일_원본_이름 = "originalName.jpeg";
     public static final String 파일_저장_이름 = UUID.randomUUID().toString() + "-" + 파일_원본_이름;
     public static final String 파일_경로 = "/filePath/" + 파일_저장_이름;
@@ -43,6 +43,6 @@ public class FileFixtures {
 
     /* Response DTO */
     public static final FileResponse 파일_응답 = new FileResponse(파일_원본_이름, 파일_전체_경로);
-    public static final FileWithIdResponse 아이디_포함_파일_응답 = FileWithIdResponse.from(ProofHistoryFixtures.인증_기록_ID, 파일, 파일_전체_경로);
+    public static final FileWithIdResponse 아이디_포함_파일_응답 = new FileWithIdResponse(연관_파일_ID, 파일_원본_이름, 파일_전체_경로);
     public static final List<FileWithIdResponse> 아이디_포함_파일_목록_응답 = List.of(아이디_포함_파일_응답);
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
@@ -4,6 +4,7 @@ import com.trybe.moduleapi.annotation.WithCustomMockUser;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
 import com.trybe.moduleapi.common.ControllerTest;
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.fixtures.FileFixtures;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
 import com.trybe.moduleapi.proof.exception.InvalidProofDateException;
@@ -14,17 +15,20 @@ import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusExce
 import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
 import com.trybe.moduleapi.proof.fixtures.ProofFixtures;
 import com.trybe.moduleapi.proof.service.ProofHistoryService;
+import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 import static com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures.*;
@@ -32,6 +36,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -43,10 +48,6 @@ public class ProofHistoryControllerTest extends ControllerTest {
     private final String endpoint = "/api/v1/proofs/histories";
 
     private final String docsPath = "proof-history-controller-test/";
-    private final String invalidBadRequestPath = "/invalid/bad-request/";
-    private final String invalidNotFoundPath = "/invalid/not-found/";
-    private final String invalidConflictPath = "/invalid/conflict/";
-    private final String invalidForbiddenPath = "/invalid/forbidden/";
 
     @Test
     @WithCustomMockUser
@@ -56,19 +57,30 @@ public class ProofHistoryControllerTest extends ControllerTest {
         Long proofId = ProofFixtures.인증_ID;
         ProofHistoryRequest.Create request = 인증_기록_생성_요청;
 
-        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+        MockMultipartFile file = FileFixtures.파일_요청_생성("files");
+
+        when(proofHistoryService.save(any(User.class), eq(proofId), eq(List.of(file)), eq(request)))
                 .thenReturn(대기_인증_기록_요약_응답);
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofId}", proofId)
+                        .file(jsonPart)
+                        .file(file)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isOk(),
                 jsonPath("$.id").value(대기_인증_기록_요약_응답.id()),
+                jsonPath("$.writer.id").value(UserFixtures.회원_PK),
+                jsonPath("$.writer.userId").value(UserFixtures.회원_아이디),
+                jsonPath("$.writer.nickname").value(UserFixtures.회원_닉네임),
                 jsonPath("$.content").value(대기_인증_기록_요약_응답.content()),
+                jsonPath("$.files").isArray(),
                 jsonPath("$.status").value(대기_인증_기록_요약_응답.status().toString()),
                 jsonPath("$.createdAt").value(대기_인증_기록_요약_응답.createdAt().toString())
         );
@@ -79,18 +91,30 @@ public class ProofHistoryControllerTest extends ControllerTest {
                 pathParameters(
                         parameterWithName("proofId").description("인증 ID")
                 ),
-                requestFields(
+                requestParts(
+                        partWithName("request").description("인증 기록 생성 요청 데이터 (JSON)"),
+                        partWithName("files").description("인증 기록 첨부파일 (선택)")
+                ),
+                requestPartFields("request",
                         fieldWithPath("content").description("인증 기록 내용 (최대 1,000자)")
                 ),
                 responseFields(
                         fieldWithPath("id").description("인증 기록 ID"),
+                        fieldWithPath("writer").description("인증 기록 작성자"),
+                        fieldWithPath("writer.id").description("작성자 PK"),
+                        fieldWithPath("writer.userId").description("작성자 아이디"),
+                        fieldWithPath("writer.nickname").description("작성자 닉네임"),
                         fieldWithPath("content").description("인증 기록 내용"),
+                        fieldWithPath("files").description("인증 기록 첨부파일 목록"),
+                        fieldWithPath("files.id").description("인증 기록 파일 PK"),
+                        fieldWithPath("files.originalName").description("첨부파일 원본 이름"),
+                        fieldWithPath("files.filePath").description("첨부파일 경로"),
                         fieldWithPath("status").description("인증 기록 상태"),
                         fieldWithPath("createdAt").description("인증 기록 생성 시간")
                 )
         ));
     }
-    
+
     @Test
     @WithCustomMockUser
     @DisplayName("비정상적인 인증 기록 생성 요청 시 응답코드 400을 반환한다.")
@@ -98,13 +122,18 @@ public class ProofHistoryControllerTest extends ControllerTest {
         /* given */
         Long proofId = ProofFixtures.인증_ID;
         ProofHistoryRequest.Create request = 잘못된_인증_기록_생성_요청;
-        
+
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
-        
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofId}", proofId)
+                        .file(jsonPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
+
         result.andExpectAll(
                 status().isBadRequest(),
                 jsonPath("$.status").value(400),
@@ -129,16 +158,21 @@ public class ProofHistoryControllerTest extends ControllerTest {
         /* given */
         Long proofId = ProofFixtures.인증_ID;
         ProofHistoryRequest.Create request = 인증_기록_생성_요청;
-        
-        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        when(proofHistoryService.save(any(User.class), eq(proofId), any(), eq(request)))
                 .thenThrow(new NotFoundProofException());
         
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
-        
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofId}", proofId)
+                        .file(jsonPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
+
         result.andExpectAll(
                 status().isNotFound(),
                 jsonPath("$.status").value(404),
@@ -163,16 +197,21 @@ public class ProofHistoryControllerTest extends ControllerTest {
         /* given */
         Long proofId = ProofFixtures.인증_ID;
         ProofHistoryRequest.Create request = 인증_기록_생성_요청;
-        
-        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        when(proofHistoryService.save(any(User.class), eq(proofId), any(), eq(request)))
                 .thenThrow(new InvalidParticipationStatusActionException("멤버만 인증 기록을 등록할 수 있습니다."));
         
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
-        
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofId}", proofId)
+                        .file(jsonPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
+
         result.andExpectAll(
                 status().isForbidden(),
                 jsonPath("$.status").value(403),
@@ -197,16 +236,21 @@ public class ProofHistoryControllerTest extends ControllerTest {
         /* given */
         Long proofId = ProofFixtures.인증_ID;
         ProofHistoryRequest.Create request = 인증_기록_생성_요청;
-        
-        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        when(proofHistoryService.save(any(User.class), eq(proofId), any(), eq(request)))
                 .thenThrow(new InvalidProofDateException());
         
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
-        
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofId}", proofId)
+                        .file(jsonPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
+
         result.andExpectAll(
                 status().isBadRequest(),
                 jsonPath("$.status").value(400),
@@ -231,16 +275,21 @@ public class ProofHistoryControllerTest extends ControllerTest {
         /* given */
         Long proofId = ProofFixtures.인증_ID;
         ProofHistoryRequest.Create request = 인증_기록_생성_요청;
-        
-        when(proofHistoryService.save(any(User.class), eq(proofId), eq(request)))
+
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        when(proofHistoryService.save(any(User.class), eq(proofId), any(), eq(request)))
                 .thenThrow(new DuplicatedProofHistoryException());
         
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(endpoint + "/{proofId}", proofId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
-        
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofId}", proofId)
+                        .file(jsonPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
+
         result.andExpectAll(
                 status().isConflict(),
                 jsonPath("$.status").value(409),
@@ -297,7 +346,15 @@ public class ProofHistoryControllerTest extends ControllerTest {
                 responseFields(
                         fieldWithPath("content").description("인증 기록 요약 목록"),
                         fieldWithPath("content[].id").description("인증 기록 ID"),
+                        fieldWithPath("content[].writer").description("인증 기록 작성자"),
+                        fieldWithPath("content[].writer.id").description("작성자 PK"),
+                        fieldWithPath("content[].writer.userId").description("작성자 아이디"),
+                        fieldWithPath("content[].writer.nickname").description("작성자 닉네임"),
                         fieldWithPath("content[].content").description("인증 기록 내용"),
+                        fieldWithPath("content[].files").description("인증 기록 첨부파일 목록"),
+                        fieldWithPath("content[].files.id").description("인증 기록 파일 PK"),
+                        fieldWithPath("content[].files.originalName").description("첨부파일 원본 이름"),
+                        fieldWithPath("content[].files.filePath").description("첨부파일 경로"),
                         fieldWithPath("content[].status").description("인증 기록 상태"),
                         fieldWithPath("content[].createdAt").description("인증 기록 생성 시간"),
                         fieldWithPath("totalPages").description("총 페이지 수"),
@@ -381,19 +438,31 @@ public class ProofHistoryControllerTest extends ControllerTest {
         Long proofHistoryId = 인증_기록_ID;
         ProofHistoryRequest.Update request =인증_기록_수정_요청;
 
-        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+        MockMultipartFile file = FileFixtures.파일_요청_생성("files");
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(List.of(file)), eq(request)))
                 .thenReturn(대기_인증_기록_요약_응답);
-        
+
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofHistoryId}", proofHistoryId)
+                        .file(jsonPart)
+                        .file(file)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isOk(),
                 jsonPath("$.id").value(대기_인증_기록_요약_응답.id()),
+                jsonPath("$.writer.id").value(UserFixtures.회원_PK),
+                jsonPath("$.writer.userId").value(UserFixtures.회원_아이디),
+                jsonPath("$.writer.nickname").value(UserFixtures.회원_닉네임),
                 jsonPath("$.content").value(대기_인증_기록_요약_응답.content()),
+                jsonPath("$.files").isArray(),
                 jsonPath("$.status").value(대기_인증_기록_요약_응답.status().toString()),
                 jsonPath("$.createdAt").value(대기_인증_기록_요약_응답.createdAt().toString())
         );
@@ -404,12 +473,25 @@ public class ProofHistoryControllerTest extends ControllerTest {
                 pathParameters(
                         parameterWithName("proofHistoryId").description("인증 기록 ID")
                 ),
-                requestFields(
-                        fieldWithPath("content").description("인증 기록 내용 (최대 1,000자)")
+                requestParts(
+                        partWithName("request").description("인증 기록 수정 요청 데이터 (JSON)"),
+                        partWithName("files").description("인증 기록 추가 첨부파일 (선택)")
+                ),
+                requestPartFields("request",
+                        fieldWithPath("content").description("인증 기록 내용 (최대 1,000자)"),
+                        fieldWithPath("fileOrder").description("인증 기록 첨부파일 순서")
                 ),
                 responseFields(
                         fieldWithPath("id").description("인증 기록 ID"),
+                        fieldWithPath("writer").description("인증 기록 작성자"),
+                        fieldWithPath("writer.id").description("작성자 PK"),
+                        fieldWithPath("writer.userId").description("작성자 아이디"),
+                        fieldWithPath("writer.nickname").description("작성자 닉네임"),
                         fieldWithPath("content").description("인증 기록 내용"),
+                        fieldWithPath("files").description("인증 기록 첨부파일 목록"),
+                        fieldWithPath("files.id").description("인증 기록 파일 PK"),
+                        fieldWithPath("files.originalName").description("첨부파일 원본 이름"),
+                        fieldWithPath("files.filePath").description("첨부파일 경로"),
                         fieldWithPath("status").description("인증 기록 상태"),
                         fieldWithPath("createdAt").description("인증 기록 생성 시간")
                 )
@@ -424,11 +506,17 @@ public class ProofHistoryControllerTest extends ControllerTest {
         Long proofHistoryId = 인증_기록_ID;
         ProofHistoryRequest.Update request = 잘못된_인증_기록_수정_요청;
 
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofHistoryId}", proofHistoryId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isBadRequest(),
@@ -455,14 +543,20 @@ public class ProofHistoryControllerTest extends ControllerTest {
         Long proofHistoryId = 인증_기록_ID;
         ProofHistoryRequest.Update request = 인증_기록_수정_요청;
 
-        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), any(), eq(request)))
                 .thenThrow(new NotFoundProofHistoryException());
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofHistoryId}", proofHistoryId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isNotFound(),
@@ -489,7 +583,9 @@ public class ProofHistoryControllerTest extends ControllerTest {
         Long proofHistoryId = 인증_기록_ID;
         ProofHistoryRequest.Update request = 인증_기록_수정_요청;
 
-        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), any(), eq(request)))
                 .thenThrow(new ForbiddenProofHistoryException("인증 기록의 작성자만 수정할 수 있습니다."));
 
         /* when */
@@ -523,7 +619,9 @@ public class ProofHistoryControllerTest extends ControllerTest {
         Long proofHistoryId = 인증_기록_ID;
         ProofHistoryRequest.Update request = 인증_기록_수정_요청;
 
-        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), eq(request)))
+        MockMultipartFile jsonPart = createJsonRequestPart(request);
+
+        when(proofHistoryService.update(any(User.class), eq(proofHistoryId), any(), eq(request)))
                 .thenThrow(new InvalidProofHistoryStatusException("이미 처리된 인증 기록은 수정할 수 없습니다."));
 
         /* when */

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/controller/ProofHistoryControllerTest.java
@@ -105,10 +105,10 @@ public class ProofHistoryControllerTest extends ControllerTest {
                         fieldWithPath("writer.userId").description("작성자 아이디"),
                         fieldWithPath("writer.nickname").description("작성자 닉네임"),
                         fieldWithPath("content").description("인증 기록 내용"),
-                        fieldWithPath("files").description("인증 기록 첨부파일 목록"),
-                        fieldWithPath("files.id").description("인증 기록 파일 PK"),
-                        fieldWithPath("files.originalName").description("첨부파일 원본 이름"),
-                        fieldWithPath("files.filePath").description("첨부파일 경로"),
+                        fieldWithPath("files[]").description("인증 기록 첨부파일 목록"),
+                        fieldWithPath("files[].id").description("인증 기록 파일 PK"),
+                        fieldWithPath("files[].originalName").description("첨부파일 원본 이름"),
+                        fieldWithPath("files[].filePath").description("첨부파일 경로"),
                         fieldWithPath("status").description("인증 기록 상태"),
                         fieldWithPath("createdAt").description("인증 기록 생성 시간")
                 )
@@ -351,10 +351,10 @@ public class ProofHistoryControllerTest extends ControllerTest {
                         fieldWithPath("content[].writer.userId").description("작성자 아이디"),
                         fieldWithPath("content[].writer.nickname").description("작성자 닉네임"),
                         fieldWithPath("content[].content").description("인증 기록 내용"),
-                        fieldWithPath("content[].files").description("인증 기록 첨부파일 목록"),
-                        fieldWithPath("content[].files.id").description("인증 기록 파일 PK"),
-                        fieldWithPath("content[].files.originalName").description("첨부파일 원본 이름"),
-                        fieldWithPath("content[].files.filePath").description("첨부파일 경로"),
+                        fieldWithPath("content[].files[]").description("인증 기록 첨부파일 목록"),
+                        fieldWithPath("content[].files[].id").description("인증 기록 파일 PK"),
+                        fieldWithPath("content[].files[].originalName").description("첨부파일 원본 이름"),
+                        fieldWithPath("content[].files[].filePath").description("첨부파일 경로"),
                         fieldWithPath("content[].status").description("인증 기록 상태"),
                         fieldWithPath("content[].createdAt").description("인증 기록 생성 시간"),
                         fieldWithPath("totalPages").description("총 페이지 수"),
@@ -436,7 +436,7 @@ public class ProofHistoryControllerTest extends ControllerTest {
     void 정상적인_인증_기록_수정_요청_시_응답코드_200을_반환한다 () throws Exception {
         /* given */
         Long proofHistoryId = 인증_기록_ID;
-        ProofHistoryRequest.Update request =인증_기록_수정_요청;
+        ProofHistoryRequest.Update request = 인증_기록_수정_요청;
 
         MockMultipartFile jsonPart = createJsonRequestPart(request);
         MockMultipartFile file = FileFixtures.파일_요청_생성("files");
@@ -488,10 +488,10 @@ public class ProofHistoryControllerTest extends ControllerTest {
                         fieldWithPath("writer.userId").description("작성자 아이디"),
                         fieldWithPath("writer.nickname").description("작성자 닉네임"),
                         fieldWithPath("content").description("인증 기록 내용"),
-                        fieldWithPath("files").description("인증 기록 첨부파일 목록"),
-                        fieldWithPath("files.id").description("인증 기록 파일 PK"),
-                        fieldWithPath("files.originalName").description("첨부파일 원본 이름"),
-                        fieldWithPath("files.filePath").description("첨부파일 경로"),
+                        fieldWithPath("files[]").description("인증 기록 첨부파일 목록"),
+                        fieldWithPath("files[].id").description("인증 기록 파일 PK"),
+                        fieldWithPath("files[].originalName").description("첨부파일 원본 이름"),
+                        fieldWithPath("files[].filePath").description("첨부파일 경로"),
                         fieldWithPath("status").description("인증 기록 상태"),
                         fieldWithPath("createdAt").description("인증 기록 생성 시간")
                 )
@@ -590,9 +590,13 @@ public class ProofHistoryControllerTest extends ControllerTest {
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofHistoryId}", proofHistoryId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isForbidden(),
@@ -626,9 +630,13 @@ public class ProofHistoryControllerTest extends ControllerTest {
 
         /* when */
         /* then */
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(endpoint + "/{proofHistoryId}", proofHistoryId)
-                .contentType(MediaType.APPLICATION_JSON).characterEncoding(StandardCharsets.UTF_8)
-                .content(objectMapper.writeValueAsString(request)));
+        ResultActions result = mockMvc.perform(
+                multipart(endpoint + "/{proofHistoryId}", proofHistoryId)
+                        .file(jsonPart)
+                        .with(mockRequest -> { mockRequest.setMethod("PUT"); return mockRequest; })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding(StandardCharsets.UTF_8)
+        );
 
         result.andExpectAll(
                 status().isConflict(),

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
@@ -7,6 +7,7 @@ import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.entity.ProofHistoryFile;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 public class ProofHistoryFixtures {
@@ -31,7 +33,7 @@ public class ProofHistoryFixtures {
 
     public static final LocalDateTime 인증_기록_생성_시간 = LocalDateTime.now().withNano(0);
 
-    public static final List<Long> 인증_기록_파일_순서 = List.of(FileFixtures.파일_ID, null);
+    public static final List<Long> 인증_기록_파일_순서 = Arrays.asList((Long) null);
 
     /* Request DTO */
     public static final ProofHistoryRequest.Create 인증_기록_생성_요청 = new ProofHistoryRequest.Create(인증_기록_내용);
@@ -52,6 +54,8 @@ public class ProofHistoryFixtures {
     public static final ProofHistory 대기_인증_기록 = 인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_대기_상태);
     public static final ProofHistory 성공_인증_기록 = 인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_성공_상태);
     public static final ProofHistory 실패_인증_기록 = 인증_기록_생성(오늘_인증, UserFixtures.회원, 인증_기록_내용, 인증_기록_실패_상태);
+
+    public static final ProofHistoryFile 인증_기록_파일 = new ProofHistoryFile(ProofHistoryFixtures.대기_인증_기록, FileFixtures.파일, FileFixtures.파일_순서);
 
     public static Pageable 페이지_요청 = PageRequest.of(0, 10);
 

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
@@ -1,6 +1,7 @@
 package com.trybe.moduleapi.proof.fixtures;
 
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.fixtures.FileFixtures;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
@@ -30,12 +31,14 @@ public class ProofHistoryFixtures {
 
     public static final LocalDateTime 인증_기록_생성_시간 = LocalDateTime.now().withNano(0);
 
+    public static final List<Long> 인증_기록_파일_순서 = List.of(FileFixtures.파일_ID, null);
+
     /* Request DTO */
     public static final ProofHistoryRequest.Create 인증_기록_생성_요청 = new ProofHistoryRequest.Create(인증_기록_내용);
-    public static final ProofHistoryRequest.Update 인증_기록_수정_요청 = new ProofHistoryRequest.Update(수정된_인증_기록_내용);
+    public static final ProofHistoryRequest.Update 인증_기록_수정_요청 = new ProofHistoryRequest.Update(수정된_인증_기록_내용, 인증_기록_파일_순서);
 
     public static final ProofHistoryRequest.Create 잘못된_인증_기록_생성_요청 = new ProofHistoryRequest.Create(잘못된_인증_기록_내용);
-    public static final ProofHistoryRequest.Update 잘못된_인증_기록_수정_요청 = new ProofHistoryRequest.Update(잘못된_인증_기록_내용);
+    public static final ProofHistoryRequest.Update 잘못된_인증_기록_수정_요청 = new ProofHistoryRequest.Update(잘못된_인증_기록_내용, 인증_기록_파일_순서);
 
     /* Entity */
     private static ProofHistory 인증_기록_생성(Proof proof, User user, String content, ProofHistoryStatus status) {
@@ -61,9 +64,9 @@ public class ProofHistoryFixtures {
     public static final Page<ProofHistory> 인증_기록_목록_페이지 = new PageImpl<>(인증_기록_목록, 페이지_요청, 인증_기록_목록.size());
 
     /* Response DTO */
-    public static final ProofHistoryResponse.Summary 대기_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, 인증_기록_내용, 인증_기록_대기_상태, 인증_기록_생성_시간);
-    public static final ProofHistoryResponse.Summary 성공_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, 인증_기록_내용, 인증_기록_성공_상태, 인증_기록_생성_시간);
-    public static final ProofHistoryResponse.Summary 실패_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, 인증_기록_내용, 인증_기록_실패_상태, 인증_기록_생성_시간);
+    public static final ProofHistoryResponse.Summary 대기_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, UserFixtures.요약_회원_응답, 인증_기록_내용, FileFixtures.아이디_포함_파일_목록_응답, 인증_기록_대기_상태, 인증_기록_생성_시간);
+    public static final ProofHistoryResponse.Summary 성공_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, UserFixtures.요약_회원_응답, 인증_기록_내용, FileFixtures.아이디_포함_파일_목록_응답, 인증_기록_성공_상태, 인증_기록_생성_시간);
+    public static final ProofHistoryResponse.Summary 실패_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, UserFixtures.요약_회원_응답, 인증_기록_내용, FileFixtures.아이디_포함_파일_목록_응답, 인증_기록_실패_상태, 인증_기록_생성_시간);
 
-    public static final PageResponse<ProofHistoryResponse.Summary> 인증_기록_목록_페이지_응답 = new PageResponse<>(인증_기록_목록_페이지.map(ProofHistoryResponse.Summary::from));
+    public static final PageResponse<ProofHistoryResponse.Summary> 인증_기록_목록_페이지_응답 = new PageResponse<>(인증_기록_목록_페이지.map(proofHistory -> ProofHistoryResponse.Summary.from(proofHistory, FileFixtures.아이디_포함_파일_목록_응답)));
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/fixtures/ProofHistoryFixtures.java
@@ -1,6 +1,7 @@
 package com.trybe.moduleapi.proof.fixtures;
 
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.dto.FileWithIdResponse;
 import com.trybe.moduleapi.file.fixtures.FileFixtures;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
@@ -68,7 +69,7 @@ public class ProofHistoryFixtures {
     public static final Page<ProofHistory> 인증_기록_목록_페이지 = new PageImpl<>(인증_기록_목록, 페이지_요청, 인증_기록_목록.size());
 
     /* Response DTO */
-    public static final ProofHistoryResponse.Summary 대기_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, UserFixtures.요약_회원_응답, 인증_기록_내용, FileFixtures.아이디_포함_파일_목록_응답, 인증_기록_대기_상태, 인증_기록_생성_시간);
+    public static final ProofHistoryResponse.Summary 대기_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, UserFixtures.요약_회원_응답, 인증_기록_내용, FileFixtures.아이디_포함_파일_목록_응답 , 인증_기록_대기_상태, 인증_기록_생성_시간);
     public static final ProofHistoryResponse.Summary 성공_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, UserFixtures.요약_회원_응답, 인증_기록_내용, FileFixtures.아이디_포함_파일_목록_응답, 인증_기록_성공_상태, 인증_기록_생성_시간);
     public static final ProofHistoryResponse.Summary 실패_인증_기록_요약_응답 = new ProofHistoryResponse.Summary(인증_기록_ID, UserFixtures.요약_회원_응답, 인증_기록_내용, FileFixtures.아이디_포함_파일_목록_응답, 인증_기록_실패_상태, 인증_기록_생성_시간);
 

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryServiceTest.java
@@ -2,6 +2,8 @@ package com.trybe.moduleapi.proof.service;
 
 import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipationStatusActionException;
 import com.trybe.moduleapi.common.dto.PageResponse;
+import com.trybe.moduleapi.file.fixtures.FileFixtures;
+import com.trybe.moduleapi.file.service.FileManager;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
 import com.trybe.moduleapi.proof.exception.InvalidProofDateException;
@@ -14,8 +16,9 @@ import com.trybe.moduleapi.proof.fixtures.ProofFixtures;
 import com.trybe.moduleapi.user.fixtures.UserFixtures;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
-import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.proof.entity.ProofHistoryFile;
+import com.trybe.modulecore.proof.repository.ProofHistoryFileRepository;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
 import com.trybe.modulecore.proof.repository.ProofRepository;
 import com.trybe.modulecore.user.entity.User;
@@ -25,7 +28,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static com.trybe.moduleapi.proof.fixtures.ProofHistoryFixtures.*;
@@ -42,10 +48,16 @@ public class ProofHistoryServiceTest {
     private ProofHistoryRepository proofHistoryRepository;
 
     @Mock
+    private ProofHistoryFileRepository proofHistoryFileRepository;
+
+    @Mock
     private ProofRepository proofRepository;
 
     @Mock
     private ChallengeParticipationRepository challengeParticipationRepository;
+
+    @Mock
+    private FileManager fileManager;
 
     @Test
     @DisplayName("인증 기록 생성 시 저장된 인증 기록 정보를 반환한다.")
@@ -55,6 +67,8 @@ public class ProofHistoryServiceTest {
         ProofHistoryRequest.Create request = 인증_기록_생성_요청;
         ProofHistory proofHistory = 대기_인증_기록;
 
+        List<MultipartFile> files = List.of(FileFixtures.파일_요청_생성("files"));
+
         when(proofRepository.findById(proofId))
                 .thenReturn(Optional.of(오늘_인증));
         when(challengeParticipationRepository.existsByUserIdAndChallengeIdAndStatus(any(), any(), eq(ParticipationStatus.ACCEPTED)))
@@ -63,13 +77,19 @@ public class ProofHistoryServiceTest {
                 .thenReturn(false);
         when(proofHistoryRepository.save(any(ProofHistory.class)))
                 .thenReturn(proofHistory);
+        when(fileManager.uploadFiles(eq(files), any(String.class)))
+                .thenReturn(List.of(FileFixtures.파일));
+        when(proofHistoryFileRepository.saveAll(anyList()))
+                .thenReturn(List.of(인증_기록_파일));
 
         /* when */
-        ProofHistoryResponse.Summary result = proofHistoryService.save(UserFixtures.회원, proofId, request);
+        ProofHistoryResponse.Summary result = proofHistoryService.save(UserFixtures.회원, proofId, files, request);
 
         /* then */
         assertEquals(proofHistory.getId(), result.id());
+        assertEquals(proofHistory.getUser().getId(), result.writer().id());
         assertEquals(proofHistory.getContent(), result.content());
+        assertEquals(files.size(), result.files().size());
         assertEquals(proofHistory.getStatus(), result.status());
 //        assertEquals(proofHistory.getCreatedAt(), result.createdAt());
     }
@@ -86,7 +106,7 @@ public class ProofHistoryServiceTest {
         
         /* when */
         /* then */
-        assertThrows(NotFoundProofException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+        assertThrows(NotFoundProofException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, null, request));
     }
     
     @Test
@@ -103,7 +123,7 @@ public class ProofHistoryServiceTest {
         
         /* when */
         /* then */
-        assertThrows(InvalidParticipationStatusActionException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+        assertThrows(InvalidParticipationStatusActionException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, null, request));
     }
     
     @Test
@@ -120,7 +140,7 @@ public class ProofHistoryServiceTest {
 
         /* when */
         /* then */
-        assertThrows(InvalidProofDateException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+        assertThrows(InvalidProofDateException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, null, request));
     }
 
     @Test
@@ -139,7 +159,7 @@ public class ProofHistoryServiceTest {
 
         /* when */
         /* then */
-        assertThrows(DuplicatedProofHistoryException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, request));
+        assertThrows(DuplicatedProofHistoryException.class, () -> proofHistoryService.save(UserFixtures.회원, proofId, null, request));
     }
 
     @Test
@@ -176,6 +196,7 @@ public class ProofHistoryServiceTest {
         /* then */
         assertThrows(NotFoundProofException.class, () -> proofHistoryService.findAll(UserFixtures.회원, proofId, 페이지_요청));
     }
+
     @Test
     @DisplayName("인증 기록 목록 조회 시 챌린지 멤버가 아닌 경우 예외를 던진다.")
     void 인증_기록_목록_조회_시_챌린지_멤버가_아닌_경우_예외를_던진다 () {
@@ -199,15 +220,25 @@ public class ProofHistoryServiceTest {
         Long proofHistoryId = 인증_기록_ID;
         ProofHistoryRequest.Update request = 인증_기록_수정_요청;
 
+        List<MultipartFile> files = List.of(FileFixtures.파일_요청_생성("files"));
+
         when(proofHistoryRepository.findById(proofHistoryId))
                 .thenReturn(Optional.of(대기_인증_기록));
+        when(proofHistoryFileRepository.findAllByProofHistoryIdOrderByFileOrder(any()))
+                .thenReturn(Collections.emptyList());
+        when(fileManager.uploadFiles(any(), any(String.class)))
+                .thenReturn(List.of(FileFixtures.파일));
+        when(proofHistoryFileRepository.save(any(ProofHistoryFile.class)))
+                .thenReturn(인증_기록_파일);
 
         /* when */
-        ProofHistoryResponse.Summary result = proofHistoryService.update(UserFixtures.회원, proofHistoryId, request);
+        ProofHistoryResponse.Summary result = proofHistoryService.update(UserFixtures.회원, proofHistoryId, null, request);
 
         /* then */
         assertEquals(대기_인증_기록.getId(), result.id());
+        assertEquals(대기_인증_기록.getUser().getId(), result.writer().id());
         assertEquals(request.content(), result.content());
+        assertEquals(files.size(), result.files().size());
         assertEquals(대기_인증_기록.getStatus(), result.status());
 //        assertEquals(대기_인증_기록.getCreatedAt(), result.createdAt());
     }
@@ -224,7 +255,7 @@ public class ProofHistoryServiceTest {
 
         /* when */
         /* then */
-        assertThrows(NotFoundProofHistoryException.class, () -> proofHistoryService.update(UserFixtures.회원, proofHistoryId, request));
+        assertThrows(NotFoundProofHistoryException.class, () -> proofHistoryService.update(UserFixtures.회원, proofHistoryId, null, request));
     }
 
     @Test
@@ -242,7 +273,7 @@ public class ProofHistoryServiceTest {
 
         /* when */
         /* then */
-        assertThrows(ForbiddenProofHistoryException.class, () -> proofHistoryService.update(user, proofHistoryId, request));
+        assertThrows(ForbiddenProofHistoryException.class, () -> proofHistoryService.update(user, proofHistoryId, null, request));
     }
 
     @Test
@@ -257,7 +288,7 @@ public class ProofHistoryServiceTest {
 
         /* when */
         /* then */
-        assertThrows(InvalidProofHistoryStatusException.class, () -> proofHistoryService.update(UserFixtures.회원, proofHistoryId, request));
+        assertThrows(InvalidProofHistoryStatusException.class, () -> proofHistoryService.update(UserFixtures.회원, proofHistoryId, null, request));
     }
 
     @Test

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
@@ -42,7 +42,7 @@ public class ProofHistory extends BaseEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @OneToMany(mappedBy = "proofHistory", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "proofHistory", cascade = CascadeType.ALL)
     @OrderBy("fileOrder ASC")
     private List<ProofHistoryFile> files = new ArrayList<>();
 
@@ -59,21 +59,5 @@ public class ProofHistory extends BaseEntity {
 
     public void updateStatus(ProofHistoryStatus status) {
         this.status = status;
-    }
-
-    public void addFile(ProofHistoryFile file) {
-        if (!files.contains(file)) {
-            files.add(file);
-        }
-        if (file.getProofHistory() != this) {
-            file.setProofHistory(this);
-        }
-    }
-
-    public void removeFile(ProofHistoryFile file) {
-        files.remove(file);
-        if (file.getProofHistory() == this) {
-            file.setProofHistory(null);
-        }
     }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
@@ -11,8 +11,6 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "proof_histories")
@@ -41,10 +39,6 @@ public class ProofHistory extends BaseEntity {
 
     @Column(name = "content", nullable = false)
     private String content;
-
-    @OneToMany(mappedBy = "proofHistory", cascade = CascadeType.ALL)
-    @OrderBy("fileOrder ASC")
-    private List<ProofHistoryFile> files = new ArrayList<>();
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistory.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "proof_histories")
@@ -40,6 +42,10 @@ public class ProofHistory extends BaseEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
+    @OneToMany(mappedBy = "proofHistory", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("fileOrder ASC")
+    private List<ProofHistoryFile> files = new ArrayList<>();
+
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     private ProofHistoryStatus status = ProofHistoryStatus.PENDING;
@@ -53,5 +59,21 @@ public class ProofHistory extends BaseEntity {
 
     public void updateStatus(ProofHistoryStatus status) {
         this.status = status;
+    }
+
+    public void addFile(ProofHistoryFile file) {
+        if (!files.contains(file)) {
+            files.add(file);
+        }
+        if (file.getProofHistory() != this) {
+            file.setProofHistory(this);
+        }
+    }
+
+    public void removeFile(ProofHistoryFile file) {
+        files.remove(file);
+        if (file.getProofHistory() == this) {
+            file.setProofHistory(null);
+        }
     }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistoryFile.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistoryFile.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "proof_history_files")
@@ -13,15 +12,14 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProofHistoryFile {
     public ProofHistoryFile(ProofHistory proofHistory, File file, int fileOrder) {
+        this.proofHistory = proofHistory;
         this.file = file;
         this.fileOrder = fileOrder;
-        proofHistory.addFile(this);
     }
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "proof_history_id", nullable = false, updatable = false)
     private ProofHistory proofHistory;

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistoryFile.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistoryFile.java
@@ -5,20 +5,23 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "proof_history_files")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProofHistoryFile {
-    public ProofHistoryFile(ProofHistory proofHistory, File file) {
-        this.proofHistory = proofHistory;
+    public ProofHistoryFile(ProofHistory proofHistory, File file, int fileOrder) {
         this.file = file;
+        this.fileOrder = fileOrder;
+        proofHistory.addFile(this);
     }
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "proof_history_id", nullable = false, updatable = false)
     private ProofHistory proofHistory;
@@ -28,5 +31,9 @@ public class ProofHistoryFile {
     private File file;
 
     @Column(name = "file_order", nullable = false)
-    private int order;
+    private int fileOrder;
+
+    public void updateFileOrder(int order) {
+        this.fileOrder = order;
+    }
 }

--- a/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistoryFile.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/entity/ProofHistoryFile.java
@@ -1,0 +1,32 @@
+package com.trybe.modulecore.proof.entity;
+
+import com.trybe.modulecore.file.entity.File;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "proof_history_files")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProofHistoryFile {
+    public ProofHistoryFile(ProofHistory proofHistory, File file) {
+        this.proofHistory = proofHistory;
+        this.file = file;
+    }
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "proof_history_id", nullable = false, updatable = false)
+    private ProofHistory proofHistory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "file_id", nullable = false, updatable = false)
+    private File file;
+
+    @Column(name = "file_order", nullable = false)
+    private int order;
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryFileRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryFileRepository.java
@@ -1,0 +1,10 @@
+package com.trybe.modulecore.proof.repository;
+
+import com.trybe.modulecore.proof.entity.ProofHistoryFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProofHistoryFileRepository extends JpaRepository<ProofHistoryFile, Long> {
+    List<ProofHistoryFile> findAllByProofHistoryIdOrderByFileOrder(Long proofHistoryId);
+}

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryFileRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryFileRepository.java
@@ -2,9 +2,11 @@ package com.trybe.modulecore.proof.repository;
 
 import com.trybe.modulecore.proof.entity.ProofHistoryFile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ProofHistoryFileRepository extends JpaRepository<ProofHistoryFile, Long> {
     List<ProofHistoryFile> findAllByProofHistoryIdOrderByFileOrder(Long proofHistoryId);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofHistoryRepository.java
@@ -3,6 +3,7 @@ package com.trybe.modulecore.proof.repository;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Repository
 public interface ProofHistoryRepository extends JpaRepository<ProofHistory, Long> {
+    @EntityGraph(attributePaths = {"files", "files.file"})
     Page<ProofHistory> findAllByProofId(Long proofId, Pageable pageable);
     List<ProofHistory> findAllByProof_Date(LocalDate date);
     boolean existsByProofIdAndUserId(Long proofId, Long userId);


### PR DESCRIPTION
- 인증 기록 생성 및 수정 시 여러 장의 파일을 첨부할 수 있는 기능 추가
  - `ProofHistoryController`, `ProofHistoryService` 코드 수정
  - `ProofHistoryRequest` 내 Update 필드에 fileOrder 필드 추가
  - `ProofHistoryResponse` 내 작성자 정보 writer, 첨부파일 리스트 files 필드 추가
- `ProofHistory`, `File`의 중간 엔티티인 `ProofHistoryFile` 엔티티 및 리포지토리 추가
- fileOrder 정의를 위한 `FileWithIdResponse` 추가
  - `File` 엔티티의 아이디가 아닌 관련 아이디(ex. `ProofHistoryFile`의 PK)를 담도록 함
- 코드 변경에 따른 테스트 코드 수정