### PR TITLE
[#16] 챌린지 알림 기능 구현

### DIFF
--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
@@ -26,10 +26,10 @@ public class ChallengeNotificationEventListener {
     }
 
     private static final String CHALLENGE_START_TITLE = "챌린지가 시작되었습니다!";
-    private static final String CHALLENGE_START_MESSAGE_FORMAT = "%s 챌린지가 시작되었습니다.";
+    private static final String CHALLENGE_START_MESSAGE_FORMAT = "[%s] 챌린지가 시작되었습니다.";
 
     private static final String CHALLENGE_END_TITLE = "챌린지가 종료되었습니다.";
-    private static final String CHALLENGE_END_MESSAGE_FORMAT = "%s 챌린지가 종료되었습니다.";
+    private static final String CHALLENGE_END_MESSAGE_FORMAT = "[%s] 챌린지가 종료되었습니다.";
 
     private static final String CHALLENGE_PARTICIPATION_REQUEST_TITLE = "챌린지 참여 요청이 도착했습니다.";
     private static final String CHALLENGE_PARTICIPATION_REQUEST_MESSAGE_FORMAT = "%s 님이 [%s] 챌린지에 참여를 요청했습니다.";

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
@@ -4,14 +4,10 @@ import com.trybe.moduleapi.challenge.event.model.ChallengeParticipationEvent;
 import com.trybe.moduleapi.challenge.event.model.ChallengeStatusEvent;
 import com.trybe.moduleapi.challenge.event.type.ChallengeParticipationEventType;
 import com.trybe.moduleapi.challenge.event.type.ChallengeStatusEventType;
-import com.trybe.moduleapi.challenge.exception.participation.NotFoundChallengeParticipationException;
 import com.trybe.moduleapi.notification.constants.NotificationTopics;
 import com.trybe.moduleapi.notification.service.NotificationProducerService;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
-import com.trybe.modulecore.challenge.enums.ChallengeRole;
-import com.trybe.modulecore.challenge.enums.ParticipationStatus;
-import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.notification.enums.NotificationType;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.scheduling.annotation.Async;
@@ -24,11 +20,9 @@ import java.util.List;
 @Component
 public class ChallengeNotificationEventListener {
     private final NotificationProducerService notificationProducerService;
-    private final ChallengeParticipationRepository challengeParticipationRepository;
 
-    public ChallengeNotificationEventListener(NotificationProducerService notificationProducerService, ChallengeParticipationRepository challengeParticipationRepository) {
+    public ChallengeNotificationEventListener(NotificationProducerService notificationProducerService) {
         this.notificationProducerService = notificationProducerService;
-        this.challengeParticipationRepository = challengeParticipationRepository;
     }
 
     private static final String CHALLENGE_START_TITLE = "챌린지가 시작되었습니다!";
@@ -47,11 +41,8 @@ public class ChallengeNotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleChallengeStatusEvent(ChallengeStatusEvent event) {
         Challenge challenge = event.getChallenge();
-        List<User> participants = challengeParticipationRepository.findAllByChallengeIdAndStatus(challenge.getId(), ParticipationStatus.ACCEPTED).stream()
-                .map(ChallengeParticipation::getUser)
-                .toList();
-
         ChallengeStatusEventType type = event.getEventType();
+        List<User> participants = event.getParticipants();
 
         switch (type) {
             case START -> notifyChallengeStart(challenge, participants);
@@ -67,7 +58,10 @@ public class ChallengeNotificationEventListener {
         ChallengeParticipation participation = event.getParticipation();
 
         switch (type) {
-            case PARTICIPATION_ADD -> notifyParticipationRequest(participation);
+            case PARTICIPATION_ADD -> {
+                User leader = event.getLeader();
+                if (leader != null) notifyParticipationRequest(participation, leader);
+            }
             case PARTICIPATION_PROCESSED -> notifyParticipationRequestProcessed(participation);
         }
     }
@@ -94,9 +88,8 @@ public class ChallengeNotificationEventListener {
         );
     }
 
-    private void notifyParticipationRequest(ChallengeParticipation participation) {
+    private void notifyParticipationRequest(ChallengeParticipation participation, User leader) {
         Challenge challenge = participation.getChallenge();
-        User leader = getLeaderParticipation(challenge).getUser();
         User applicant = participation.getUser();
 
         notificationProducerService.publishNotification(
@@ -129,10 +122,5 @@ public class ChallengeNotificationEventListener {
                         participation.getStatus().getDescription()
                 )
         );
-    }
-
-    private ChallengeParticipation getLeaderParticipation(Challenge challenge) {
-        return challengeParticipationRepository.findByChallengeIdAndRole(challenge.getId(), ChallengeRole.LEADER)
-                .orElseThrow(() -> new NotFoundChallengeParticipationException("챌린지의 리더 참여 정보를 찾을 수 없습니다."));
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
@@ -40,8 +40,8 @@ public class ChallengeNotificationEventListener {
     private static final String CHALLENGE_PARTICIPATION_REQUEST_TITLE = "챌린지 참여 요청이 도착했습니다.";
     private static final String CHALLENGE_PARTICIPATION_REQUEST_MESSAGE_FORMAT = "%s 님이 [%s] 챌린지에 참여를 요청했습니다.";
 
-    private static final String CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_TITLE = "챌린지 참여 요청이 처리되었습니다.";
-    private static final String CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_MESSAGE_FORMAT = "[%s] 챌린지에 대한 참여 신청이 %s되었습니다.";
+    private static final String CHALLENGE_PARTICIPATION_PROCESSED_TITLE = "챌린지 참여 요청이 처리되었습니다.";
+    private static final String CHALLENGE_PARTICIPATION_PROCESSED_MESSAGE_FORMAT = "[%s] 챌린지에 대한 참여 신청이 %s되었습니다.";
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -67,8 +67,8 @@ public class ChallengeNotificationEventListener {
         ChallengeParticipation participation = event.getParticipation();
 
         switch (type) {
-            case PARTICIPATION_REQUEST -> notifyParticipationRequest(participation);
-            case PARTICIPATION_REQUEST_PROCESSED -> notifyParticipationRequestProcessed(participation);
+            case PARTICIPATION_ADD -> notifyParticipationRequest(participation);
+            case PARTICIPATION_PROCESSED -> notifyParticipationRequestProcessed(participation);
         }
     }
 
@@ -122,9 +122,9 @@ public class ChallengeNotificationEventListener {
                 applicant,
                 NotificationType.CHALLENGE_PARTICIPATION,
                 challenge.getId(),
-                CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_TITLE,
+                CHALLENGE_PARTICIPATION_PROCESSED_TITLE,
                 String.format(
-                        CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_MESSAGE_FORMAT,
+                        CHALLENGE_PARTICIPATION_PROCESSED_MESSAGE_FORMAT,
                         challenge.getTitle(),
                         participation.getStatus().getDescription()
                 )

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengeNotificationEventListener.java
@@ -1,0 +1,138 @@
+package com.trybe.moduleapi.challenge.event.listener;
+
+import com.trybe.moduleapi.challenge.event.model.ChallengeParticipationEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeStatusEvent;
+import com.trybe.moduleapi.challenge.event.type.ChallengeParticipationEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeStatusEventType;
+import com.trybe.moduleapi.challenge.exception.participation.NotFoundChallengeParticipationException;
+import com.trybe.moduleapi.notification.constants.NotificationTopics;
+import com.trybe.moduleapi.notification.service.NotificationProducerService;
+import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.challenge.enums.ChallengeRole;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.notification.enums.NotificationType;
+import com.trybe.modulecore.user.entity.User;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Component
+public class ChallengeNotificationEventListener {
+    private final NotificationProducerService notificationProducerService;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
+
+    public ChallengeNotificationEventListener(NotificationProducerService notificationProducerService, ChallengeParticipationRepository challengeParticipationRepository) {
+        this.notificationProducerService = notificationProducerService;
+        this.challengeParticipationRepository = challengeParticipationRepository;
+    }
+
+    private static final String CHALLENGE_START_TITLE = "챌린지가 시작되었습니다!";
+    private static final String CHALLENGE_START_MESSAGE_FORMAT = "%s 챌린지가 시작되었습니다.";
+
+    private static final String CHALLENGE_END_TITLE = "챌린지가 종료되었습니다.";
+    private static final String CHALLENGE_END_MESSAGE_FORMAT = "%s 챌린지가 종료되었습니다.";
+
+    private static final String CHALLENGE_PARTICIPATION_REQUEST_TITLE = "챌린지 참여 요청이 도착했습니다.";
+    private static final String CHALLENGE_PARTICIPATION_REQUEST_MESSAGE_FORMAT = "%s 님이 [%s] 챌린지에 참여를 요청했습니다.";
+
+    private static final String CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_TITLE = "챌린지 참여 요청이 처리되었습니다.";
+    private static final String CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_MESSAGE_FORMAT = "[%s] 챌린지에 대한 참여 신청이 %s되었습니다.";
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChallengeStatusEvent(ChallengeStatusEvent event) {
+        Challenge challenge = event.getChallenge();
+        List<User> participants = challengeParticipationRepository.findAllByChallengeIdAndStatus(challenge.getId(), ParticipationStatus.ACCEPTED).stream()
+                .map(ChallengeParticipation::getUser)
+                .toList();
+
+        ChallengeStatusEventType type = event.getEventType();
+
+        switch (type) {
+            case START -> notifyChallengeStart(challenge, participants);
+            case END -> notifyChallengeEnd(challenge, participants);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChallengeParticipationEvent(ChallengeParticipationEvent event) {
+        ChallengeParticipationEventType type = event.getEventType();
+
+        ChallengeParticipation participation = event.getParticipation();
+
+        switch (type) {
+            case PARTICIPATION_REQUEST -> notifyParticipationRequest(participation);
+            case PARTICIPATION_REQUEST_PROCESSED -> notifyParticipationRequestProcessed(participation);
+        }
+    }
+
+    private void notifyChallengeStart(Challenge challenge, List<User> receivers) {
+        notificationProducerService.publishNotifications(
+                NotificationTopics.CHALLENGE,
+                receivers,
+                NotificationType.CHALLENGE,
+                challenge.getId(),
+                CHALLENGE_START_TITLE,
+                String.format(CHALLENGE_START_MESSAGE_FORMAT, challenge.getTitle())
+        );
+    }
+
+    private void notifyChallengeEnd(Challenge challenge, List<User> receivers) {
+        notificationProducerService.publishNotifications(
+                NotificationTopics.CHALLENGE,
+                receivers,
+                NotificationType.CHALLENGE,
+                challenge.getId(),
+                CHALLENGE_END_TITLE,
+                String.format(CHALLENGE_END_MESSAGE_FORMAT, challenge.getTitle())
+        );
+    }
+
+    private void notifyParticipationRequest(ChallengeParticipation participation) {
+        Challenge challenge = participation.getChallenge();
+        User leader = getLeaderParticipation(challenge).getUser();
+        User applicant = participation.getUser();
+
+        notificationProducerService.publishNotification(
+                NotificationTopics.CHALLENGE,
+                leader,
+                NotificationType.CHALLENGE_PARTICIPATION,
+                challenge.getId(),
+                CHALLENGE_PARTICIPATION_REQUEST_TITLE,
+                String.format(
+                        CHALLENGE_PARTICIPATION_REQUEST_MESSAGE_FORMAT,
+                        applicant.getNickname(),
+                        challenge.getTitle()
+                )
+        );
+    }
+
+    private void notifyParticipationRequestProcessed(ChallengeParticipation participation) {
+        Challenge challenge = participation.getChallenge();
+        User applicant = participation.getUser();
+
+        notificationProducerService.publishNotification(
+                NotificationTopics.CHALLENGE,
+                applicant,
+                NotificationType.CHALLENGE_PARTICIPATION,
+                challenge.getId(),
+                CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_TITLE,
+                String.format(
+                        CHALLENGE_PARTICIPATION_REQUEST_PROCESSED_MESSAGE_FORMAT,
+                        challenge.getTitle(),
+                        participation.getStatus().getDescription()
+                )
+        );
+    }
+
+    private ChallengeParticipation getLeaderParticipation(Challenge challenge) {
+        return challengeParticipationRepository.findByChallengeIdAndRole(challenge.getId(), ChallengeRole.LEADER)
+                .orElseThrow(() -> new NotFoundChallengeParticipationException("챌린지의 리더 참여 정보를 찾을 수 없습니다."));
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
@@ -1,5 +1,7 @@
-package com.trybe.moduleapi.challenge.event;
+package com.trybe.moduleapi.challenge.event.listener;
 
+import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
 import org.springframework.scheduling.annotation.Async;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
@@ -1,7 +1,7 @@
 package com.trybe.moduleapi.challenge.event.listener;
 
 import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
 import org.springframework.scheduling.annotation.Async;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
@@ -1,8 +1,11 @@
 package com.trybe.moduleapi.challenge.event.listener;
 
-import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.model.ChallengeActionEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeParticipationEvent;
+import com.trybe.moduleapi.challenge.event.type.ChallengeActionEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeParticipationEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -19,16 +22,34 @@ public class ChallengePreferenceEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleChallengeEvent(ChallengeEvent event) {
+    public void handleChallengeActionEvent(ChallengeActionEvent event) {
         Challenge challenge = event.getChallenge();
+        ChallengeActionEventType type = event.getEventType();
         Long userId = event.getUserId();
 
-        ChallengeEventType type = event.getType();
-        int score = event.getType().getActionType().getPreferenceScore();
-
-        if (score == 0) { return; }
+        int score = type.getScoreType().getPreferenceScore();
 
         if (type.isScoreUp()) {
+            challengePreferenceCache.addPreference(userId, challenge, score);
+        } else {
+            challengePreferenceCache.removePreference(userId, challenge, score);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChallengeParticipationEvent(ChallengeParticipationEvent event) {
+        ChallengeParticipation participation = event.getParticipation();
+
+        Challenge challenge = event.getChallenge();
+        ChallengeParticipationEventType type = event.getEventType();
+        Long userId = participation.getUser().getId();
+
+        if (type.getScoreType() == null || type.getIsScoreUp() == null) return;
+
+        int score = type.getScoreType().getPreferenceScore();
+
+        if (type.getIsScoreUp()) {
             challengePreferenceCache.addPreference(userId, challenge, score);
         } else {
             challengePreferenceCache.removePreference(userId, challenge, score);

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/ChallengePreferenceEventListener.java
@@ -1,6 +1,6 @@
 package com.trybe.moduleapi.challenge.event.listener;
 
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
@@ -1,5 +1,7 @@
-package com.trybe.moduleapi.challenge.event;
+package com.trybe.moduleapi.challenge.event.listener;
 
+import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.moduleapi.utils.DateUtils;
 import com.trybe.modulecore.challenge.repository.popular.PopularChallengeCache;
 import org.springframework.scheduling.annotation.Async;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
@@ -1,6 +1,6 @@
 package com.trybe.moduleapi.challenge.event.listener;
 
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.moduleapi.utils.DateUtils;
 import com.trybe.modulecore.challenge.repository.popular.PopularChallengeCache;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
@@ -1,7 +1,7 @@
 package com.trybe.moduleapi.challenge.event.listener;
 
 import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
 import com.trybe.moduleapi.utils.DateUtils;
 import com.trybe.modulecore.challenge.repository.popular.PopularChallengeCache;
 import org.springframework.scheduling.annotation.Async;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/listener/PopularChallengeEventListener.java
@@ -1,7 +1,9 @@
 package com.trybe.moduleapi.challenge.event.listener;
 
-import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.model.ChallengeActionEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeParticipationEvent;
+import com.trybe.moduleapi.challenge.event.type.ChallengeActionEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeParticipationEventType;
 import com.trybe.moduleapi.utils.DateUtils;
 import com.trybe.modulecore.challenge.repository.popular.PopularChallengeCache;
 import org.springframework.scheduling.annotation.Async;
@@ -19,15 +21,30 @@ public class PopularChallengeEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleChallengeEvent(ChallengeEvent event) {
+    public void handleChallengeActionEvent(ChallengeActionEvent event) {
+        ChallengeActionEventType type = event.getEventType();
         Long challengeId = event.getChallenge().getId();
 
-        ChallengeEventType type = event.getType();
-        int score = type.getActionType().getPopularityScore();
-
-        if (score == 0) { return; }
+        int score = type.getScoreType().getPopularityScore();
 
         if (type.isScoreUp()) {
+            increasePopularity(challengeId, score);
+        } else {
+            decreasePopularity(challengeId, score);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChallengeParticipationEvent(ChallengeParticipationEvent event) {
+        ChallengeParticipationEventType type = event.getEventType();
+        Long challengeId = event.getChallenge().getId();
+
+        if (type.getScoreType() == null || type.getIsScoreUp() == null) return;
+
+        int score = type.getScoreType().getPopularityScore();
+
+        if (type.getIsScoreUp()) {
             increasePopularity(challengeId, score);
         } else {
             decreasePopularity(challengeId, score);

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeActionEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeActionEvent.java
@@ -1,0 +1,17 @@
+package com.trybe.moduleapi.challenge.event.model;
+
+import com.trybe.moduleapi.challenge.event.type.ChallengeActionEventType;
+import com.trybe.modulecore.challenge.entity.Challenge;
+import lombok.Getter;
+
+@Getter
+public class ChallengeActionEvent extends ChallengeEvent {
+    private final ChallengeActionEventType eventType;
+    private final Long userId;
+
+    public ChallengeActionEvent(Challenge challenge, ChallengeActionEventType eventType, Long userId) {
+        super(challenge);
+        this.eventType = eventType;
+        this.userId = userId;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeEvent.java
@@ -1,5 +1,6 @@
-package com.trybe.moduleapi.challenge.event;
+package com.trybe.moduleapi.challenge.event.model;
 
+import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import lombok.Getter;
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeEvent.java
@@ -1,18 +1,13 @@
 package com.trybe.moduleapi.challenge.event.model;
 
-import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import lombok.Getter;
 
 @Getter
 public class ChallengeEvent {
     private final Challenge challenge;
-    private final Long userId;
-    private final ChallengeEventType type;
 
-    public ChallengeEvent(Challenge challenge, Long userId, ChallengeEventType type) {
+    public ChallengeEvent(Challenge challenge) {
         this.challenge = challenge;
-        this.userId = userId;
-        this.type = type;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeEvent.java
@@ -1,6 +1,6 @@
 package com.trybe.moduleapi.challenge.event.model;
 
-import com.trybe.moduleapi.challenge.event.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import lombok.Getter;
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeParticipationEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeParticipationEvent.java
@@ -3,16 +3,19 @@ package com.trybe.moduleapi.challenge.event.model;
 import com.trybe.moduleapi.challenge.event.type.ChallengeParticipationEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.user.entity.User;
 import lombok.Getter;
 
 @Getter
 public class ChallengeParticipationEvent extends ChallengeEvent {
     private final ChallengeParticipationEventType eventType;
     private final ChallengeParticipation participation;
+    private final User leader;
 
-    public ChallengeParticipationEvent(Challenge challenge, ChallengeParticipationEventType eventType, ChallengeParticipation participation) {
+    public ChallengeParticipationEvent(Challenge challenge, ChallengeParticipationEventType eventType, ChallengeParticipation participation, User leader) {
         super(challenge);
         this.eventType = eventType;
         this.participation = participation;
+        this.leader = leader;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeParticipationEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeParticipationEvent.java
@@ -1,0 +1,18 @@
+package com.trybe.moduleapi.challenge.event.model;
+
+import com.trybe.moduleapi.challenge.event.type.ChallengeParticipationEventType;
+import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import lombok.Getter;
+
+@Getter
+public class ChallengeParticipationEvent extends ChallengeEvent {
+    private final ChallengeParticipationEventType eventType;
+    private final ChallengeParticipation participation;
+
+    public ChallengeParticipationEvent(Challenge challenge, ChallengeParticipationEventType eventType, ChallengeParticipation participation) {
+        super(challenge);
+        this.eventType = eventType;
+        this.participation = participation;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeStatusEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeStatusEvent.java
@@ -1,0 +1,15 @@
+package com.trybe.moduleapi.challenge.event.model;
+
+import com.trybe.moduleapi.challenge.event.type.ChallengeStatusEventType;
+import com.trybe.modulecore.challenge.entity.Challenge;
+import lombok.Getter;
+
+@Getter
+public class ChallengeStatusEvent extends ChallengeEvent {
+    private final ChallengeStatusEventType eventType;
+
+    public ChallengeStatusEvent(Challenge challenge, ChallengeStatusEventType eventType) {
+        super(challenge);
+        this.eventType = eventType;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeStatusEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/model/ChallengeStatusEvent.java
@@ -2,14 +2,19 @@ package com.trybe.moduleapi.challenge.event.model;
 
 import com.trybe.moduleapi.challenge.event.type.ChallengeStatusEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.user.entity.User;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class ChallengeStatusEvent extends ChallengeEvent {
     private final ChallengeStatusEventType eventType;
+    private final List<User> participants;
 
-    public ChallengeStatusEvent(Challenge challenge, ChallengeStatusEventType eventType) {
+    public ChallengeStatusEvent(Challenge challenge, ChallengeStatusEventType eventType, List<User> participants) {
         super(challenge);
         this.eventType = eventType;
+        this.participants = participants;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/pub/ChallengeApplicationEventPublisher.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/pub/ChallengeApplicationEventPublisher.java
@@ -1,6 +1,6 @@
 package com.trybe.moduleapi.challenge.event.pub;
 
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/pub/ChallengeEventPublisher.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/pub/ChallengeEventPublisher.java
@@ -1,6 +1,6 @@
 package com.trybe.moduleapi.challenge.event.pub;
 
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 
 public interface ChallengeEventPublisher {
     void publish(ChallengeEvent event);

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeActionEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeActionEventType.java
@@ -3,19 +3,18 @@ package com.trybe.moduleapi.challenge.event.type;
 import lombok.Getter;
 
 @Getter
-public enum ChallengeEventType {
+public enum ChallengeActionEventType {
     CREATE(ChallengeScoreType.CREATE, true),
     VIEW(ChallengeScoreType.VIEW, true),
     BOOKMARK_ADD(ChallengeScoreType.BOOKMARK, true),
     BOOKMARK_REMOVE(ChallengeScoreType.BOOKMARK, false),
-    PARTICIPATION_ADD(ChallengeScoreType.PARTICIPATION, true),
-    PARTICIPATION_REMOVE(ChallengeScoreType.PARTICIPATION, false);
+    ;
 
-    private final ChallengeScoreType actionType;
+    private final ChallengeScoreType scoreType;
     private final boolean isScoreUp;
 
-    ChallengeEventType(ChallengeScoreType actionType, boolean isScoreUp) {
-        this.actionType = actionType;
+    ChallengeActionEventType(ChallengeScoreType scoreType, boolean isScoreUp) {
+        this.scoreType = scoreType;
         this.isScoreUp = isScoreUp;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeActionType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeActionType.java
@@ -1,4 +1,4 @@
-package com.trybe.moduleapi.challenge.event;
+package com.trybe.moduleapi.challenge.event.type;
 
 import lombok.Getter;
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeEventType.java
@@ -4,17 +4,17 @@ import lombok.Getter;
 
 @Getter
 public enum ChallengeEventType {
-    CREATE(ChallengeActionType.CREATE, true),
-    VIEW(ChallengeActionType.VIEW, true),
-    BOOKMARK_ADD(ChallengeActionType.BOOKMARK, true),
-    BOOKMARK_REMOVE(ChallengeActionType.BOOKMARK, false),
-    PARTICIPATION_ADD(ChallengeActionType.PARTICIPATION, true),
-    PARTICIPATION_REMOVE(ChallengeActionType.PARTICIPATION, false);
+    CREATE(ChallengeScoreType.CREATE, true),
+    VIEW(ChallengeScoreType.VIEW, true),
+    BOOKMARK_ADD(ChallengeScoreType.BOOKMARK, true),
+    BOOKMARK_REMOVE(ChallengeScoreType.BOOKMARK, false),
+    PARTICIPATION_ADD(ChallengeScoreType.PARTICIPATION, true),
+    PARTICIPATION_REMOVE(ChallengeScoreType.PARTICIPATION, false);
 
-    private final ChallengeActionType actionType;
+    private final ChallengeScoreType actionType;
     private final boolean isScoreUp;
 
-    ChallengeEventType(ChallengeActionType actionType, boolean isScoreUp) {
+    ChallengeEventType(ChallengeScoreType actionType, boolean isScoreUp) {
         this.actionType = actionType;
         this.isScoreUp = isScoreUp;
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeEventType.java
@@ -1,4 +1,4 @@
-package com.trybe.moduleapi.challenge.event;
+package com.trybe.moduleapi.challenge.event.type;
 
 import lombok.Getter;
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeParticipationEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeParticipationEventType.java
@@ -6,8 +6,7 @@ import lombok.Getter;
 public enum ChallengeParticipationEventType {
     PARTICIPATION_ADD(ChallengeScoreType.PARTICIPATION, true),
     PARTICIPATION_REMOVE(ChallengeScoreType.PARTICIPATION, false),
-    PARTICIPATION_REQUEST(null, null),
-    PARTICIPATION_REQUEST_PROCESSED(null, null)
+    PARTICIPATION_PROCESSED(null, null)
     ;
 
     private final ChallengeScoreType scoreType;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeParticipationEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeParticipationEventType.java
@@ -1,0 +1,20 @@
+package com.trybe.moduleapi.challenge.event.type;
+
+import lombok.Getter;
+
+@Getter
+public enum ChallengeParticipationEventType {
+    PARTICIPATION_ADD(ChallengeScoreType.PARTICIPATION, true),
+    PARTICIPATION_REMOVE(ChallengeScoreType.PARTICIPATION, false),
+    PARTICIPATION_REQUEST(null, null),
+    PARTICIPATION_REQUEST_PROCESSED(null, null)
+    ;
+
+    private final ChallengeScoreType scoreType;
+    private final Boolean isScoreUp;
+
+    ChallengeParticipationEventType(ChallengeScoreType scoreType, Boolean isScoreUp) {
+        this.scoreType = scoreType;
+        this.isScoreUp = isScoreUp;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeScoreType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeScoreType.java
@@ -3,7 +3,7 @@ package com.trybe.moduleapi.challenge.event.type;
 import lombok.Getter;
 
 @Getter
-public enum ChallengeActionType {
+public enum ChallengeScoreType {
     CREATE(0, 10),
     VIEW(1, 1),
     BOOKMARK(10, 10),
@@ -12,7 +12,7 @@ public enum ChallengeActionType {
     private final int popularityScore;
     private final int preferenceScore;
 
-    ChallengeActionType(int popularityScore, int preferenceScore) {
+    ChallengeScoreType(int popularityScore, int preferenceScore) {
         this.popularityScore = popularityScore;
         this.preferenceScore = preferenceScore;
     }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeStatusEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/event/type/ChallengeStatusEventType.java
@@ -1,0 +1,6 @@
+package com.trybe.moduleapi.challenge.event.type;
+
+public enum ChallengeStatusEventType {
+    START,
+    END,
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -2,9 +2,9 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
-import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.model.ChallengeActionEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
+import com.trybe.moduleapi.challenge.event.type.ChallengeActionEventType;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.modulecore.challenge.entity.Challenge;
@@ -43,7 +43,7 @@ public class ChallengeBookmarkService {
 
         if (!challengeBookmarkCache.isBookmarked(userId, challengeId)) {
             challengeBookmarkCache.addBookmark(userId, challengeId);
-            challengeEventPublisher.publish(new ChallengeEvent(challenge, userId, ChallengeEventType.BOOKMARK_ADD));
+            challengeEventPublisher.publish(new ChallengeActionEvent(challenge, ChallengeActionEventType.BOOKMARK_ADD, userId));
             count++;
         }
 
@@ -59,7 +59,7 @@ public class ChallengeBookmarkService {
 
         if (challengeBookmarkCache.isBookmarked(userId, challengeId)) {
             challengeBookmarkCache.removeBookmark(userId, challengeId);
-            challengeEventPublisher.publish(new ChallengeEvent(challenge, userId, ChallengeEventType.BOOKMARK_REMOVE));
+            challengeEventPublisher.publish(new ChallengeActionEvent(challenge, ChallengeActionEventType.BOOKMARK_REMOVE, userId));
             count--;
         }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -3,7 +3,7 @@ package com.trybe.moduleapi.challenge.service;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
 import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.common.dto.PageResponse;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkService.java
@@ -2,7 +2,7 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -1,9 +1,9 @@
 package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
-import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.model.ChallengeParticipationEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
+import com.trybe.moduleapi.challenge.event.type.ChallengeParticipationEventType;
 import com.trybe.moduleapi.challenge.exception.*;
 import com.trybe.moduleapi.challenge.exception.participation.*;
 import com.trybe.moduleapi.chat.service.ChatService;
@@ -49,7 +49,8 @@ public class ChallengeParticipationService {
 
         ChallengeParticipation savedParticipation = challengeParticipationRepository.save(
                 new ChallengeParticipation(user, challenge, ChallengeRole.MEMBER, ParticipationStatus.PENDING));
-        challengeEventPublisher.publish(new ChallengeEvent(challenge, userId, ChallengeEventType.PARTICIPATION_ADD));
+
+        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_ADD, savedParticipation));
 
         return ChallengeParticipationResponse.Detail.from(savedParticipation);
     }
@@ -103,12 +104,13 @@ public class ChallengeParticipationService {
     @Transactional
     public void cancel(User user, Long participationId) {
         ChallengeParticipation participation = getParticipation(participationId);
+        Challenge challenge = participation.getChallenge();
         Long userId = user.getId();
 
         validateParticipationUser(participation, userId);
         validateParticipationStatus(participation, ParticipationStatus.PENDING);
 
-        challengeEventPublisher.publish(new ChallengeEvent(participation.getChallenge(), userId, ChallengeEventType.PARTICIPATION_REMOVE));
+        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_REMOVE, participation));
         challengeParticipationRepository.delete(participation);
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -1,7 +1,7 @@
 package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.*;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -79,15 +79,19 @@ public class ChallengeParticipationService {
     @Transactional
     public ChallengeParticipationResponse.Detail confirm(User user, Long participationId, ParticipationStatus status) {
         ChallengeParticipation participation = getParticipation(participationId);
-        ChallengeParticipation userParticipation = getParticipation(user.getId(), participation.getChallenge().getId());
+        Challenge challenge = participation.getChallenge();
+
+        ChallengeParticipation userParticipation = getParticipation(user.getId(), challenge.getId());
 
         validateRole(userParticipation, ChallengeRole.LEADER, "리더만 참여자를 처리할 수 있습니다.");
-        validateChallengeStatus(participation.getChallenge(), "챌린지가 진행 예정인 경우에만 참여 신청을 처리할 수 있습니다.");
-        validateChallengeCapacity(participation.getChallenge());
+        validateChallengeStatus(challenge, "챌린지가 진행 예정인 경우에만 참여 신청을 처리할 수 있습니다.");
+        validateChallengeCapacity(challenge);
         validateStatus(participation, status);
 
         participation.updateStatus(status);
-        chatService.enter(participation.getUser(), participation.getChallenge().getId());
+        chatService.enter(participation.getUser(), challenge.getId());
+        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_PROCESSED, participation));
+
         return ChallengeParticipationResponse.Detail.from(participation);
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -50,7 +50,7 @@ public class ChallengeParticipationService {
         ChallengeParticipation savedParticipation = challengeParticipationRepository.save(
                 new ChallengeParticipation(user, challenge, ChallengeRole.MEMBER, ParticipationStatus.PENDING));
 
-        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_ADD, savedParticipation));
+        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_ADD, savedParticipation, getLeader(challengeId)));
 
         return ChallengeParticipationResponse.Detail.from(savedParticipation);
     }
@@ -90,7 +90,7 @@ public class ChallengeParticipationService {
 
         participation.updateStatus(status);
         chatService.enter(participation.getUser(), challenge.getId());
-        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_PROCESSED, participation));
+        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_PROCESSED, participation, null));
 
         return ChallengeParticipationResponse.Detail.from(participation);
     }
@@ -114,7 +114,7 @@ public class ChallengeParticipationService {
         validateParticipationUser(participation, userId);
         validateParticipationStatus(participation, ParticipationStatus.PENDING);
 
-        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_REMOVE, participation));
+        challengeEventPublisher.publish(new ChallengeParticipationEvent(challenge, ChallengeParticipationEventType.PARTICIPATION_REMOVE, participation, null));
         challengeParticipationRepository.delete(participation);
     }
 
@@ -131,6 +131,12 @@ public class ChallengeParticipationService {
     private ChallengeParticipation getParticipation(Long userId, Long challengeId) {
         return challengeParticipationRepository.findByUserIdAndChallengeId(userId, challengeId)
                 .orElseThrow(() -> new NotFoundChallengeParticipationException("존재하지 않는 챌린지 참여입니다."));
+    }
+
+    private User getLeader(Long challengeId) {
+        return challengeParticipationRepository.findByChallengeIdAndRole(challengeId, ChallengeRole.LEADER)
+                .orElseThrow(() -> new NotFoundChallengeParticipationException("챌린지 리더 참여 정보가 없습니다."))
+                .getUser();
     }
 
     private void validateRole(ChallengeParticipation participation, ChallengeRole requiredRole, String message) {

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationService.java
@@ -2,7 +2,7 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
 import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.*;
 import com.trybe.moduleapi.challenge.exception.participation.*;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
@@ -5,8 +5,12 @@ import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.event.type.ChallengeStatusEventType;
 import com.trybe.moduleapi.chat.service.ChatService;
 import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
+import com.trybe.modulecore.user.entity.User;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,11 +21,13 @@ import java.util.List;
 @Service
 public class ChallengeScheduler {
     private final ChallengeRepository challengeRepository;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
     private final ChatService chatService;
     private final ChallengeEventPublisher challengeEventPublisher;
 
-    public ChallengeScheduler(ChallengeRepository challengeRepository, ChatService chatService, ChallengeEventPublisher challengeEventPublisher) {
+    public ChallengeScheduler(ChallengeRepository challengeRepository, ChallengeParticipationRepository challengeParticipationRepository, ChatService chatService, ChallengeEventPublisher challengeEventPublisher) {
         this.challengeRepository = challengeRepository;
+        this.challengeParticipationRepository = challengeParticipationRepository;
         this.chatService = chatService;
         this.challengeEventPublisher = challengeEventPublisher;
     }
@@ -32,9 +38,11 @@ public class ChallengeScheduler {
         List<Challenge> challenges = challengeRepository.findAllByStatusAndStartDate(ChallengeStatus.PENDING, LocalDate.now());
 
         challenges.forEach(challenge -> {
+            List<User> participants = getParticipants(challenge.getId());
+
             challenge.updateStatus(ChallengeStatus.ONGOING);
             chatService.challengeStartMessage(challenge);
-            challengeEventPublisher.publish(new ChallengeStatusEvent(challenge, ChallengeStatusEventType.START));
+            challengeEventPublisher.publish(new ChallengeStatusEvent(challenge, ChallengeStatusEventType.START, participants));
         });
     }
 
@@ -43,9 +51,18 @@ public class ChallengeScheduler {
     public void updateChallengeStatusDone() {
         List<Challenge> challenges = challengeRepository.findAllByStatusAndEndDate(ChallengeStatus.ONGOING, LocalDate.now());
         challenges.forEach(challenge -> {
+            List<User> participants = getParticipants(challenge.getId());
+
             challenge.updateStatus(ChallengeStatus.DONE);
             chatService.challengeClosedMessage(challenge);
-            challengeEventPublisher.publish(new ChallengeStatusEvent(challenge, ChallengeStatusEventType.END));
+            challengeEventPublisher.publish(new ChallengeStatusEvent(challenge, ChallengeStatusEventType.END, participants));
         });
+    }
+
+    private List<User> getParticipants(Long challengeId) {
+        return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
+                .stream()
+                .map(ChallengeParticipation::getUser)
+                .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
@@ -63,6 +63,7 @@ public class ChallengeScheduler {
         return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
                 .stream()
                 .map(ChallengeParticipation::getUser)
+                .peek(User::getUuid)
                 .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeScheduler.java
@@ -1,5 +1,8 @@
 package com.trybe.moduleapi.challenge.service;
 
+import com.trybe.moduleapi.challenge.event.model.ChallengeStatusEvent;
+import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
+import com.trybe.moduleapi.challenge.event.type.ChallengeStatusEventType;
 import com.trybe.moduleapi.chat.service.ChatService;
 import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.enums.ChallengeStatus;
@@ -15,19 +18,23 @@ import java.util.List;
 public class ChallengeScheduler {
     private final ChallengeRepository challengeRepository;
     private final ChatService chatService;
+    private final ChallengeEventPublisher challengeEventPublisher;
 
-    public ChallengeScheduler(ChallengeRepository challengeRepository, ChatService chatService) {
+    public ChallengeScheduler(ChallengeRepository challengeRepository, ChatService chatService, ChallengeEventPublisher challengeEventPublisher) {
         this.challengeRepository = challengeRepository;
         this.chatService = chatService;
+        this.challengeEventPublisher = challengeEventPublisher;
     }
 
-    @Scheduled(cron = "0 4 * * * *")
+    @Scheduled(cron = " 0 0 4 * * *")
     @Transactional
     public void updateChallengeStatusOnGoing() {
         List<Challenge> challenges = challengeRepository.findAllByStatusAndStartDate(ChallengeStatus.PENDING, LocalDate.now());
+
         challenges.forEach(challenge -> {
             challenge.updateStatus(ChallengeStatus.ONGOING);
             chatService.challengeStartMessage(challenge);
+            challengeEventPublisher.publish(new ChallengeStatusEvent(challenge, ChallengeStatusEventType.START));
         });
     }
 
@@ -38,6 +45,7 @@ public class ChallengeScheduler {
         challenges.forEach(challenge -> {
             challenge.updateStatus(ChallengeStatus.DONE);
             chatService.challengeClosedMessage(challenge);
+            challengeEventPublisher.publish(new ChallengeStatusEvent(challenge, ChallengeStatusEventType.END));
         });
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -3,7 +3,7 @@ package com.trybe.moduleapi.challenge.service;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -3,9 +3,9 @@ package com.trybe.moduleapi.challenge.service;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
-import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.model.ChallengeActionEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
+import com.trybe.moduleapi.challenge.event.type.ChallengeActionEventType;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.exception.participation.InvalidChallengeRoleActionException;
@@ -72,7 +72,7 @@ public class ChallengeService {
 
         challenge.updateThumbnail(thumbnailFile);
         challengeParticipationRepository.save(participation);
-        challengeEventPublisher.publish(new ChallengeEvent(savedChallenge, user.getId(), ChallengeEventType.CREATE));
+        challengeEventPublisher.publish(new ChallengeActionEvent(savedChallenge, ChallengeActionEventType.CREATE, user.getId()));
         chatService.create(savedChallenge);
 
         return challengeResponseAssembler.toInitialDetail(savedChallenge);
@@ -193,7 +193,7 @@ public class ChallengeService {
         Long challengeId = challenge.getId();
         if (userId != null && !challengeViewCache.hasViewed(userId, challengeId)) {
             challengeViewCache.recordView(userId, challengeId);
-            challengeEventPublisher.publish(new ChallengeEvent(challenge, userId, ChallengeEventType.VIEW));
+            challengeEventPublisher.publish(new ChallengeActionEvent(challenge, ChallengeActionEventType.VIEW, userId));
         }
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/challenge/service/ChallengeService.java
@@ -4,7 +4,7 @@ import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
 import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
-import com.trybe.moduleapi.challenge.event.ChallengeEventType;
+import com.trybe.moduleapi.challenge.event.type.ChallengeEventType;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;

--- a/module-api/src/main/java/com/trybe/moduleapi/notification/constants/NotificationTopics.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/notification/constants/NotificationTopics.java
@@ -3,4 +3,5 @@ package com.trybe.moduleapi.notification.constants;
 public class NotificationTopics {
     public static final String CHALLENGE = "Challenge_Notification";
     public static final String CHALLENGE_PROOF = "Challenge_Proof_Notification";
+    public static final String CHALLENGE_PROOF_HISTORY = "Challenge_Proof_History_Notification";
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/notification/constants/NotificationTopics.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/notification/constants/NotificationTopics.java
@@ -1,0 +1,6 @@
+package com.trybe.moduleapi.notification.constants;
+
+public class NotificationTopics {
+    public static final String CHALLENGE = "Challenge_Notification";
+    public static final String CHALLENGE_PROOF = "Challenge_Proof_Notification";
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationProducerService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationProducerService.java
@@ -1,8 +1,15 @@
 package com.trybe.moduleapi.notification.service;
 
 import com.trybe.moduleapi.notification.dto.NotificationMessage;
+import com.trybe.modulecore.notification.entity.Notification;
+import com.trybe.modulecore.notification.enums.NotificationType;
+import com.trybe.modulecore.user.entity.User;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class NotificationProducerService {
@@ -12,5 +19,43 @@ public class NotificationProducerService {
     public NotificationProducerService(KafkaTemplate<String, NotificationMessage> kafkaTemplate, NotificationService notificationService) {
         this.kafkaTemplate = kafkaTemplate;
         this.notificationService = notificationService;
+    }
+
+    @Transactional
+    public void publishNotification(
+            String topic,
+            User receiver,
+            NotificationType type,
+            Long typeId,
+            String title,
+            String message
+    ) {
+        Notification notification = new Notification(receiver.getId(), type, typeId, title, message);
+        NotificationMessage notificationMessage = NotificationMessage.from(notification, receiver.getUuid());
+        
+        kafkaTemplate.send(topic, notificationMessage);
+        notificationService.save(notification);
+    }
+
+    @Transactional
+    public void publishNotifications(
+            String topic,
+            List<User> receivers,
+            NotificationType type,
+            Long typeId,
+            String title,
+            String message
+    ) {
+        List<Notification> notifications = new ArrayList<>();
+
+        for (User receiver : receivers) {
+            Notification notification = new Notification(receiver.getId(), type, typeId, title, message);
+            notifications.add(notification);
+
+            NotificationMessage notificationMessage = NotificationMessage.from(notification, receiver.getUuid());
+            kafkaTemplate.send(topic, notificationMessage);
+        }
+
+        notificationService.saveAll(notifications);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/notification/service/NotificationService.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 public class NotificationService {
     private final NotificationRepository notificationRepository;
@@ -25,6 +27,11 @@ public class NotificationService {
     @Transactional
     public Notification save(Notification notification) {
         return notificationRepository.save(notification);
+    }
+
+    @Transactional
+    public List<Notification> saveAll(List<Notification> notifications) {
+        return notificationRepository.saveAll(notifications);
     }
 
     @Transactional(readOnly = true)

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
@@ -1,0 +1,146 @@
+package com.trybe.moduleapi.proof.event.listener;
+
+import com.trybe.moduleapi.notification.constants.NotificationTopics;
+import com.trybe.moduleapi.notification.service.NotificationProducerService;
+import com.trybe.moduleapi.proof.event.model.ProofEvent;
+import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
+import com.trybe.moduleapi.proof.event.type.ProofEventType;
+import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
+import com.trybe.modulecore.challenge.entity.Challenge;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
+import com.trybe.modulecore.notification.enums.NotificationType;
+import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.user.entity.User;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Component
+public class ProofNotificationEventListener {
+    private final NotificationProducerService notificationProducerService;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
+
+    public ProofNotificationEventListener(NotificationProducerService notificationProducerService, ChallengeParticipationRepository challengeParticipationRepository) {
+        this.notificationProducerService = notificationProducerService;
+        this.challengeParticipationRepository = challengeParticipationRepository;
+    }
+
+    private static final String PROOF_START_TITLE = "인증이 시작되었습니다!";
+    private static final String PROOF_START_MESSAGE_FORMAT = "%s 챌린지의 %d번째 인증이 시작되었습니다.";
+
+    private static final String PROOF_END_TITLE = "인증이 종료되었습니다.";
+    private static final String PROOF_END_MESSAGE_FORMAT = "%s 챌린지의 인증이 종료되었습니다. 투표에 참여하세요!";
+
+    private static final String PROOF_HISTORY_CREATED_TITLE = "인증 기록이 등록되었습니다.";
+    private static final String PROOF_HISTORY_CREATED_MESSAGE_FORMAT = "%s 님이 %s 챌린지의 인증 기록을 등록했습니다.";
+
+    private static final String PROOF_HISTORY_VOTE_END_TITLE = "인증 기록 투표가 종료되었습니다.";
+    private static final String PROOF_HISTORY_VOTE_END_MESSAGE_FORMAT = "%s 챌린지의 인증 기록 투표가 종료되었습니다. 투표 결과를 확인하세요!";
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProofEvent(ProofEvent event) {
+        Proof proof = event.getProof();
+        ProofEventType type = event.getEventType();
+
+        switch (type) {
+            case START -> notifyProofStart(proof);
+            case END -> notifyProofEnd(proof);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProofHistoryEvent(ProofHistoryEvent event) {
+        ProofHistory proofHistory = event.getProofHistory();
+        ProofHistoryEventType type = event.getEventType();
+
+        switch (type) {
+            case CREATED -> notifyProofHistoryCreated(proofHistory);
+            case VOTE_END -> notifyProofHistoryVoteEnd(proofHistory);
+        }
+    }
+
+    private void notifyProofStart(Proof proof) {
+        Challenge challenge = proof.getChallenge();
+        List<User> participants = getParticipants(challenge.getId());
+
+        String message = String.format(PROOF_START_MESSAGE_FORMAT, challenge.getTitle(), proof.getRound());
+
+        notificationProducerService.publishNotifications(
+                NotificationTopics.CHALLENGE_PROOF,
+                participants,
+                NotificationType.PROOF,
+                proof.getId(),
+                PROOF_START_TITLE,
+                message
+        );
+    }
+
+    private void notifyProofEnd(Proof proof) {
+        Challenge challenge = proof.getChallenge();
+        List<User> participants = getParticipants(challenge.getId());
+
+        String message = String.format(PROOF_END_MESSAGE_FORMAT, challenge.getTitle());
+
+        notificationProducerService.publishNotifications(
+                NotificationTopics.CHALLENGE_PROOF,
+                participants,
+                NotificationType.PROOF,
+                proof.getId(),
+                PROOF_END_TITLE,
+                message
+        );
+    }
+
+    private void notifyProofHistoryCreated(ProofHistory proofHistory) {
+        Proof proof = proofHistory.getProof();
+        Challenge challenge = proof.getChallenge();
+        User writer = proofHistory.getUser();
+
+        List<User> receivers = getParticipants(challenge.getId()).stream()
+                .filter(user -> user.getId().equals(writer.getId()))
+                .toList();
+
+        String message = String.format(PROOF_HISTORY_CREATED_MESSAGE_FORMAT, writer.getNickname(), challenge.getTitle());
+
+        notificationProducerService.publishNotifications(
+                NotificationTopics.CHALLENGE_PROOF_HISTORY,
+                receivers,
+                NotificationType.PROOF_HISTORY,
+                proof.getId(),
+                PROOF_HISTORY_CREATED_TITLE,
+                message
+        );
+    }
+
+    private void notifyProofHistoryVoteEnd(ProofHistory proofHistory) {
+        Proof proof = proofHistory.getProof();
+        Challenge challenge = proof.getChallenge();
+        User writer = proofHistory.getUser();
+
+        String message = String.format(PROOF_HISTORY_VOTE_END_MESSAGE_FORMAT, challenge.getTitle());
+
+        notificationProducerService.publishNotification(
+                NotificationTopics.CHALLENGE_PROOF_HISTORY,
+                writer,
+                NotificationType.PROOF_HISTORY,
+                proof.getId(),
+                PROOF_HISTORY_VOTE_END_TITLE,
+                message
+        );
+    }
+
+    private List<User> getParticipants(Long challengeId) {
+        return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
+                .stream()
+                .map(ChallengeParticipation::getUser)
+                .toList();
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
@@ -41,13 +41,14 @@ public class ProofNotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleProofEvent(ProofEvent event) {
-        Proof proof = event.getProof();
-        ProofEventType type = event.getEventType();
-        List<User> participants = event.getParticipants();
+        Proof proof = event.proof();
+        ProofEventType type = event.eventType();
+        String challengeTitle = event.challengeTitle();
+        List<User> participants = event.participants();
 
         switch (type) {
-            case START -> notifyProofStart(proof, participants);
-            case END -> notifyProofEnd(proof, participants);
+            case START -> notifyProofStart(proof, challengeTitle, participants);
+            case END -> notifyProofEnd(proof, challengeTitle, participants);
         }
     }
 
@@ -64,9 +65,8 @@ public class ProofNotificationEventListener {
         }
     }
 
-    private void notifyProofStart(Proof proof, List<User> participants) {
-        Challenge challenge = proof.getChallenge();
-        String message = String.format(PROOF_START_MESSAGE_FORMAT, challenge.getTitle(), proof.getRound());
+    private void notifyProofStart(Proof proof, String challengeTitle, List<User> participants) {
+        String message = String.format(PROOF_START_MESSAGE_FORMAT, challengeTitle, proof.getRound());
 
         notificationProducerService.publishNotifications(
                 NotificationTopics.CHALLENGE_PROOF,
@@ -78,9 +78,8 @@ public class ProofNotificationEventListener {
         );
     }
 
-    private void notifyProofEnd(Proof proof, List<User> participants) {
-        Challenge challenge = proof.getChallenge();
-        String message = String.format(PROOF_END_MESSAGE_FORMAT, challenge.getTitle());
+    private void notifyProofEnd(Proof proof, String challengeTitle, List<User> participants) {
+        String message = String.format(PROOF_END_MESSAGE_FORMAT, challengeTitle);
 
         notificationProducerService.publishNotifications(
                 NotificationTopics.CHALLENGE_PROOF,

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
@@ -27,16 +27,16 @@ public class ProofNotificationEventListener {
     }
 
     private static final String PROOF_START_TITLE = "인증이 시작되었습니다!";
-    private static final String PROOF_START_MESSAGE_FORMAT = "%s 챌린지의 %d번째 인증이 시작되었습니다.";
+    private static final String PROOF_START_MESSAGE_FORMAT = "[%s] 챌린지의 %d번째 인증이 시작되었습니다.";
 
     private static final String PROOF_END_TITLE = "인증이 종료되었습니다.";
-    private static final String PROOF_END_MESSAGE_FORMAT = "%s 챌린지의 인증이 종료되었습니다. 투표에 참여하세요!";
+    private static final String PROOF_END_MESSAGE_FORMAT = "[%s] 챌린지의 인증이 종료되었습니다. 투표에 참여하세요!";
 
     private static final String PROOF_HISTORY_CREATED_TITLE = "인증 기록이 등록되었습니다.";
-    private static final String PROOF_HISTORY_CREATED_MESSAGE_FORMAT = "%s 님이 %s 챌린지의 인증 기록을 등록했습니다.";
+    private static final String PROOF_HISTORY_CREATED_MESSAGE_FORMAT = "%s 님이 [%s] 챌린지의 인증 기록을 등록했습니다.";
 
     private static final String PROOF_HISTORY_VOTE_END_TITLE = "인증 기록 투표가 종료되었습니다.";
-    private static final String PROOF_HISTORY_VOTE_END_MESSAGE_FORMAT = "%s 챌린지의 인증 기록 투표가 종료되었습니다. 투표 결과를 확인하세요!";
+    private static final String PROOF_HISTORY_VOTE_END_MESSAGE_FORMAT = "[%s] 챌린지의 인증 기록 투표가 종료되었습니다. 투표 결과를 확인하세요!";
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
@@ -6,7 +6,6 @@ import com.trybe.moduleapi.proof.event.model.ProofEvent;
 import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
 import com.trybe.moduleapi.proof.event.type.ProofEventType;
 import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
-import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.notification.enums.NotificationType;
 import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
@@ -41,8 +40,8 @@ public class ProofNotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleProofEvent(ProofEvent event) {
-        Proof proof = event.proof();
         ProofEventType type = event.eventType();
+        Proof proof = event.proof();
         String challengeTitle = event.challengeTitle();
         List<User> participants = event.participants();
 
@@ -55,13 +54,14 @@ public class ProofNotificationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleProofHistoryEvent(ProofHistoryEvent event) {
-        ProofHistory proofHistory = event.getProofHistory();
-        ProofHistoryEventType type = event.getEventType();
-        List<User> participants = event.getParticipants();
+        ProofHistoryEventType type = event.eventType();
+        ProofHistory proofHistory = event.proofHistory();
+        String challengeTitle = event.challengeTitle();
+        List<User> participants = event.participants();
 
         switch (type) {
-            case CREATED -> notifyProofHistoryCreated(proofHistory, participants);
-            case VOTE_END -> notifyProofHistoryVoteEnd(proofHistory);
+            case CREATED -> notifyProofHistoryCreated(proofHistory, challengeTitle, participants);
+            case VOTE_END -> notifyProofHistoryVoteEnd(proofHistory, challengeTitle);
         }
     }
 
@@ -91,16 +91,15 @@ public class ProofNotificationEventListener {
         );
     }
 
-    private void notifyProofHistoryCreated(ProofHistory proofHistory, List<User> participants) {
+    private void notifyProofHistoryCreated(ProofHistory proofHistory, String challengeTitle, List<User> participants) {
         Proof proof = proofHistory.getProof();
-        Challenge challenge = proof.getChallenge();
         User writer = proofHistory.getUser();
 
         List<User> receivers = participants.stream()
                 .filter(user -> user.getId().equals(writer.getId()))
                 .toList();
 
-        String message = String.format(PROOF_HISTORY_CREATED_MESSAGE_FORMAT, writer.getNickname(), challenge.getTitle());
+        String message = String.format(PROOF_HISTORY_CREATED_MESSAGE_FORMAT, writer.getNickname(), challengeTitle);
 
         notificationProducerService.publishNotifications(
                 NotificationTopics.CHALLENGE_PROOF_HISTORY,
@@ -112,12 +111,11 @@ public class ProofNotificationEventListener {
         );
     }
 
-    private void notifyProofHistoryVoteEnd(ProofHistory proofHistory) {
+    private void notifyProofHistoryVoteEnd(ProofHistory proofHistory, String challengeTitle) {
         Proof proof = proofHistory.getProof();
-        Challenge challenge = proof.getChallenge();
         User writer = proofHistory.getUser();
 
-        String message = String.format(PROOF_HISTORY_VOTE_END_MESSAGE_FORMAT, challenge.getTitle());
+        String message = String.format(PROOF_HISTORY_VOTE_END_MESSAGE_FORMAT, challengeTitle);
 
         notificationProducerService.publishNotification(
                 NotificationTopics.CHALLENGE_PROOF_HISTORY,

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/listener/ProofNotificationEventListener.java
@@ -7,9 +7,6 @@ import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
 import com.trybe.moduleapi.proof.event.type.ProofEventType;
 import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
 import com.trybe.modulecore.challenge.entity.Challenge;
-import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
-import com.trybe.modulecore.challenge.enums.ParticipationStatus;
-import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.notification.enums.NotificationType;
 import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.entity.ProofHistory;
@@ -24,11 +21,9 @@ import java.util.List;
 @Component
 public class ProofNotificationEventListener {
     private final NotificationProducerService notificationProducerService;
-    private final ChallengeParticipationRepository challengeParticipationRepository;
 
-    public ProofNotificationEventListener(NotificationProducerService notificationProducerService, ChallengeParticipationRepository challengeParticipationRepository) {
+    public ProofNotificationEventListener(NotificationProducerService notificationProducerService) {
         this.notificationProducerService = notificationProducerService;
-        this.challengeParticipationRepository = challengeParticipationRepository;
     }
 
     private static final String PROOF_START_TITLE = "인증이 시작되었습니다!";
@@ -48,10 +43,11 @@ public class ProofNotificationEventListener {
     public void handleProofEvent(ProofEvent event) {
         Proof proof = event.getProof();
         ProofEventType type = event.getEventType();
+        List<User> participants = event.getParticipants();
 
         switch (type) {
-            case START -> notifyProofStart(proof);
-            case END -> notifyProofEnd(proof);
+            case START -> notifyProofStart(proof, participants);
+            case END -> notifyProofEnd(proof, participants);
         }
     }
 
@@ -60,17 +56,16 @@ public class ProofNotificationEventListener {
     public void handleProofHistoryEvent(ProofHistoryEvent event) {
         ProofHistory proofHistory = event.getProofHistory();
         ProofHistoryEventType type = event.getEventType();
+        List<User> participants = event.getParticipants();
 
         switch (type) {
-            case CREATED -> notifyProofHistoryCreated(proofHistory);
+            case CREATED -> notifyProofHistoryCreated(proofHistory, participants);
             case VOTE_END -> notifyProofHistoryVoteEnd(proofHistory);
         }
     }
 
-    private void notifyProofStart(Proof proof) {
+    private void notifyProofStart(Proof proof, List<User> participants) {
         Challenge challenge = proof.getChallenge();
-        List<User> participants = getParticipants(challenge.getId());
-
         String message = String.format(PROOF_START_MESSAGE_FORMAT, challenge.getTitle(), proof.getRound());
 
         notificationProducerService.publishNotifications(
@@ -83,10 +78,8 @@ public class ProofNotificationEventListener {
         );
     }
 
-    private void notifyProofEnd(Proof proof) {
+    private void notifyProofEnd(Proof proof, List<User> participants) {
         Challenge challenge = proof.getChallenge();
-        List<User> participants = getParticipants(challenge.getId());
-
         String message = String.format(PROOF_END_MESSAGE_FORMAT, challenge.getTitle());
 
         notificationProducerService.publishNotifications(
@@ -99,12 +92,12 @@ public class ProofNotificationEventListener {
         );
     }
 
-    private void notifyProofHistoryCreated(ProofHistory proofHistory) {
+    private void notifyProofHistoryCreated(ProofHistory proofHistory, List<User> participants) {
         Proof proof = proofHistory.getProof();
         Challenge challenge = proof.getChallenge();
         User writer = proofHistory.getUser();
 
-        List<User> receivers = getParticipants(challenge.getId()).stream()
+        List<User> receivers = participants.stream()
                 .filter(user -> user.getId().equals(writer.getId()))
                 .toList();
 
@@ -135,12 +128,5 @@ public class ProofNotificationEventListener {
                 PROOF_HISTORY_VOTE_END_TITLE,
                 message
         );
-    }
-
-    private List<User> getParticipants(Long challengeId) {
-        return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
-                .stream()
-                .map(ChallengeParticipation::getUser)
-                .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofEvent.java
@@ -3,19 +3,11 @@ package com.trybe.moduleapi.proof.event.model;
 import com.trybe.moduleapi.proof.event.type.ProofEventType;
 import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.user.entity.User;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-public class ProofEvent {
-    private final Proof proof;
-    private final ProofEventType eventType;
-    private final List<User> participants;
-
-    public ProofEvent(Proof proof, ProofEventType eventType, List<User> participants) {
-        this.proof = proof;
-        this.eventType = eventType;
-        this.participants = participants;
+public record ProofEvent(ProofEventType eventType, Proof proof, String challengeTitle, List<User> participants) {
+    public static ProofEvent from(ProofEventType eventType, Proof proof, List<User> participants) {
+        return new ProofEvent(eventType, proof, proof.getChallenge().getTitle(), participants);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofEvent.java
@@ -1,0 +1,16 @@
+package com.trybe.moduleapi.proof.event.model;
+
+import com.trybe.moduleapi.proof.event.type.ProofEventType;
+import com.trybe.modulecore.proof.entity.Proof;
+import lombok.Getter;
+
+@Getter
+public class ProofEvent {
+    private final Proof proof;
+    private final ProofEventType eventType;
+
+    public ProofEvent(Proof proof, ProofEventType eventType) {
+        this.proof = proof;
+        this.eventType = eventType;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofEvent.java
@@ -2,15 +2,20 @@ package com.trybe.moduleapi.proof.event.model;
 
 import com.trybe.moduleapi.proof.event.type.ProofEventType;
 import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.user.entity.User;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class ProofEvent {
     private final Proof proof;
     private final ProofEventType eventType;
+    private final List<User> participants;
 
-    public ProofEvent(Proof proof, ProofEventType eventType) {
+    public ProofEvent(Proof proof, ProofEventType eventType, List<User> participants) {
         this.proof = proof;
         this.eventType = eventType;
+        this.participants = participants;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofHistoryEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofHistoryEvent.java
@@ -1,0 +1,16 @@
+package com.trybe.moduleapi.proof.event.model;
+
+import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
+import com.trybe.modulecore.proof.entity.ProofHistory;
+import lombok.Getter;
+
+@Getter
+public class ProofHistoryEvent {
+    private final ProofHistory proofHistory;
+    private final ProofHistoryEventType eventType;
+
+    public ProofHistoryEvent(ProofHistory proofHistory, ProofHistoryEventType eventType) {
+        this.proofHistory = proofHistory;
+        this.eventType = eventType;
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofHistoryEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofHistoryEvent.java
@@ -2,15 +2,20 @@ package com.trybe.moduleapi.proof.event.model;
 
 import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
 import com.trybe.modulecore.proof.entity.ProofHistory;
+import com.trybe.modulecore.user.entity.User;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class ProofHistoryEvent {
     private final ProofHistory proofHistory;
     private final ProofHistoryEventType eventType;
+    private final List<User> participants;
 
-    public ProofHistoryEvent(ProofHistory proofHistory, ProofHistoryEventType eventType) {
+    public ProofHistoryEvent(ProofHistory proofHistory, ProofHistoryEventType eventType, List<User> participants) {
         this.proofHistory = proofHistory;
         this.eventType = eventType;
+        this.participants = participants;
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofHistoryEvent.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/model/ProofHistoryEvent.java
@@ -3,19 +3,11 @@ package com.trybe.moduleapi.proof.event.model;
 import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import com.trybe.modulecore.user.entity.User;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-public class ProofHistoryEvent {
-    private final ProofHistory proofHistory;
-    private final ProofHistoryEventType eventType;
-    private final List<User> participants;
-
-    public ProofHistoryEvent(ProofHistory proofHistory, ProofHistoryEventType eventType, List<User> participants) {
-        this.proofHistory = proofHistory;
-        this.eventType = eventType;
-        this.participants = participants;
+public record ProofHistoryEvent(ProofHistoryEventType eventType, ProofHistory proofHistory, String challengeTitle, List<User> participants) {
+    public static ProofHistoryEvent from(ProofHistoryEventType eventType, ProofHistory proofHistory, List<User> participants) {
+        return new ProofHistoryEvent(eventType, proofHistory, proofHistory.getProof().getChallenge().getTitle(), participants);
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/pub/ProofApplicationEventPublisher.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/pub/ProofApplicationEventPublisher.java
@@ -1,0 +1,25 @@
+package com.trybe.moduleapi.proof.event.pub;
+
+import com.trybe.moduleapi.proof.event.model.ProofEvent;
+import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProofApplicationEventPublisher implements ProofEventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public ProofApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    @Override
+    public void publish(ProofEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void publish(ProofHistoryEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/pub/ProofEventPublisher.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/pub/ProofEventPublisher.java
@@ -1,0 +1,9 @@
+package com.trybe.moduleapi.proof.event.pub;
+
+import com.trybe.moduleapi.proof.event.model.ProofEvent;
+import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
+
+public interface ProofEventPublisher {
+    void publish(ProofEvent event);
+    void publish(ProofHistoryEvent event);
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/type/ProofEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/type/ProofEventType.java
@@ -1,0 +1,6 @@
+package com.trybe.moduleapi.proof.event.type;
+
+public enum ProofEventType {
+    START,
+    END,
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/event/type/ProofHistoryEventType.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/event/type/ProofHistoryEventType.java
@@ -1,0 +1,6 @@
+package com.trybe.moduleapi.proof.event.type;
+
+public enum ProofHistoryEventType {
+    CREATED,
+    VOTE_END,
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
@@ -43,7 +43,7 @@ public class ProofHistoryScheduler {
             proofHistory.updateStatus(result ? ProofHistoryStatus.PASSED : ProofHistoryStatus.FAILED);
 
             List<User> participants = getParticipants(proofHistory.getProof().getChallenge().getId());
-            proofEventPublisher.publish(new ProofHistoryEvent(proofHistory, ProofHistoryEventType.VOTE_END, participants));
+            proofEventPublisher.publish(ProofHistoryEvent.from(ProofHistoryEventType.VOTE_END, proofHistory, participants));
         });
     }
 
@@ -58,6 +58,7 @@ public class ProofHistoryScheduler {
         return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
                 .stream()
                 .map(ChallengeParticipation::getUser)
+                .peek(User::getUuid)
                 .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
@@ -3,10 +3,14 @@ package com.trybe.moduleapi.proof.service;
 import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
 import com.trybe.moduleapi.proof.event.pub.ProofEventPublisher;
 import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
 import com.trybe.modulecore.proof.repository.vote.ProofHistoryVoteCache;
+import com.trybe.modulecore.user.entity.User;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,11 +21,13 @@ import java.util.List;
 @Service
 public class ProofHistoryScheduler {
     private final ProofHistoryRepository proofHistoryRepository;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
     private final ProofHistoryVoteCache proofHistoryVoteCache;
     private final ProofEventPublisher proofEventPublisher;
 
-    public ProofHistoryScheduler(ProofHistoryRepository proofHistoryRepository, ProofHistoryVoteCache proofHistoryVoteCache, ProofEventPublisher proofEventPublisher) {
+    public ProofHistoryScheduler(ProofHistoryRepository proofHistoryRepository, ChallengeParticipationRepository challengeParticipationRepository, ProofHistoryVoteCache proofHistoryVoteCache, ProofEventPublisher proofEventPublisher) {
         this.proofHistoryRepository = proofHistoryRepository;
+        this.challengeParticipationRepository = challengeParticipationRepository;
         this.proofHistoryVoteCache = proofHistoryVoteCache;
         this.proofEventPublisher = proofEventPublisher;
     }
@@ -35,7 +41,9 @@ public class ProofHistoryScheduler {
         proofHistories.forEach(proofHistory -> {
             boolean result = isApproved(proofHistory);
             proofHistory.updateStatus(result ? ProofHistoryStatus.PASSED : ProofHistoryStatus.FAILED);
-            proofEventPublisher.publish(new ProofHistoryEvent(proofHistory, ProofHistoryEventType.VOTE_END));
+
+            List<User> participants = getParticipants(proofHistory.getProof().getChallenge().getId());
+            proofEventPublisher.publish(new ProofHistoryEvent(proofHistory, ProofHistoryEventType.VOTE_END, participants));
         });
     }
 
@@ -44,5 +52,12 @@ public class ProofHistoryScheduler {
         int disapprovedCount = proofHistoryVoteCache.getVoteCount(proofHistory.getId(), false);
 
         return approvedCount >= disapprovedCount;
+    }
+
+    private List<User> getParticipants(Long challengeId) {
+        return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
+                .stream()
+                .map(ChallengeParticipation::getUser)
+                .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryScheduler.java
@@ -1,5 +1,8 @@
 package com.trybe.moduleapi.proof.service;
 
+import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
+import com.trybe.moduleapi.proof.event.pub.ProofEventPublisher;
+import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
 import com.trybe.modulecore.proof.entity.ProofHistory;
 import com.trybe.modulecore.proof.enums.ProofHistoryStatus;
 import com.trybe.modulecore.proof.repository.ProofHistoryRepository;
@@ -15,10 +18,12 @@ import java.util.List;
 public class ProofHistoryScheduler {
     private final ProofHistoryRepository proofHistoryRepository;
     private final ProofHistoryVoteCache proofHistoryVoteCache;
+    private final ProofEventPublisher proofEventPublisher;
 
-    public ProofHistoryScheduler(ProofHistoryRepository proofHistoryRepository, ProofHistoryVoteCache proofHistoryVoteCache) {
+    public ProofHistoryScheduler(ProofHistoryRepository proofHistoryRepository, ProofHistoryVoteCache proofHistoryVoteCache, ProofEventPublisher proofEventPublisher) {
         this.proofHistoryRepository = proofHistoryRepository;
         this.proofHistoryVoteCache = proofHistoryVoteCache;
+        this.proofEventPublisher = proofEventPublisher;
     }
 
     @Scheduled(cron = "0 0 0 * * *")
@@ -30,6 +35,7 @@ public class ProofHistoryScheduler {
         proofHistories.forEach(proofHistory -> {
             boolean result = isApproved(proofHistory);
             proofHistory.updateStatus(result ? ProofHistoryStatus.PASSED : ProofHistoryStatus.FAILED);
+            proofEventPublisher.publish(new ProofHistoryEvent(proofHistory, ProofHistoryEventType.VOTE_END));
         });
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -12,6 +12,7 @@ import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryExcepti
 import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
 import com.trybe.moduleapi.proof.exception.history.InvalidProofHistoryStatusException;
 import com.trybe.moduleapi.proof.exception.history.NotFoundProofHistoryException;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.proof.entity.Proof;
@@ -26,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 public class ProofHistoryService {
@@ -50,7 +52,8 @@ public class ProofHistoryService {
         validateDuplicateProofHistory(proof.getId(), user.getId());
 
         ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
-        proofEventPublisher.publish(new ProofHistoryEvent(savedProofHistory, ProofHistoryEventType.CREATED));
+        List<User> participants = getParticipants(proof.getChallenge().getId());
+        proofEventPublisher.publish(new ProofHistoryEvent(savedProofHistory, ProofHistoryEventType.CREATED, participants));
 
         return ProofHistoryResponse.Summary.from(savedProofHistory);
     }
@@ -124,5 +127,12 @@ public class ProofHistoryService {
         if (proofHistoryRepository.existsByProofIdAndUserId(proofId, userId)) {
             throw new DuplicatedProofHistoryException();
         }
+    }
+
+    private List<User> getParticipants(Long challengeId) {
+        return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
+                .stream()
+                .map(ChallengeParticipation::getUser)
+                .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -53,7 +53,7 @@ public class ProofHistoryService {
 
         ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
         List<User> participants = getParticipants(proof.getChallenge().getId());
-        proofEventPublisher.publish(new ProofHistoryEvent(savedProofHistory, ProofHistoryEventType.CREATED, participants));
+        proofEventPublisher.publish(ProofHistoryEvent.from(ProofHistoryEventType.CREATED, savedProofHistory, participants));
 
         return ProofHistoryResponse.Summary.from(savedProofHistory);
     }
@@ -133,6 +133,7 @@ public class ProofHistoryService {
         return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
                 .stream()
                 .map(ChallengeParticipation::getUser)
+                .peek(User::getUuid)
                 .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofHistoryService.java
@@ -4,6 +4,9 @@ import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipatio
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
+import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
+import com.trybe.moduleapi.proof.event.pub.ProofEventPublisher;
+import com.trybe.moduleapi.proof.event.type.ProofHistoryEventType;
 import com.trybe.moduleapi.proof.exception.*;
 import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryException;
 import com.trybe.moduleapi.proof.exception.history.ForbiddenProofHistoryException;
@@ -29,11 +32,13 @@ public class ProofHistoryService {
     private final ProofHistoryRepository proofHistoryRepository;
     private final ProofRepository proofRepository;
     private final ChallengeParticipationRepository challengeParticipationRepository;
+    private final ProofEventPublisher proofEventPublisher;
 
-    public ProofHistoryService(ProofHistoryRepository proofHistoryRepository, ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository) {
+    public ProofHistoryService(ProofHistoryRepository proofHistoryRepository, ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository, ProofEventPublisher proofEventPublisher) {
         this.proofHistoryRepository = proofHistoryRepository;
         this.proofRepository = proofRepository;
         this.challengeParticipationRepository = challengeParticipationRepository;
+        this.proofEventPublisher = proofEventPublisher;
     }
 
     @Transactional
@@ -45,6 +50,8 @@ public class ProofHistoryService {
         validateDuplicateProofHistory(proof.getId(), user.getId());
 
         ProofHistory savedProofHistory = proofHistoryRepository.save(request.toEntity(proof, user, request.content()));
+        proofEventPublisher.publish(new ProofHistoryEvent(savedProofHistory, ProofHistoryEventType.CREATED));
+
         return ProofHistoryResponse.Summary.from(savedProofHistory);
     }
 

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofScheduler.java
@@ -1,0 +1,43 @@
+package com.trybe.moduleapi.proof.service;
+
+import com.trybe.moduleapi.proof.event.model.ProofEvent;
+import com.trybe.moduleapi.proof.event.pub.ProofEventPublisher;
+import com.trybe.moduleapi.proof.event.type.ProofEventType;
+import com.trybe.modulecore.proof.entity.Proof;
+import com.trybe.modulecore.proof.repository.ProofRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class ProofScheduler {
+    private final ProofRepository proofRepository;
+    private final ProofEventPublisher proofEventPublisher;
+
+    public ProofScheduler(ProofRepository proofRepository, ProofEventPublisher proofEventPublisher) {
+        this.proofRepository = proofRepository;
+        this.proofEventPublisher = proofEventPublisher;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void notifyProofStart() {
+        LocalDate today = LocalDate.now();
+        List<Proof> proofs = proofRepository.findAllByDate(today);
+
+        for (Proof proof : proofs) {
+            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.START));
+        }
+    }
+
+    @Scheduled(cron = "0 59 23 * * *")
+    public void notifyProofEnd() {
+        LocalDate today = LocalDate.now();
+        List<Proof> proofs = proofRepository.findAllByDate(today);
+
+        for (Proof proof : proofs) {
+            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.END));
+        }
+    }
+}

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofScheduler.java
@@ -3,6 +3,7 @@ package com.trybe.moduleapi.proof.service;
 import com.trybe.moduleapi.proof.event.model.ProofEvent;
 import com.trybe.moduleapi.proof.event.pub.ProofEventPublisher;
 import com.trybe.moduleapi.proof.event.type.ProofEventType;
+import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.enums.ParticipationStatus;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
@@ -11,6 +12,7 @@ import com.trybe.modulecore.proof.repository.ProofRepository;
 import com.trybe.modulecore.user.entity.User;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -28,24 +30,28 @@ public class ProofScheduler {
     }
 
     @Scheduled(cron = "0 0 0 * * *")
+    @Transactional(readOnly = true)
     public void notifyProofStart() {
         LocalDate today = LocalDate.now();
         List<Proof> proofs = proofRepository.findAllByDate(today);
 
         for (Proof proof : proofs) {
-            List<User> participants = getParticipants(proof.getChallenge().getId());
-            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.START, participants));
+            Challenge challenge = proof.getChallenge();
+            List<User> participants = getParticipants(challenge.getId());
+            proofEventPublisher.publish(ProofEvent.from(ProofEventType.START, proof, participants));
         }
     }
 
     @Scheduled(cron = "0 59 23 * * *")
+    @Transactional(readOnly = true)
     public void notifyProofEnd() {
         LocalDate today = LocalDate.now();
         List<Proof> proofs = proofRepository.findAllByDate(today);
 
         for (Proof proof : proofs) {
-            List<User> participants = getParticipants(proof.getChallenge().getId());
-            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.END, participants));
+            Challenge challenge = proof.getChallenge();
+            List<User> participants = getParticipants(challenge.getId());
+            proofEventPublisher.publish(ProofEvent.from(ProofEventType.END, proof, participants));
         }
     }
 
@@ -53,6 +59,7 @@ public class ProofScheduler {
         return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
                 .stream()
                 .map(ChallengeParticipation::getUser)
+                .peek(User::getUuid)
                 .toList();
     }
 }

--- a/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofScheduler.java
+++ b/module-api/src/main/java/com/trybe/moduleapi/proof/service/ProofScheduler.java
@@ -3,8 +3,12 @@ package com.trybe.moduleapi.proof.service;
 import com.trybe.moduleapi.proof.event.model.ProofEvent;
 import com.trybe.moduleapi.proof.event.pub.ProofEventPublisher;
 import com.trybe.moduleapi.proof.event.type.ProofEventType;
+import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
+import com.trybe.modulecore.challenge.enums.ParticipationStatus;
+import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.proof.entity.Proof;
 import com.trybe.modulecore.proof.repository.ProofRepository;
+import com.trybe.modulecore.user.entity.User;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -14,10 +18,12 @@ import java.util.List;
 @Service
 public class ProofScheduler {
     private final ProofRepository proofRepository;
+    private final ChallengeParticipationRepository challengeParticipationRepository;
     private final ProofEventPublisher proofEventPublisher;
 
-    public ProofScheduler(ProofRepository proofRepository, ProofEventPublisher proofEventPublisher) {
+    public ProofScheduler(ProofRepository proofRepository, ChallengeParticipationRepository challengeParticipationRepository, ProofEventPublisher proofEventPublisher) {
         this.proofRepository = proofRepository;
+        this.challengeParticipationRepository = challengeParticipationRepository;
         this.proofEventPublisher = proofEventPublisher;
     }
 
@@ -27,7 +33,8 @@ public class ProofScheduler {
         List<Proof> proofs = proofRepository.findAllByDate(today);
 
         for (Proof proof : proofs) {
-            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.START));
+            List<User> participants = getParticipants(proof.getChallenge().getId());
+            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.START, participants));
         }
     }
 
@@ -37,7 +44,15 @@ public class ProofScheduler {
         List<Proof> proofs = proofRepository.findAllByDate(today);
 
         for (Proof proof : proofs) {
-            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.END));
+            List<User> participants = getParticipants(proof.getChallenge().getId());
+            proofEventPublisher.publish(new ProofEvent(proof, ProofEventType.END, participants));
         }
+    }
+
+    private List<User> getParticipants(Long challengeId) {
+        return challengeParticipationRepository.findAllByChallengeIdAndStatus(challengeId, ParticipationStatus.ACCEPTED)
+                .stream()
+                .map(ChallengeParticipation::getUser)
+                .toList();
     }
 }

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeBookmarkServiceTest.java
@@ -2,7 +2,7 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
 import com.trybe.moduleapi.challenge.fixtures.ChallengeFixtures;

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
@@ -3,6 +3,7 @@ package com.trybe.moduleapi.challenge.service;
 import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeParticipationEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
@@ -69,6 +70,8 @@ class ChallengeParticipationServiceTest {
                 .thenReturn(챌린지_참여_대기_최대_수 - 1);
         when(challengeParticipationRepository.save(any(ChallengeParticipation.class)))
                 .thenReturn(participation);
+        when(challengeParticipationRepository.findByChallengeIdAndRole(any(), eq(챌린지_리더_역할)))
+                .thenReturn(Optional.of(챌린지_리더_참여()));
 
         /* when */
         ChallengeParticipationResponse.Detail result = challengeParticipationService.join(멤버, challengeId);
@@ -272,6 +275,7 @@ class ChallengeParticipationServiceTest {
         /* then */
         verifyChallengeParticipationResponse(챌린지_멤버_참여(), result);
         verify(chatService, times(1)).enter(any(), any());
+        verify(challengeEventPublisher, times(1)).publish(any(ChallengeParticipationEvent.class));
     }
     
     @Test

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeParticipationServiceTest.java
@@ -2,7 +2,7 @@ package com.trybe.moduleapi.challenge.service;
 
 import com.trybe.moduleapi.challenge.dto.ChallengeParticipationResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;
@@ -15,7 +15,6 @@ import com.trybe.modulecore.challenge.entity.Challenge;
 import com.trybe.modulecore.challenge.entity.ChallengeParticipation;
 import com.trybe.modulecore.challenge.repository.ChallengeParticipationRepository;
 import com.trybe.modulecore.challenge.repository.ChallengeRepository;
-import com.trybe.modulecore.challenge.repository.preference.ChallengePreferenceCache;
 import com.trybe.modulecore.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/challenge/service/ChallengeServiceTest.java
@@ -3,7 +3,7 @@ package com.trybe.moduleapi.challenge.service;
 import com.trybe.moduleapi.challenge.dto.ChallengeRequest;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponse;
 import com.trybe.moduleapi.challenge.dto.ChallengeResponseAssembler;
-import com.trybe.moduleapi.challenge.event.ChallengeEvent;
+import com.trybe.moduleapi.challenge.event.model.ChallengeEvent;
 import com.trybe.moduleapi.challenge.event.pub.ChallengeEventPublisher;
 import com.trybe.moduleapi.challenge.exception.InvalidChallengeStatusException;
 import com.trybe.moduleapi.challenge.exception.NotFoundChallengeException;

--- a/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryServiceTest.java
+++ b/module-api/src/test/java/com/trybe/moduleapi/proof/service/ProofHistoryServiceTest.java
@@ -4,6 +4,8 @@ import com.trybe.moduleapi.challenge.exception.participation.InvalidParticipatio
 import com.trybe.moduleapi.common.dto.PageResponse;
 import com.trybe.moduleapi.proof.dto.request.ProofHistoryRequest;
 import com.trybe.moduleapi.proof.dto.response.ProofHistoryResponse;
+import com.trybe.moduleapi.proof.event.model.ProofHistoryEvent;
+import com.trybe.moduleapi.proof.event.pub.ProofEventPublisher;
 import com.trybe.moduleapi.proof.exception.InvalidProofDateException;
 import com.trybe.moduleapi.proof.exception.NotFoundProofException;
 import com.trybe.moduleapi.proof.exception.history.DuplicatedProofHistoryException;
@@ -47,6 +49,9 @@ public class ProofHistoryServiceTest {
     @Mock
     private ChallengeParticipationRepository challengeParticipationRepository;
 
+    @Mock
+    private ProofEventPublisher proofEventPublisher;
+
     @Test
     @DisplayName("인증 기록 생성 시 저장된 인증 기록 정보를 반환한다.")
     void 인증_기록_생성_시_저장된_인증_기록_정보를_반환한다 () {
@@ -72,6 +77,8 @@ public class ProofHistoryServiceTest {
         assertEquals(proofHistory.getContent(), result.content());
         assertEquals(proofHistory.getStatus(), result.status());
 //        assertEquals(proofHistory.getCreatedAt(), result.createdAt());
+
+        verify(proofEventPublisher, times(1)).publish(any(ProofHistoryEvent.class));
     }
     
     @Test

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ParticipationStatus.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/enums/ParticipationStatus.java
@@ -4,12 +4,12 @@ import lombok.Getter;
 
 @Getter
 public enum ParticipationStatus {
-    PENDING("대기중"),
-    ACCEPTED("수락됨"),
-    REJECTED("거절됨"),
-    DISABLED("탈퇴됨");
+    PENDING("대기"),
+    ACCEPTED("수락"),
+    REJECTED("거절"),
+    DISABLED("탈퇴");
 
-    private String description;
+    private final String description;
 
     ParticipationStatus(String description) {
         this.description = description;

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeParticipationRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeParticipationRepository.java
@@ -20,6 +20,7 @@ public interface ChallengeParticipationRepository extends JpaRepository<Challeng
     boolean existsByUserIdAndChallengeIdAndRole(Long userId, Long challengeId, ChallengeRole role);
     int countByChallengeIdAndStatus(Long challengeId, ParticipationStatus status);
     Optional<ChallengeParticipation> findByUserIdAndChallengeId(Long userId, Long challengeId);
+    Optional<ChallengeParticipation> findByChallengeIdAndRole(Long challengeId, ChallengeRole role);
     Page<ChallengeParticipation> findAllByUserIdAndStatusOrderByCreatedAtDesc(Long userId, ParticipationStatus status, Pageable pageable);
     Page<ChallengeParticipation> findAllByChallengeIdAndStatusOrderByCreatedAtAsc(Long challengeId, ParticipationStatus status, Pageable pageable);
     List<ChallengeParticipation> findAllByChallengeIdAndStatus(Long challengeId, ParticipationStatus status);

--- a/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeParticipationRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/challenge/repository/ChallengeParticipationRepository.java
@@ -19,9 +19,10 @@ public interface ChallengeParticipationRepository extends JpaRepository<Challeng
     boolean existsByUserIdAndChallengeIdAndStatus(Long userId, Long challengeId, ParticipationStatus status);
     boolean existsByUserIdAndChallengeIdAndRole(Long userId, Long challengeId, ChallengeRole role);
     int countByChallengeIdAndStatus(Long challengeId, ParticipationStatus status);
+    Optional<ChallengeParticipation> findByUserIdAndChallengeId(Long userId, Long challengeId);
     Page<ChallengeParticipation> findAllByUserIdAndStatusOrderByCreatedAtDesc(Long userId, ParticipationStatus status, Pageable pageable);
     Page<ChallengeParticipation> findAllByChallengeIdAndStatusOrderByCreatedAtAsc(Long challengeId, ParticipationStatus status, Pageable pageable);
-    Optional<ChallengeParticipation> findByUserIdAndChallengeId(Long userId, Long challengeId);
+    List<ChallengeParticipation> findAllByChallengeIdAndStatus(Long challengeId, ParticipationStatus status);
     List<ChallengeParticipation> findAllByStatusAndChallengeIdIn(ParticipationStatus status, Set<Long> challengeId);
     void deleteAllByChallengeId(Long challengeId);
 }

--- a/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofRepository.java
+++ b/module-core/src/main/java/com/trybe/modulecore/proof/repository/ProofRepository.java
@@ -7,10 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface ProofRepository extends JpaRepository<Proof, Long> {
     boolean existsByChallengeIdAndDate(Long challengeId, LocalDate date);
     int countByChallengeId(Long challengeId);
     Page<Proof> findAllByChallengeId(Long challengeId, Pageable pageable);
+    List<Proof> findAllByDate(LocalDate date);
 }

--- a/module-notification/src/main/java/com/trybe/modulenotification/service/NotificationConsumerService.java
+++ b/module-notification/src/main/java/com/trybe/modulenotification/service/NotificationConsumerService.java
@@ -1,5 +1,6 @@
 package com.trybe.modulenotification.service;
 
+import com.trybe.moduleapi.notification.constants.NotificationTopics;
 import com.trybe.moduleapi.notification.dto.NotificationMessage;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
@@ -13,8 +14,10 @@ public class NotificationConsumerService {
         this.emitterService = emitterService;
     }
 
-    // TODO: topics 내에 사용할 topic 작성
-    @KafkaListener(topics = {}, groupId = "notification-group")
+    @KafkaListener(topics = {
+            NotificationTopics.CHALLENGE,
+            NotificationTopics.CHALLENGE_PROOF,
+    }, groupId = "notification-group")
     public void listen(NotificationMessage message) {
         SseEmitter emitter = emitterService.getEmitter(message.getUserUuid().toString());
         emitterService.sendToClient(message.getUserUuid().toString(), emitter, message);


### PR DESCRIPTION
- Kafka 통신을 위한 토픽을 담은 공통 상수 클래스 `NotificationTopics` 추가
- `NotificationProducerService` 내 단일 알림 발행, 일괄 알림 발행 메서드 추가
- 챌린지 관련 이벤트를 분리 (`ChallengeEvent` -> `ChallengeStatusEvent`, `ChallengeActionEvent`, `ChallengeParticipationEvent` / `ChallengeType` -> `ChallengeStatusEventType`, `ChallengeActionEventType`, `ChallengeParticipationEventType`)
- 챌린지 알림 발행을 위한 `ChallengeNotificationEventListener` 구현
- 인증 관련 이벤트 `ProofEvent`, `ProofHistoryEvent` 구현
- 인증 관련 이벤트 처리를 위한 `ProofEventPublisher`, `ProofNotificationEventListener` 구현
- 관련 테스트 코드 수정
---
### 알림 종류
- 챌린지 시작 및 종료 시 알림
- 챌린지 참가 신청 시 챌린지 리더에게 알림
- 챌린지 참가 신청 처리 시 신청자에게 결과 알림
- 인증 시작 및 종료 시 알림
- 챌린지 멤버의 인증 히스토리 게재 시 알림
- 인증 히스토리의 투표 집계 완료 시 알림